### PR TITLE
Fix composer api change issue

### DIFF
--- a/main/recorder/Recorder.php
+++ b/main/recorder/Recorder.php
@@ -18,6 +18,7 @@ use Composer\DependencyResolver\Operation\InstallOperation;
 use Composer\DependencyResolver\Pool;
 use Composer\DependencyResolver\Request;
 use Composer\DependencyResolver\Solver;
+use Composer\IO\NullIO;
 use Composer\Package\Package;
 use Composer\Repository\ArrayRepository;
 use Composer\Repository\PlatformRepository;
@@ -90,7 +91,7 @@ class Recorder
             $request->install($package->getName());
         }
 
-        $solver = new Solver(new DefaultPolicy(), $pool, $toRepo);
+        $solver = new Solver(new DefaultPolicy(), $pool, $toRepo, new NullIO());
 
         return $solver->solve($request);
     }


### PR DESCRIPTION
This should solve this error, which came with an upgrade of composer:

> Argument 4 passed to Composer\DependencyResolver\Solver::__construct() must implement interface Composer\IO\IOInterface, none given