### PR TITLE
Fixing ws suppression if no workspace root

### DIFF
--- a/main/core/Manager/WorkspaceManager.php
+++ b/main/core/Manager/WorkspaceManager.php
@@ -245,9 +245,9 @@ class WorkspaceManager
     {
         $this->om->startFlushSuite();
         $root = $this->resourceManager->getWorkspaceRoot($workspace);
-        $this->log('Removing root directory ' . $root->getName() . '[id:' . $root->getId() . ']');
-
+        
         if ($root) {
+            $this->log('Removing root directory ' . $root->getName() . '[id:' . $root->getId() . ']');
             $children = $root->getChildren();
             $this->log('Looping through ' . count($children) . ' children...');
 


### PR DESCRIPTION
There no point doing a `$root->getName()` before checking if $root actually exists. Also it cause issues if we want do remove a workspace and something went wrong before because the $root doesn't exists anymore.