### PR TITLE
Fixing stats user count.

### DIFF
--- a/main/core/Manager/UserManager.php
+++ b/main/core/Manager/UserManager.php
@@ -707,7 +707,7 @@ class UserManager
             $usersInRoles[$role->getTranslationKey()] = intval(
                 $this->userRepo->countUsersByRole($role, $restrictionRoleNames)
             );
-            $usersInRoles['user_accounts'] += $usersInRoles[$role->getTranslationKey()];
+            $usersInRoles['user_accounts'] = $this->userRepo->countUsers();
         }
 
         return $usersInRoles;

--- a/main/core/Repository/UserRepository.php
+++ b/main/core/Repository/UserRepository.php
@@ -424,7 +424,7 @@ class UserRepository extends EntityRepository implements UserProviderInterface
     public function countUsers()
     {
         $qb = $this->createQueryBuilder('user')
-            ->select('COUNT(DISTINCT user.id)')
+            ->select('COUNT(user.id)')
             ->where('user.isEnabled = true');
 
         return $qb->getQuery()->getSingleScalarResult();

--- a/main/core/Repository/UserRepository.php
+++ b/main/core/Repository/UserRepository.php
@@ -421,6 +421,15 @@ class UserRepository extends EntityRepository implements UserProviderInterface
         return $query->getSingleScalarResult();
     }
 
+    public function countUsers()
+    {
+        $qb = $this->createQueryBuilder('user')
+            ->select('COUNT(DISTINCT user.id)')
+            ->where('user.isEnabled = true');
+
+        return $qb->getQuery()->getSingleScalarResult();
+    }
+
     /**
      * Returns user Ids that are subscribed to one of the roles given
      * @param  array $roleNames
@@ -1443,7 +1452,7 @@ class UserRepository extends EntityRepository implements UserProviderInterface
         return $query->getOneOrNullResult();
     }
 
-    
+
     /**
      * Returns all the users by search.
      *


### PR DESCRIPTION
It's better to count the number of users directly than incrementing a counter that count the number of users for each roles... because if a user is in 2 different roles, the counter will be wrong.