### PR TITLE
Avoid name collision with webpack.

### DIFF
--- a/main/core/Resources/scripts/lib/collect-packages.js
+++ b/main/core/Resources/scripts/lib/collect-packages.js
@@ -86,7 +86,7 @@ function getMetaEntries(targetDir) {
         Object.keys(data.webpack.entry).forEach(entry => {
           var parts = dir.split("/");
           var lastDir = parts[parts.length - 1];
-          metadata.webpack.entry[entry] = {
+          metadata.webpack.entry[`${bundle}-${entry}`]  = {
             name: data.webpack.entry[entry],
             prefix: `${dir}/${bundle}`,
             dir: lastDir,

--- a/main/core/Resources/scripts/lib/webpack.js
+++ b/main/core/Resources/scripts/lib/webpack.js
@@ -106,7 +106,7 @@ function extractEntries(packages) {
     .reduce((entries, def) => {
       Object.keys(def.assets.webpack.entry).forEach(entry => {
          def.meta ?
-           entries[`${def.name}-${def.assets.webpack.entry[entry].dir}-${def.assets.webpack.entry[entry].bundle}-${entry}`] = `${def.assets.webpack.entry[entry].prefix}/Resources/${def.assets.webpack.entry[entry].name}`:
+           entries[`${def.name}-${def.assets.webpack.entry[entry].dir}-${entry}`] = `${def.assets.webpack.entry[entry].prefix}/Resources/${def.assets.webpack.entry[entry].name}`:
            entries[`${def.name}-${entry}`] = `${def.path}/Resources/${def.assets.webpack.entry[entry]}`
       })
 


### PR DESCRIPTION
Otherwise, in the distribution, nobody can share the same entry keys in the assets.json file.

There is no name collision in the files generated, so it only removes this limitation.