### PR TITLE
[CoreBundle] - Remove flash fallback from embed templates

### DIFF
--- a/main/core/Resources/views/Resource/embed/audio.html.twig
+++ b/main/core/Resources/views/Resource/embed/audio.html.twig
@@ -1,9 +1,4 @@
-<audio width="100%" controls="controls" preload='none'>
+<audio width="100%" controls="controls" preload='auto'>
     <source src="{{ path('claro_file_get_media', {'node': node.getId}) }}" type="{{ node.getMimeType() }}">
-    <!-- In case of the browser does not support the video tag: -->
-    <object width="100%" height="400">
-        <param name="audio" value="{{ path('claro_file_get_media', {'node': node.getId}) }}">
-        <embed src="{{ path('claro_file_get_media', {'node': node.getId}) }}"></embed>
-    </object>
 </audio>
 <a href="{{ path('claro_resource_open', {'resourceType': node.getResourceType().getName(), 'node' : node.getId()}) }}">{{ node.getName() }}</a>

--- a/main/core/Resources/views/Resource/embed/video.html.twig
+++ b/main/core/Resources/views/Resource/embed/video.html.twig
@@ -1,9 +1,4 @@
 <video width="100%" height="400" controls="controls" preload='none'>
     <source src="{{ path('claro_file_get_media', {'node': node.getId}) }}" type="{{ node.getMimeType() }}">
-    <!-- In case of the browser does not support the video tag: -->
-    <object width="100%" height="400">
-        <param name="video" value="{{ path('claro_file_get_media', {'node': node.getId}) }}">
-        <embed src="{{ path('claro_file_get_media', {'node': node.getId}) }}"></embed>
-    </object>
 </video>
 <a href="{{ path('claro_resource_open', {'resourceType': node.getResourceType().getName(), 'node' : node.getId()}) }}">{{ node.getName() }}</a>

--- a/plugin/video-player/Controller/VideoPlayerController.php
+++ b/plugin/video-player/Controller/VideoPlayerController.php
@@ -18,8 +18,8 @@ use Claroline\CoreBundle\Entity\Resource\ResourceNode;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration as EXT;
 use JMS\SecurityExtraBundle\Annotation as SEC;
 use Claroline\VideoPlayerBundle\Form\PlayersType;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
-//todo use sf2.2 BinaryFileResponse
 class VideoPlayerController extends Controller
 {
     /**

--- a/plugin/video-player/Controller/VideoPlayerController.php
+++ b/plugin/video-player/Controller/VideoPlayerController.php
@@ -18,7 +18,6 @@ use Claroline\CoreBundle\Entity\Resource\ResourceNode;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration as EXT;
 use JMS\SecurityExtraBundle\Annotation as SEC;
 use Claroline\VideoPlayerBundle\Form\PlayersType;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class VideoPlayerController extends Controller
 {


### PR DESCRIPTION
Remove flash fallback from resource embed templates to avoid heratic media autoplay.
Also removed the comment from ```plugin/video-player/Controller/VideoPlayerController.php
```