### PR TITLE
Optimize test suite memory usage

### DIFF
--- a/main/core/Library/Testing/TransactionalTestCase.php
+++ b/main/core/Library/Testing/TransactionalTestCase.php
@@ -40,6 +40,17 @@ abstract class TransactionalTestCase extends WebTestCase
             $this->client->shutdown();
         }
 
+        // the following helps to free memory and speed up test suite execution.
+        // see http://kriswallsmith.net/post/18029585104/faster-phpunit
+        $refl = new \ReflectionObject($this);
+
+        foreach ($refl->getProperties() as $prop) {
+            if (!$prop->isStatic() && 0 !== strpos($prop->getDeclaringClass()->getName(), 'PHPUnit_')) {
+                $prop->setAccessible(true);
+                $prop->setValue($this, null);
+            }
+        }
+
         parent::tearDown();
     }
 


### PR DESCRIPTION
Following [this article](http://kriswallsmith.net/post/18029585104/faster-phpunit), I can see a huge performance gain when running the test suite locally (80% faster, 500% drop in memory).