### PR TITLE
Exclude non-php files from cs finder

### DIFF
--- a/main/dev/Resources/travis/php-cs.php
+++ b/main/dev/Resources/travis/php-cs.php
@@ -16,7 +16,10 @@ if (!file_exists($targetFile)) {
 }
 
 $targets = array_filter(file($targetFile), function ($line) {
-    return !empty($line);
+    $line = trim($line);
+    $length = strlen($line);
+
+    return $length > 4 && strpos($line, '.php') === $length - 4;
 });
 
 $files = array_map(function ($filePath) use ($pkgDir) {


### PR DESCRIPTION
Prevents php-cs-fixer to apply fixers blindly on binary files.