### PR TITLE
Add phpmd to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,7 @@ before_script:
   - php app/console claroline:install --env=test
 
 script:
-  - bin/php-cs-fixer fix --dry-run --diff --config-file=vendor/claroline/distribution/main/dev/Resources/travis/php-cs.php -vvv
-  - SYMFONY_DEPRECATIONS_HELPER=weak bin/phpunit -c vendor/claroline/distribution
+  - cd vendor/claroline/distribution
+  - ../../../bin/phpmd --exclude main/core/Resources/bundle-creator,main/web-installer `cat git_diff_files.txt | xargs | sed -e :a -e '$!N; s/ /,/; ta'` text phpmd.xml
+  - ../../../bin/php-cs-fixer fix --dry-run --diff --config-file=main/dev/Resources/travis/php-cs.php -vvv
+  - SYMFONY_DEPRECATIONS_HELPER=weak ../../../bin/phpunit

--- a/main/core/Command/CreatePluginCommand.php
+++ b/main/core/Command/CreatePluginCommand.php
@@ -556,14 +556,6 @@ class CreatePluginCommand extends ContainerAwareCommand
         }
     }
 
-    /**
-     * Placeholders are put between [[]].
-     */
-    private function removePlaceHolders($content)
-    {
-        $content = preg_replace('/\[\[(.*)\]\]/', '', $content);
-    }
-
     private function getNormalizedBundleName($ibundle)
     {
         preg_match_all('/[A-Z][^A-Z]*/', $ibundle, $results);

--- a/main/core/Controller/FileController.php
+++ b/main/core/Controller/FileController.php
@@ -289,16 +289,4 @@ class FileController extends Controller
             throw new AccessDeniedException($collection->getErrorsForDisplay());
         }
     }
-
-    /**
-     * Get Current User.
-     *
-     * @return mixed Claroline\CoreBundle\Entity\User or null
-     */
-    private function getCurrentUser()
-    {
-        if (is_object($token = $this->get('security.token_storage')->getToken()) and is_object($user = $token->getUser())) {
-            return $user;
-        }
-    }
 }

--- a/main/core/Controller/WorkspaceController.php
+++ b/main/core/Controller/WorkspaceController.php
@@ -1645,13 +1645,4 @@ class WorkspaceController extends Controller
             }
         }
     }
-
-    private function checkWorkspaceManagerAccess(Workspace $workspace)
-    {
-        $role = $this->roleManager->getManagerRole($workspace);
-
-        if (is_null($role) || !$this->authorization->isGranted($role->getName())) {
-            throw new AccessDeniedException();
-        }
-    }
 }

--- a/main/core/Library/Installation/Updater/Updater030000.php
+++ b/main/core/Library/Installation/Updater/Updater030000.php
@@ -123,25 +123,6 @@ class Updater030000 extends Updater
         $this->container->get('claroline.manager.icon_manager')->createShortcutIcon($icon);
     }
 
-    private function updateTools()
-    {
-        $this->log('updating icons...');
-        $tools = $this->om->getRepository('ClarolineCoreBundle:Tool\Tool')->findAll();
-        $adminTools = $this->om->getRepository('ClarolineCoreBundle:Tool\AdminTool')->findAll();
-
-        foreach ($tools as $tool) {
-            if (isset($this->icons[$tool->getClass()])) {
-                $this->updateToolClass($tool, $this->icons[$tool->getClass()]);
-            }
-        }
-
-        foreach ($adminTools as $tool) {
-            if (isset($this->icons[$tool->getClass()])) {
-                $this->updateToolClass($tool, $this->icons[$tool->getClass()]);
-            }
-        }
-    }
-
     private function updateAdminPluginTool()
     {
         $this->log('updating admin plugin tool...');
@@ -155,13 +136,6 @@ class Updater030000 extends Updater
             $this->om->persist($pluginTool);
             $this->om->flush();
         }
-    }
-
-    private function updateToolClass($tool, $class)
-    {
-        $tool->setClass($class);
-        $this->om->persist($tool);
-        $this->om->flush();
     }
 
     private function cleanWeb()

--- a/main/core/Library/Installation/Updater/Updater030400.php
+++ b/main/core/Library/Installation/Updater/Updater030400.php
@@ -28,9 +28,6 @@ class Updater030400 extends Updater
     {
         $this->log('replacing default zip file');
         $this->replaceDefaultZip();
-
-        //why is it here ? can't remember
-        //$this->removeModelTable();
     }
 
     private function replaceDefaultZip()
@@ -39,15 +36,5 @@ class Updater030400 extends Updater
         $sourcePath = $this->container->getParameter('claroline.param.default_template');
         @unlink($destinationPath);
         copy($sourcePath, $destinationPath);
-    }
-
-    private function removeModelTable()
-    {
-        $this->log('Removing model table...');
-        try {
-            $this->conn->query('DROP TABLE claro_workspace_model_resource');
-        } catch (\Doctrine\DBAL\DBALException $e) {
-            $this->log('claro_workspace_model_resource already removed.');
-        }
     }
 }

--- a/main/core/Library/Transfert/ConfigurationBuilders/UsersImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/UsersImporter.php
@@ -170,11 +170,6 @@ class UsersImporter extends Importer implements ConfigurationInterface
         self::$data = $data;
     }
 
-    private static function getData()
-    {
-        return self::$data;
-    }
-
     public static function roleNameExists($v, $roles)
     {
         return !in_array($v, $roles);

--- a/main/core/Manager/ToolManager.php
+++ b/main/core/Manager/ToolManager.php
@@ -591,12 +591,6 @@ class ToolManager
         );
     }
 
-    private function configChecker($conf)
-    {
-        //no implementation yet
-        return true;
-    }
-
     /**
      * Sets a tool visible for a user in the desktop.
      *

--- a/main/core/Manager/TransfertManager.php
+++ b/main/core/Manager/TransfertManager.php
@@ -288,11 +288,6 @@ class TransfertManager
         $this->om->flush();
     }
 
-    private function setRootPath($rootPath)
-    {
-        $this->rootPath = $rootPath;
-    }
-
     private function getImporterByName($name)
     {
         foreach ($this->listImporters as $importer) {

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+
+<!-- see https://phpmd.org/rules/index.html -->
+<!-- see http://phpmd.org/documentation/creating-a-ruleset.html -->
+<!-- see https://github.com/phpmd/phpmd -->
+
+<ruleset name="Claroline distribution PHPMD rule set" xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation=" http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <description>Code checks</description>
+
+    <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
+
+    <!-- MUST HAVE -->
+
+    <!-- <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/> -->
+    <!-- <rule ref="rulesets/design.xml/ExitExpression"/> -->
+    <!-- <rule ref="rulesets/design.xml/EvalExpression"/> -->
+
+    <!-- NICE TO HAVE -->
+
+    <!-- <rule ref="rulesets/codesize.xml/ExcessiveMethodLength"/> -->
+    <!-- <rule ref="rulesets/codesize.xml/ExcessiveParameterList"/> -->
+    <!-- <rule ref="rulesets/naming.xml/BooleanGetMethodName/> -->
+    <!-- <rule ref="rulesets/controversial.xml"/> -->
+    <!-- <rule ref="rulesets/design.xml"/> -->
+
+</ruleset>

--- a/plugin/collecticiel/Controller/DropController.php
+++ b/plugin/collecticiel/Controller/DropController.php
@@ -4,6 +4,7 @@
  * Date: 22/08/13
  * Time: 09:30.
  */
+
 namespace Innova\CollecticielBundle\Controller;
 
 use Innova\CollecticielBundle\Entity\Correction;
@@ -248,117 +249,6 @@ class DropController extends DropzoneBaseController
             'dropzone' => $dropzone,
             'pager' => $pager,
         ));
-    }
-
-    /**
-     * @Route(
-     *      "/{resourceId}/unlock/{userId}",
-     *      name="innova_collecticiel_unlock_user",
-     *      requirements={"resourceId" = "\d+", "userId" = "\d+"}
-     * )
-     * @ParamConverter("dropzone",class="InnovaCollecticielBundle:Dropzone", options={"id" = "resourceId"})
-     *
-     * @param \Innova\CollecticielBundle\Entity\Dropzone $dropzone
-     * @param $userId
-     *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
-     *
-     * @internal param $user
-     * @internal param $userId
-     */
-    private function unlockUser(Dropzone $dropzone, $userId)
-    {
-        $this->get('innova.manager.dropzone_voter')->isAllowToOpen($dropzone);
-        $this->get('innova.manager.dropzone_voter')->isAllowToEdit($dropzone);
-        $dropRepo = $this->getDoctrine()->getManager()->getRepository('InnovaCollecticielBundle:Drop');
-        $drop = $dropRepo->getDropByUser($dropzone->getId(), $userId);
-        if ($drop != null) {
-            $drop->setUnlockedUser(true);
-        }
-        $em = $this->getDoctrine()->getManager();
-        $em->merge($drop);
-        $em->flush();
-
-        return $this->redirect(
-            $this->generateUrl(
-                'innova_collecticiel_examiners',
-                array(
-                    'resourceId' => $dropzone->getId(),
-                )
-            )
-        );
-    }
-
-    /**
-     * @Route(
-     *      "/{resourceId}/unlock/all",
-     *      name="innova_collecticiel_unlock_all_user",
-     *      requirements={"resourceId" = "\d+"}
-     * )
-     * @ParamConverter("dropzone",class="InnovaCollecticielBundle:Dropzone", options={"id" = "resourceId"})
-     *
-     * @param \Innova\CollecticielBundle\Entity\Dropzone $dropzone
-     *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
-     *
-     * @internal param $user
-     * @internal param $userId
-     */
-    private function unlockUsers(Dropzone $dropzone)
-    {
-        return $this->unlockOrLockUsers($dropzone, true);
-    }
-
-    /**
-     * @Route(
-     *      "/{resourceId}/unlock/cancel",
-     *      name="innova_collecticiel_unlock_cancel",
-     *      requirements={"resourceId" = "\d+"}
-     * )
-     * @ParamConverter("dropzone",class="InnovaCollecticielBundle:Dropzone", options={"id" = "resourceId"})
-     *
-     * @param \Innova\CollecticielBundle\Entity\Dropzone $dropzone
-     *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
-     *
-     * @internal param $user
-     * @internal param $userId
-     */
-    private function unlockUsersCancel(Dropzone $dropzone)
-    {
-        return $this->unlockOrLockUsers($dropzone, false);
-    }
-
-    /**
-     *  Factorised function for lock & unlock users in a dropzone.
-     *
-     * @param Dropzone $dropzone
-     * @param bool     $unlock
-     *
-     * @return \Symfony\Component\HttpFoundation\RedirectResponse
-     */
-    private function unlockOrLockUsers(Dropzone $dropzone, $unlock = true)
-    {
-        $this->get('innova.manager.dropzone_voter')->isAllowToOpen($dropzone);
-        $this->get('innova.manager.dropzone_voter')->isAllowToEdit($dropzone);
-
-        $dropRepo = $this->getDoctrine()->getManager()->getRepository('InnovaCollecticielBundle:Drop');
-        $drops = $dropRepo->findBy(array('dropzone' => $dropzone->getId(), 'unlockedUser' => !$unlock));
-
-        foreach ($drops as $drop) {
-            $drop->setUnlockedUser($unlock);
-        }
-        $em = $this->getDoctrine()->getManager();
-        $em->flush();
-
-        return $this->redirect(
-            $this->generateUrl(
-                'innova_collecticiel_examiners',
-                array(
-                    'resourceId' => $dropzone->getId(),
-                )
-            )
-        );
     }
 
     /**
@@ -1374,7 +1264,7 @@ class DropController extends DropzoneBaseController
                 // Ici, on récupère le créateur du collecticiel = l'admin
                 $userCreator = $dropzone->getResourceNode()->getCreator()->getId();
                 // Ici, on récupère celui qui vient de déposer le nouveau document
-                //$userAddDocument = $this->get('security.context')->getToken()->getUser()->getId(); 
+                //$userAddDocument = $this->get('security.context')->getToken()->getUser()->getId();
                 $userDropDocument = $document->getDrop()->getUser()->getId();
                 $userSenderDocument = $document->getSender()->getId();
 

--- a/plugin/competency/Tests/Installation/AdditionalInstallerTest.php
+++ b/plugin/competency/Tests/Installation/AdditionalInstallerTest.php
@@ -2,9 +2,7 @@
 
 namespace HeVinci\CompetencyBundle\Installation;
 
-use Claroline\CoreBundle\Entity\Resource\ResourceType;
 use Claroline\CoreBundle\Library\Testing\TransactionalTestCase;
-use Doctrine\ORM\EntityManagerInterface;
 
 class AdditionalInstallerTest extends TransactionalTestCase
 {
@@ -26,13 +24,5 @@ class AdditionalInstallerTest extends TransactionalTestCase
 
         $this->assertNotNull($actionRepo->findOneByName('manage-competencies'));
         $this->assertNotNull($roleRepo->findOneByName('ROLE_COMPETENCY_MANAGER'));
-    }
-
-    private function createActivityType(EntityManagerInterface $em)
-    {
-        $activityType = new ResourceType();
-        $activityType->setName('activity');
-        $em->persist($activityType);
-        $em->flush();
     }
 }

--- a/plugin/oauth/Manager/OauthManager.php
+++ b/plugin/oauth/Manager/OauthManager.php
@@ -168,9 +168,17 @@ class OauthManager
         if (!$appId || !$secret) {
             return array('error' => $service.'_application_validation_error');
         }
-        $serviceMethodName = str_replace(' ', '', ucwords(str_replace('_', ' ', $service)));
 
-        return call_user_func(array($this, 'validate'.$serviceMethodName), $appId, $secret);
+        switch ($service) {
+            case 'facebook':
+                return $this->validateFacebook($appId, $secret);
+            case 'twitter':
+                return $this->validateTwitter($appId, $secret);
+            case 'google':
+            case 'linkedin':
+            case 'windows_live':
+                return [];
+        }
     }
 
     public function getConfiguration($service)
@@ -345,21 +353,6 @@ class OauthManager
             return array('error' => 'twitter_application_validation_error');
         }
 
-        return array();
-    }
-
-    private function validateGoogle($appId, $secret)
-    {
-        return array();
-    }
-
-    private function validateLinkedin($appId, $secret)
-    {
-        return array();
-    }
-
-    private function validateWindowsLive($appId, $secret)
-    {
         return array();
     }
 }


### PR DESCRIPTION
This PR adds a minimal phpmd check -- only unused private methods for now -- to the travis build. The goal is to progressively add rules to:

- eliminate dead code
- eliminate problematic functions like `exit`, `eval`, `var_dump`, etc.
- limit code complexity (class/method length, dependencies)

cc @claroline/commiters