### PR TITLE
Mirror build repo in vendor on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,8 @@ before_script:
   - php scripts/configure.php --default
 
   # override platform composer.json with build/repo local reference
-  - mkdir -p travis/local/pkg && mv ../$TRAVIS_REPO_SLUG/* ../$TRAVIS_REPO_SLUG/.[!.]* travis/local/pkg
-  - rm -rf travis/local/pkg/.git
-  - php travis/local/pkg/main/dev/Resources/travis/pre-composer.php claroline/distribution travis/local/pkg
+  - rm -rf ../$TRAVIS_REPO_SLUG/.git
+  - php ../$TRAVIS_REPO_SLUG/main/dev/Resources/travis/pre-composer.php claroline/distribution ../$TRAVIS_REPO_SLUG
 
   # fetch dependencies and build
   - composer self-update

--- a/main/dev/Resources/travis/pre-composer.php
+++ b/main/dev/Resources/travis/pre-composer.php
@@ -19,7 +19,7 @@ set_error_handler(function ($severity, $message, $file, $line) {
 });
 
 if ($argc < 3) {
-    echo "Expected three arguments: package_name package_path\n";
+    echo "Expected two arguments: package_name package_path\n";
     exit(1);
 }
 
@@ -39,10 +39,13 @@ if (!isset($data->repositories)) {
     $data->repositories = [];
 }
 
-$repo = new stdClass();
-$repo->type = 'path';
-$repo->url = $packagePath;
-$data->repositories[] = $repo;
+$data->repositories[] = [
+    'type' => 'path',
+    'url' => $packagePath,
+    'options' => [
+        'symlink' => false,
+    ],
+];
 
 $content = json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
 file_put_contents($composerFile, $content);


### PR DESCRIPTION
When fetching the platform dependencies on travis, the distribution build is included as a local dependency using the `path` option. This PR changes the default behaviour of that option from symlink to mirror (hard copy). Advantages:

- simplify build config
- prevent issues like [this one](https://github.com/claroline/Distribution/pull/125#issuecomment-211324433)
- enable easier caching strategies 