### PR TITLE
[CoreBundle] Fixing wrong admin tool check

### DIFF
--- a/main/core/Controller/Administration/HomeTabController.php
+++ b/main/core/Controller/Administration/HomeTabController.php
@@ -38,7 +38,7 @@ use JMS\SecurityExtraBundle\Annotation as SEC;
 
 /**
  * @DI\Tag("security.secure_service")
- * @SEC\PreAuthorize("canOpenAdminTool('home_tabs')")
+ * @SEC\PreAuthorize("canOpenAdminTool('desktop_and_home')")
  */
 class HomeTabController extends Controller
 {


### PR DESCRIPTION
The home_tabs tool doesn't exist so the check will fail for everyone who don't have the ROLE_ADMIN.

desktop_and_home exists and is probably what was intended.