### PR TITLE
[BundleRecorder] Exclude non symfony bundle classes

### DIFF
--- a/main/recorder/Detector/Detector.php
+++ b/main/recorder/Detector/Detector.php
@@ -109,10 +109,12 @@ class Detector
 
         if ($class) {
             $namespaceSegments[] = $class;
+            $fqcn = implode('\\', $namespaceSegments);
+            $bundleInterface = 'Symfony\Component\HttpKernel\Bundle\BundleInterface';
 
-            return implode('\\', $namespaceSegments);
+            if (in_array($bundleInterface, class_implements($fqcn))) {
+                return $fqcn;
+            }
         }
-
-        return $class;
     }
 }


### PR DESCRIPTION
Removes a false positive in bundle detection, which makes all the travis builds fail:

https://travis-ci.org/claroline/Distribution/builds/129190687#L2036