### PR TITLE
Fix default value of Exercise description

### DIFF
--- a/plugin/exo/Entity/Exercise.php
+++ b/plugin/exo/Entity/Exercise.php
@@ -24,7 +24,7 @@ class Exercise extends AbstractResource
     /**
      * @ORM\Column(name="description", type="text", nullable=true)
      */
-    private $description;
+    private $description = '';
 
     /**
      * @ORM\Column(name="shuffle", type="boolean", nullable=true)


### PR DESCRIPTION
Set an empty string as the default value for Exercise description (because the validation schema does not allow `null` value).