### PR TITLE
Fix external PR detection in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,8 @@ script:
   - SYMFONY_DEPRECATIONS_HELPER=weak $ROOT/vendor/phpunit/phpunit/phpunit
 
 after_success:
-  # send a preview release to a remote server
+  # send a preview release to a remote server (only for internal PRs)
+  - if [ -z ${REMOTE_HOST+x} ]; then exit 1; fi
   - cd $ROOT
   - export PREVIEW="pr-$TRAVIS_PULL_REQUEST-`date +%s`.zip"
   - mysqldump --opt --no-create-db claroline_test -uroot --password="" > claroline.sql

--- a/main/dev/Resources/travis/fetch-deps.bash
+++ b/main/dev/Resources/travis/fetch-deps.bash
@@ -54,7 +54,7 @@ fetch() {
         echo "Failure ($STATUS), executing $1..."
         eval $3
 
-        if [ "${TRAVIS_REPO_SLUG}" != "claroline/Distribution" ]
+        if [ -z ${REMOTE_HOST+x} ]
         then
             # We need to access encrypted environment variables to push the
             # package through SSH, but those variables aren't available in PRs


### PR DESCRIPTION
This should fix build errors like this one: https://travis-ci.org/claroline/Distribution/builds/131400211#L841 (secured environment variables aren't available in PRs coming from forks).

Not sure about the `after_success` step though.