### PR TITLE
Move preview build to a separate script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ mysql:
   encoding: utf8
 
 before_install:
+
+
   # keep a list of files impacted by the PR
   - git diff-tree --no-commit-id --diff-filter=ACM --name-only -r ${TRAVIS_COMMIT_RANGE/.../ } > git_diff_files.txt
   # leave build/repo dir
@@ -52,7 +54,6 @@ before_script:
   - rm -rf ../$TRAVIS_REPO_SLUG/.git
   - php ../$TRAVIS_REPO_SLUG/main/dev/Resources/travis/pre-composer.php claroline/distribution ../$TRAVIS_REPO_SLUG
   # fetch dependencies and build
-  - export TRAVIS_REPO_SLUG REMOTE_HOST REMOTE_USER REMOTE_PASS CACHE_PATH
   - bash ../$TRAVIS_REPO_SLUG/main/dev/Resources/travis/fetch-deps.bash
   - composer build
   - php app/console claroline:install --env=test -vvv
@@ -70,11 +71,4 @@ script:
 
 after_success:
   # send a preview release to a remote server (only for internal PRs)
-  - if [ -z ${REMOTE_HOST+x} ]; then exit 1; fi
-  - cd $ROOT
-  - export PREVIEW="pr-$TRAVIS_PULL_REQUEST-`date +%s`.zip"
-  - mysqldump --opt --no-create-db claroline_test -uroot --password="" > claroline.sql
-  - rm -rf app/cache/* app/logs/* web/bundles
-  - zip -qr --exclude=*.git* $PREVIEW .
-  - export SSHPASS=$REMOTE_PASS
-  - sshpass -e scp -q -o stricthostkeychecking=no $PREVIEW $REMOTE_USER@$REMOTE_HOST:$PREVIEW_PATH/$PREVIEW
+  - if [ ${REMOTE_HOST+x} ]; then cd $ROOT && sh vendor/claroline/distribution/main/dev/Resources/travis/send-preview.sh; fi

--- a/main/dev/Resources/travis/fetch-deps.bash
+++ b/main/dev/Resources/travis/fetch-deps.bash
@@ -7,18 +7,18 @@
 #
 # Note that:
 #
-# 1. this script must be executed with bash, not sh;
-# 2. the working directory must be the root directory of the platform;
-# 3. the following environment variables are supposed to be available:
-#      - TRAVIS_REPO_SLUG (set by travis)
-#      - REMOTE_HOST
-#      - REMOTE_USER
-#      - REMOTE_PASS
-#      - CACHE_PATH
+# 1. this script must be executed with bash, not sh
+# 2. the working directory must be the root directory of the platform
 ################################################################################
 
 set -e
 set -o pipefail
+
+: ${TRAVIS_REPO_SLUG:?"must be set"}
+: ${REMOTE_HOST:?"must be set"}
+: ${REMOTE_USER:?"must be set"}
+: ${REMOTE_PASS:?"must be set"}
+: ${CACHE_PATH:?"must be set"}
 
 DIST=../$TRAVIS_REPO_SLUG
 

--- a/main/dev/Resources/travis/send-preview.sh
+++ b/main/dev/Resources/travis/send-preview.sh
@@ -1,0 +1,20 @@
+################################################################################
+# This script makes a preview archive of a travis build and sends it to a remote
+# server. It must be executed from the root directory of the platform.
+################################################################################
+
+set -e
+
+: ${TRAVIS_PULL_REQUEST:?"must be set"}
+: ${REMOTE_HOST:?"must be set"}
+: ${REMOTE_USER:?"must be set"}
+: ${REMOTE_PASS:?"must be set"}
+: ${PREVIEW_PATH:?"must be set"}
+
+PREVIEW="pr-$TRAVIS_PULL_REQUEST-`date +%s`.zip"
+
+mysqldump --opt --no-create-db claroline_test -uroot --password="" > claroline.sql
+rm -rf app/cache/* app/logs/* web/bundles
+zip -qr --exclude=*.git* $PREVIEW .
+export SSHPASS=$REMOTE_PASS
+sshpass -e scp -q -o stricthostkeychecking=no $PREVIEW $REMOTE_USER@$REMOTE_HOST:$PREVIEW_PATH/$PREVIEW


### PR DESCRIPTION
This should allow to bypass that step effectively for PRs coming from external repositories (see #342).