### PR TITLE
Switch to tar gzip archives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,11 +62,11 @@ before_script:
 
 script:
   # launch phpmd on modified files
-  - $ROOT/vendor/phpmd/phpmd/src/bin/phpmd --exclude main/core/Resources/bundle-creator,main/web-installer `cat git_diff_files.txt | xargs | sed -e :a -e '$!N; s/ /,/; ta'` text phpmd.xml
+  - $ROOT/vendor/bin/phpmd --exclude main/core/Resources/bundle-creator,main/web-installer `cat git_diff_files.txt | xargs | sed -e :a -e '$!N; s/ /,/; ta'` text phpmd.xml
   # dry run php-cs-fixer on modified files (fail on violation)
-  - $ROOT/vendor/fabpot/php-cs-fixer/php-cs-fixer fix --dry-run --diff --config-file=main/dev/Resources/travis/php-cs.php
+  - $ROOT/vendor/bin/php-cs-fixer fix --dry-run --diff --config-file=main/dev/Resources/travis/php-cs.php
   # launch the whole test suite
-  - SYMFONY_DEPRECATIONS_HELPER=weak $ROOT/vendor/phpunit/phpunit/phpunit
+  - SYMFONY_DEPRECATIONS_HELPER=weak $ROOT/vendor/bin/phpunit
 
 after_success:
   # send a preview release to a remote server (only for internal PRs)

--- a/main/dev/Resources/travis/fetch-deps.bash
+++ b/main/dev/Resources/travis/fetch-deps.bash
@@ -2,8 +2,8 @@
 # This script handles dependency fetching in travis builds. Whenever possible,
 # it reuses dependency sets which where built by previous requests and sent to a
 # remote cache server. When a set is not already cached, the usual commands
-# (composer update, npm install, etc.) are performed and the result is zipped
-# and sent to the remote server for later use.
+# (composer update, npm install, etc.) are performed and the result is
+# compressed and sent to the remote server for later use.
 #
 # Note that:
 #
@@ -41,18 +41,18 @@ BOWER_SUM=`cat bower.json $DIST/bower.json | md5sum | cut -c -32`
 # $3 update/install command
 # $4 dependencies directory
 fetch() {
-    ZIP="$1-$2.zip"
+    ARCHIVE="$1-$2.tar.gz"
 
-    echo "Trying to fetch $1 dependencies from cache ($ZIP)..."
+    echo "Trying to fetch $1 dependencies from cache ($ARCHIVE)..."
 
     set +o errexit # allow curl failure
-    STATUS=`curl -o $ZIP -s -w "%{http_code}" "$REMOTE_HOST/cache/$ZIP"`
+    STATUS=`curl -o $ARCHIVE -s -w "%{http_code}" "$REMOTE_HOST/cache/$ARCHIVE"`
     set -e
 
     if [ $STATUS = 200 ]
     then
-        echo "Success, unzipping..."
-        unzip -q "$ZIP"
+        echo "Success, extracting..."
+        tar -xzf "$ARCHIVE"
     else
         echo "Failure ($STATUS), executing $1..."
         eval $3
@@ -66,16 +66,16 @@ fetch() {
             # see https://docs.travis-ci.com/user/pull-requests#Security-Restrictions-when-testing-Pull-Requests
             echo 'Not an internal PR, skipping caching part...'
         else
-            echo "Zipping $4 directory ($ZIP)..."
-            rm -f $ZIP
-            zip -qr --exclude=*.git* $ZIP $4
+            echo "Compressing $4 directory ($ARCHIVE)..."
+            rm -f $ARCHIVE
+            tar --exclude=".git" -czf $ARCHIVE $4
             echo "Sending archive to remote cache..."
             export SSHPASS=$REMOTE_PASS
-            sshpass -e scp -o stricthostkeychecking=no $ZIP $REMOTE_USER@$REMOTE_HOST:$CACHE_PATH/$ZIP
+            sshpass -e scp -o stricthostkeychecking=no $ARCHIVE $REMOTE_USER@$REMOTE_HOST:$CACHE_PATH/$ARCHIVE
         fi
     fi
 
-    rm -f $ZIP
+    rm -f $ARCHIVE
 }
 
 fetch composer $COMPOSER_SUM "composer update --prefer-dist" vendor

--- a/main/dev/Resources/travis/send-preview.sh
+++ b/main/dev/Resources/travis/send-preview.sh
@@ -11,10 +11,11 @@ set -e
 : ${REMOTE_PASS:?"must be set"}
 : ${PREVIEW_PATH:?"must be set"}
 
-PREVIEW="pr-$TRAVIS_PULL_REQUEST-`date +%s`.zip"
+PREVIEW="pr-$TRAVIS_PULL_REQUEST-`date +%s`.tar.gz"
 
 mysqldump --opt --no-create-db claroline_test -uroot --password="" > claroline.sql
 rm -rf app/cache/* app/logs/* web/bundles
-zip -qr --exclude=*.git* $PREVIEW .
+tar --exclude=".git" -czf $PREVIEW .
+
 export SSHPASS=$REMOTE_PASS
 sshpass -e scp -q -o stricthostkeychecking=no $PREVIEW $REMOTE_USER@$REMOTE_HOST:$PREVIEW_PATH/$PREVIEW


### PR DESCRIPTION
Replace zip with tar.gz compression for cache and previews:

- reduce storage and bandwidth use
- preserve symlinks by default

**EDIT**: also use new bin dir location (see #365)