### PR TITLE
[ExoBundle] Updater brokens

### DIFF
--- a/plugin/exo/Installation/AdditionalInstaller.php
+++ b/plugin/exo/Installation/AdditionalInstaller.php
@@ -20,7 +20,7 @@ class AdditionalInstaller extends BaseInstaller
             $updater->preUpdate();
         }
 
-        if (version_compare($currentVersion, '6.1.0.0', '<=') || version_compare($currentVersion, '6.9999999.9999999.9999999-dev', '<=')) {
+        if (version_compare($currentVersion, '6.2.0.0', '<=')) {
             $updater = new Updater600200($this->container);
             $updater->setLogger($this->logger);
             $updater->preUpdate();
@@ -41,7 +41,7 @@ class AdditionalInstaller extends BaseInstaller
             $updater->postUpdate();
         }
 
-        if (version_compare($currentVersion, '6.1.0.0', '<=') || version_compare($currentVersion, '6.9999999.9999999.9999999-dev', '<=')) {
+        if (version_compare($currentVersion, '6.2.0.0', '<=')) {
             $updater = new Updater600200($this->container);
             $updater->setLogger($this->logger);
             $updater->postUpdate();

--- a/plugin/exo/Installation/AdditionalInstaller.php
+++ b/plugin/exo/Installation/AdditionalInstaller.php
@@ -20,7 +20,7 @@ class AdditionalInstaller extends BaseInstaller
             $updater->preUpdate();
         }
 
-        if (version_compare($currentVersion, '6.2.0.0', '<=')) {
+        if (version_compare($currentVersion, '6.2.0.0', '<')) {
             $updater = new Updater600200($this->container);
             $updater->setLogger($this->logger);
             $updater->preUpdate();
@@ -41,7 +41,7 @@ class AdditionalInstaller extends BaseInstaller
             $updater->postUpdate();
         }
 
-        if (version_compare($currentVersion, '6.2.0.0', '<=')) {
+        if (version_compare($currentVersion, '6.2.0.0', '<')) {
             $updater = new Updater600200($this->container);
             $updater->setLogger($this->logger);
             $updater->postUpdate();

--- a/plugin/exo/Installation/Updater600200.php
+++ b/plugin/exo/Installation/Updater600200.php
@@ -187,6 +187,7 @@ class Updater600200
     {
         $exoId = -1;
         $stepId = -1;
+        $orderStep = 1;
 
         $exoQuestion = $this->checkExoQuestion();
         $stepStmt = $this->connection->prepare("
@@ -208,6 +209,7 @@ class Updater600200
 
             $stepId = $this->connection->lastInsertId();
             $this->addQuestionStep($stepId, $eq['question_id'], 1);
+            ++$orderStep;
         }
     }
 


### PR DESCRIPTION
C'est juste pour attirer l'attention sur les bugs que j'ai pu constater, pas pour être mergé.

- La condition dans l'installer est pas logique. Si on regarde <= 6.1 ou <= 6.999999999, ça veut dire que tant qu'on est sur la v6 l'updater se déclenchera.

- Il manque le orderStep. La j'ai fait un patch à la con avec une variable qui s'incrémente mais elle n'est pas déclarée sinon, donc la valeur 'ordre' est null et ça casse derrière.

@UJM-dev 
