### PR TITLE
[SensioInsight] Logical operators should be avoided

### DIFF
--- a/plugin/ldap/Manager/LdapManager.php
+++ b/plugin/ldap/Manager/LdapManager.php
@@ -159,7 +159,7 @@ class LdapManager
     {
         $servers = isset($this->config['servers']) ? $this->config['servers'] : null;
 
-        if ((!$name or ($name && $name !== $data['name'])) &&
+        if ((!$name || ($name && $name !== $data['name'])) &&
             isset($data['name']) && isset($servers[$data['name']])
         ) {
             return true;


### PR DESCRIPTION
Changes an "or" to "||" in the LDAP Manager as recomended by Sensio Insight