### PR TITLE
[ExoBundle] closes #140

### DIFF
--- a/plugin/exo/Controller/Api/ExerciseController.php
+++ b/plugin/exo/Controller/Api/ExerciseController.php
@@ -152,7 +152,7 @@ class ExerciseController
             return new JsonResponse($this->paperManager->exportExercisePapers($exercise));
         }
 
-        return new JsonResponse($this->paperManager->exportUserPapers($exercise, $user));
+        return new JsonResponse($this->paperManager->exportExercisePapers($exercise, $user));
     }
 
     /**

--- a/plugin/exo/Resources/public/js/angular/Paper/Controllers/PaperListCtrl.js
+++ b/plugin/exo/Resources/public/js/angular/Paper/Controllers/PaperListCtrl.js
@@ -17,7 +17,8 @@ var PaperListCtrl = function PaperListCtrl($filter, CommonService, ExerciseServi
 
     this.editEnabled = this.ExerciseService.isEditEnabled();
     this.exercise    = this.ExerciseService.getExercise();
-    this.papers      = papers;
+    this.papers      = papers.papers;
+    this.questions   = papers.questions;
 
     this.filtered = this.papers;
 };
@@ -35,6 +36,8 @@ PaperListCtrl.prototype.editEnabled = false;
  * @type {Array}
  */
 PaperListCtrl.prototype.papers = [];
+
+PaperListCtrl.prototype.questions = [];
 
 /**
  * Current Exercise
@@ -106,7 +109,18 @@ PaperListCtrl.prototype.deletePaper = function deletePaper(paper) {
  * @returns {Number}
  */
 PaperListCtrl.prototype.getPaperScore = function getPaperScore(paper) {
-    return this.PaperService.getPaperScore(paper);
+    var questions = [];
+
+    // Search the correct set of Papers questions
+    for (var i = 0; i < this.questions.length; i++) {
+        if (this.questions[i].paperId === paper.id) {
+            questions = this.questions[i].questions;
+
+            break;
+        }
+    }
+
+    return this.PaperService.getPaperScore(paper, questions);
 };
 
 /**

--- a/plugin/exo/Resources/public/js/angular/Paper/Controllers/PaperShowCtrl.js
+++ b/plugin/exo/Resources/public/js/angular/Paper/Controllers/PaperShowCtrl.js
@@ -39,7 +39,7 @@ PaperShowCtrl.prototype.getQuestionPaper = function getQuestionPaper(question) {
  * @returns {Number}
  */
 PaperShowCtrl.prototype.getScore = function getScore() {
-    return this.PaperService.getPaperScore(this.paper);
+    return this.PaperService.getPaperScore(this.paper, this.questions);
 };
 
 // Register controller into Angular JS

--- a/plugin/exo/Resources/public/js/angular/Paper/Services/PaperService.js
+++ b/plugin/exo/Resources/public/js/angular/Paper/Services/PaperService.js
@@ -225,11 +225,19 @@ PaperService.prototype.saveScore = function saveScore(question, score) {
 /**
  * Calculate the score of the Paper (/20)
  * @param   {Object} paper
+ * @param   {Array} questions
  * @returns {number}
  */
-PaperService.prototype.getPaperScore = function getPaperScore(paper) {
+PaperService.prototype.getPaperScore = function getPaperScore(paper, questions) {
     var score = 0.0; // final score
-    var scoreTotal = this.ExerciseService.getScoreTotal();
+    var scoreTotal = 0;
+
+    for (var i = 0; i < questions.length; i++) {
+        if (questions[i].scoreTotal) {
+            scoreTotal += questions[i].scoreTotal;
+        }
+    }
+
     var userScore = paper.scoreTotal;
     if (userScore) {
         score = userScore * 20 / scoreTotal;

--- a/plugin/exo/Tests/Controller/Api/ExerciseControllerCommonTest.php
+++ b/plugin/exo/Tests/Controller/Api/ExerciseControllerCommonTest.php
@@ -215,7 +215,7 @@ class ExerciseControllerCommonTest extends TransactionalTestCase
 
         $content = json_decode($this->client->getResponse()->getContent());
         $this->assertEquals(1, count($content));
-        $this->assertEquals($pa1->getId(), $content[0]->id);
+        $this->assertEquals($pa1->getId(), $content->papers[0]->id);
     }
 
     /**
@@ -234,10 +234,10 @@ class ExerciseControllerCommonTest extends TransactionalTestCase
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
 
         $content = json_decode($this->client->getResponse()->getContent());
-        $this->assertEquals(4, count($content));
-        $this->assertEquals($pa1->getId(), $content[0]->id);
-        $this->assertEquals($pa2->getId(), $content[1]->id);
-        $this->assertEquals($pa3->getId(), $content[2]->id);
-        $this->assertEquals($pa4->getId(), $content[3]->id);
+        $this->assertEquals(4, count($content->papers));
+        $this->assertEquals($pa1->getId(), $content->papers[0]->id);
+        $this->assertEquals($pa2->getId(), $content->papers[1]->id);
+        $this->assertEquals($pa3->getId(), $content->papers[2]->id);
+        $this->assertEquals($pa4->getId(), $content->papers[3]->id);
     }
 }


### PR DESCRIPTION
I think it can be improved and it requires further tests if you want to continue an attempt with a deleted question.

But at least the corrections and scores are  OK. When loading the list of papers, I also load the set of questions for each paper. Can be improved to avoid performance impact...

I create a "fake" step at the end of the step list to get the questions which are no longer in the Exercise. So in that step, the questions are ordered. But the step is not at the correct place and the questions maybe not belong to the same step (this information has been lost when deleting).