### PR TITLE
[CoreBundle] Add confirm modal management

### DIFF
--- a/main/core/Resources/modules/modal/Controller/ConfirmModalController.js
+++ b/main/core/Resources/modules/modal/Controller/ConfirmModalController.js
@@ -1,0 +1,14 @@
+export default class ConfirmModalController {
+    constructor($uibModalInstance, content) {
+        this.$uibModalInstance = $uibModalInstance
+        this.content = content
+    }
+
+    cancel() {
+        this.$uibModalInstance.dismiss('cancel');
+    }
+
+    confirm() {
+        this.$uibModalInstance.close();
+    }
+}

--- a/main/core/Resources/modules/modal/Directive/ConfirmModalDirective.js
+++ b/main/core/Resources/modules/modal/Directive/ConfirmModalDirective.js
@@ -1,0 +1,69 @@
+import ConfirmModalController from './../Controller/ConfirmModalController'
+import confirmTpl from './../Partial/confirm-modal.html'
+
+export default class ConfirmModalDirective {
+    constructor () {
+        this.restrict = 'A'
+        this.replace = false
+        this.scope = {
+            /**
+             * Content message
+             */
+            content: '@confirmModal',
+
+            /**
+             * Callback to execute if the User confirm his action
+             */
+            confirmCallback: '&confirmModalAction',
+
+            /**
+             * Callback to execute if the User cancel his action
+             */
+            cancelCallback: '&confirmModalCancel'
+        }
+        this.bindToController = true
+        this.controllerAs = 'modalCtrl'
+        this.controller = [
+            '$uibModal',
+            class ModalCtrl {
+                constructor ($uibModal) {
+                    this.$uibModal = $uibModal
+                }
+
+                open() {
+                    var message = this.content;
+                    this.$uibModal.open({
+                        template: confirmTpl,
+                        controller: ConfirmModalController,
+                        controllerAs: 'confirmCtrl',
+                        resolve: {
+                            content: () => message
+                        }
+                    }).result.then(
+                        // On confirm
+                        d => {
+                            if (typeof this.confirmCallback === 'function') {
+                                this.confirmCallback();
+                            }
+                        },
+
+                        // On cancel
+                        d => {
+                            if (typeof this.cancelCallback === 'function') {
+                                this.cancelCallback();
+                            }
+                        }
+                    )
+                }
+            }
+        ]
+        this.link = function link(scope, element, attr, controller) {
+            // Open the modal on click on the element
+            element.on('click', controller.open.bind(controller));
+
+            scope.$on('$destroy', () => {
+                element.off('click', controller.open.bind(controller));
+            })
+        }
+    }
+}

--- a/main/core/Resources/modules/modal/Partial/confirm-modal.html
+++ b/main/core/Resources/modules/modal/Partial/confirm-modal.html
@@ -1,0 +1,12 @@
+<div class="modal-body">
+    {{ confirmCtrl.content }}
+</div>
+
+<div class="modal-footer">
+    <button class="btn btn-primary" data-ng-click="confirmCtrl.confirm()">
+        {{ 'confirm' | trans:{}:'platform' }}
+    </button>
+    <button class="btn btn-default cancel" data-ng-click="confirmCtrl.cancel()">
+        {{ 'cancel' | trans:{}:'platform' }}
+    </button>
+</div>

--- a/main/core/Resources/modules/modal/README.md
+++ b/main/core/Resources/modules/modal/README.md
@@ -1,0 +1,34 @@
+Modal
+=====
+
+Simple modal management build on top of AngularBootstrap
+
+Add modals to your module dependencies
+--------------------------------------
+
+```
+angular
+    .module('MY_MODULE', [
+        'ui.modal'
+    ])
+```
+
+Directives usage
+----------------
+
+**Confirm**
+
+```
+<button type="button"
+    data-confirm-modal="{{ 'confirm_message'|trans:{}:'domain'}}"
+    data-confirm-modal-action="confirmCallback()"
+    data-confirm-modal-cancel="cancelCallback()"
+>
+    My toggle modal button
+</button>
+```
+
+Where :
+- `data-confirm-modal` : the message to display in the modal
+- `data-confirm-modal-action` : the callback to execute if the User confirm his action (can be a method of the parent controller)
+- `data-confirm-modal-cancel` : the callback to execute if the User cancel his action (can be a method of the parent controller)

--- a/main/core/Resources/modules/modal/module.js
+++ b/main/core/Resources/modules/modal/module.js
@@ -1,0 +1,14 @@
+import 'angular/angular.min'
+
+import bootstrap from 'angular-bootstrap'
+
+import ConfirmModalDirective from './Directive/ConfirmModalDirective'
+
+angular
+    .module('ui.modal', [
+        'ui.bootstrap'
+    ])
+    .directive('confirmModal', [
+        '$uibModal',
+        () => new ConfirmModalDirective
+    ])

--- a/main/core/Resources/translations/platform.de.yml
+++ b/main/core/Resources/translations/platform.de.yml
@@ -168,6 +168,7 @@ communication: Communication
 completed: Terminé
 configuration: Configuration
 configure: Configurer
+confirm: OK
 confirm_send_data: 'Nous vous proposons de marquer votre accord pour l''envoi de données :'
 connections: 'Nb Cnx.'
 contact: Contact

--- a/main/core/Resources/translations/platform.en.yml
+++ b/main/core/Resources/translations/platform.en.yml
@@ -171,6 +171,7 @@ communication: Communication
 completed: Completed
 configuration: Configuration
 configure: Configure
+confirm: OK
 confirm_send_data: 'We suggest to confirm your agreement to send data:'
 connections: Connections
 contact: Contact

--- a/main/core/Resources/translations/platform.es.yml
+++ b/main/core/Resources/translations/platform.es.yml
@@ -170,6 +170,7 @@ communication: Comunicación
 completed: Completado
 configuration: Configuración
 configure: Configurar
+confirm: OK
 confirm_send_data: 'Sugerimos confirmar su acuerdo para enviar datos:'
 connections: Conexiones
 contact: Contacto

--- a/main/core/Resources/translations/platform.fr.yml
+++ b/main/core/Resources/translations/platform.fr.yml
@@ -171,6 +171,7 @@ communication: Communication
 completed: Terminé
 configuration: Configuration
 configure: Configurer
+confirm: OK
 confirm_send_data: 'Nous vous proposons de marquer votre accord pour l''envoi de données :'
 connections: 'Nb Cnx.'
 contact: Contact


### PR DESCRIPTION
Maybe not needed in 7.x.

This PR contains a new directive to simplify the usage of AngularBootstrap modal.
For now only confirm modals are managed based on ngBootbox way to do it (directives that can be appended to DOM elements).

So once this PR is merged, there will be no more need of ngBootbox (which requires jquery and bootstrap js) which is only used in Exercises.

Implementation détails : 
- I have kept the controller inside the directive definition as the directive and the controller do practically nothing.
- The design and features are very limited for now (I only do what bootbox did) and will be updated when adding alert modal and other modal types.

See README for more information about usage.