### PR TITLE
Resource creation autofocus on first field

### DIFF
--- a/main/core/Form/ActivityType.php
+++ b/main/core/Form/ActivityType.php
@@ -21,7 +21,7 @@ class ActivityType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('title', 'text', array('label' => 'name', 'constraints' => new NotBlank()))
+            ->add('title', 'text', array('label' => 'name', 'constraints' => new NotBlank(), 'attr' => array('autofocus' => true)))
             ->add('description', 'tinymce', array('required' => false, 'label' => 'description'))
             ->add(
                 'primaryResource',

--- a/main/core/Form/DirectoryType.php
+++ b/main/core/Form/DirectoryType.php
@@ -26,6 +26,7 @@ class DirectoryType extends AbstractType
             array(
                 'constraints' => new NotBlank(),
                 'label' => 'name',
+                'attr' => array('autofocus' => true)
             )
         );
         $builder->add(

--- a/main/core/Form/DirectoryType.php
+++ b/main/core/Form/DirectoryType.php
@@ -26,7 +26,7 @@ class DirectoryType extends AbstractType
             array(
                 'constraints' => new NotBlank(),
                 'label' => 'name',
-                'attr' => array('autofocus' => true)
+                'attr' => array('autofocus' => true),
             )
         );
         $builder->add(

--- a/main/core/Form/ResourceNameType.php
+++ b/main/core/Form/ResourceNameType.php
@@ -20,7 +20,7 @@ class ResourceNameType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'text', array('label' => 'name', 'constraints' => new NotBlank()));
+        $builder->add('name', 'text', array('label' => 'name', 'constraints' => new NotBlank(), 'attr' => array('autofocus' => true)));
     }
 
     public function getName()

--- a/main/core/Form/TextType.php
+++ b/main/core/Form/TextType.php
@@ -27,7 +27,7 @@ class TextType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'text', array('label' => 'name', 'constraints' => new NotBlank()));
+        $builder->add('name', 'text', array('label' => 'name', 'constraints' => new NotBlank(), 'attr' => array('autofocus' => true)));
         $builder->add('text', 'tinymce', array('label' => 'text'));
         $builder->add(
             'published',

--- a/main/core/Resources/views/Tool/workspace/resource_manager/resources.html.twig
+++ b/main/core/Resources/views/Tool/workspace/resource_manager/resources.html.twig
@@ -23,6 +23,16 @@
 {% endblock %}
 {% block javascripts %}
     {{ parent() }}
+
+    <script type="text/javascript">
+        {# autofocus HTML has no effect in second and next loaded Bootstrap modals #}
+        $(function(){
+            $(document).on('shown.bs.modal', '.modal', function () {
+                $(this).find('[autofocus]').focus();
+            });
+        });
+    </script>
+
     <script type="text/javascript">
         $(function() {
             Claroline.ResourceManager.createFullManager({

--- a/plugin/blog/Form/BlogType.php
+++ b/plugin/blog/Form/BlogType.php
@@ -10,7 +10,7 @@ class BlogType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name');
+        $builder->add('name', 'text', array('attr' => array('autofocus' => true)));
     }
 
     public function getName()

--- a/plugin/collecticiel/Form/DropzoneType.php
+++ b/plugin/collecticiel/Form/DropzoneType.php
@@ -15,6 +15,7 @@ class DropzoneType extends AbstractType
         array(
             'constraints' => new NotBlank(),
             'required' => true,
+            'attr' => array('autofocus' => true)
              )
         );
     }

--- a/plugin/collecticiel/Form/DropzoneType.php
+++ b/plugin/collecticiel/Form/DropzoneType.php
@@ -15,7 +15,7 @@ class DropzoneType extends AbstractType
         array(
             'constraints' => new NotBlank(),
             'required' => true,
-            'attr' => array('autofocus' => true)
+            'attr' => array('autofocus' => true),
              )
         );
     }

--- a/plugin/dropzone/Form/DropzoneType.php
+++ b/plugin/dropzone/Form/DropzoneType.php
@@ -10,7 +10,7 @@ class DropzoneType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name');
+        $builder->add('name', 'text', array('attr' => array('autofocus' => true)));
     }
 
     public function getName()

--- a/plugin/forum/Form/ForumType.php
+++ b/plugin/forum/Form/ForumType.php
@@ -20,7 +20,7 @@ class ForumType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'text', array('constraints' => new NotBlank()));
+        $builder->add('name', 'text', array('constraints' => new NotBlank(), 'attr' => array('autofocus' => true)));
         $builder->add(
             'activateNotifications',
             'choice',

--- a/plugin/path/Form/AbstractPathType.php
+++ b/plugin/path/Form/AbstractPathType.php
@@ -12,7 +12,7 @@ abstract class AbstractPathType extends AbstractType
     {
         $builder->add('name',                       'text',     array(
             'required' => true,
-            'attr' => array('autofocus' => true)
+            'attr' => array('autofocus' => true),
         ));
         $builder->add('description',                'tinymce',  array('required' => false));
         $builder->add('breadcrumbs',                'checkbox', array('required' => false));

--- a/plugin/path/Form/AbstractPathType.php
+++ b/plugin/path/Form/AbstractPathType.php
@@ -10,7 +10,10 @@ abstract class AbstractPathType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options = array())
     {
-        $builder->add('name',                       'text',     array('required' => true));
+        $builder->add('name',                       'text',     array(
+            'required' => true,
+            'attr' => array('autofocus' => true)
+        ));
         $builder->add('description',                'tinymce',  array('required' => false));
         $builder->add('breadcrumbs',                'checkbox', array('required' => false));
         $builder->add('summaryDisplayed',           'checkbox', array('required' => false));

--- a/plugin/result/Form/ResultType.php
+++ b/plugin/result/Form/ResultType.php
@@ -30,7 +30,7 @@ class ResultType extends AbstractType
             ->add('name', 'text', [
                 'label' => 'title',
                 'constraints' => new NotBlank(),
-                'attr' =>['autofocus' => true]
+                'attr' => ['autofocus' => true],
             ])
             ->add('total', 'integer', [
                 'label' => 'maximum_mark',

--- a/plugin/result/Form/ResultType.php
+++ b/plugin/result/Form/ResultType.php
@@ -30,6 +30,7 @@ class ResultType extends AbstractType
             ->add('name', 'text', [
                 'label' => 'title',
                 'constraints' => new NotBlank(),
+                'attr' =>['autofocus' => true]
             ])
             ->add('total', 'integer', [
                 'label' => 'maximum_mark',

--- a/plugin/scorm/Form/ScormType.php
+++ b/plugin/scorm/Form/ScormType.php
@@ -27,7 +27,7 @@ class ScormType extends AbstractType
             array(
                 'required' => true,
                 'constraints' => new NotBlank(),
-                'attr' => array('autofocus' => true)
+                'attr' => array('autofocus' => true),
             )
         );
         $builder->add(

--- a/plugin/scorm/Form/ScormType.php
+++ b/plugin/scorm/Form/ScormType.php
@@ -27,6 +27,7 @@ class ScormType extends AbstractType
             array(
                 'required' => true,
                 'constraints' => new NotBlank(),
+                'attr' => array('autofocus' => true)
             )
         );
         $builder->add(

--- a/plugin/survey/Form/SurveyType.php
+++ b/plugin/survey/Form/SurveyType.php
@@ -26,6 +26,7 @@ class SurveyType extends AbstractType
             array(
                 'constraints' => new NotBlank(),
                 'label' => 'name',
+                'attr' => array('autofocus' => true)
             )
         );
         $builder->add(

--- a/plugin/survey/Form/SurveyType.php
+++ b/plugin/survey/Form/SurveyType.php
@@ -26,7 +26,7 @@ class SurveyType extends AbstractType
             array(
                 'constraints' => new NotBlank(),
                 'label' => 'name',
-                'attr' => array('autofocus' => true)
+                'attr' => array('autofocus' => true),
             )
         );
         $builder->add(

--- a/plugin/website/Form/WebsiteType.php
+++ b/plugin/website/Form/WebsiteType.php
@@ -16,7 +16,7 @@ class WebsiteType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name');
+        $builder->add('name', 'text', array('attr' => array('autofocus' => true)));
     }
 
     public function getName()

--- a/plugin/wiki/Form/WikiType.php
+++ b/plugin/wiki/Form/WikiType.php
@@ -10,7 +10,7 @@ class WikiType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name');
+        $builder->add('name', 'text', array('attr' => array('autofocus' => true)));
     }
 
     public function getName()


### PR DESCRIPTION
Added an autofocus HTML option on the first field of each resource creation form (displayed in a bootstrap modal on the resource page of each workspace).
Added some javascript to enable autofocus if a second (or more modal) is opened without a full page reload.