### PR TITLE
Fix claroline/Distribution#463 Fix scoring on match questions

### DIFF
--- a/plugin/exo/Services/classes/Interactions/Matching.php
+++ b/plugin/exo/Services/classes/Interactions/Matching.php
@@ -76,8 +76,8 @@ class Matching extends Interaction
         $score = 0;
 
         foreach ($tabRightResponse as $labelId => $value) {
-            $rightResponseArray = split("-", $tabRightResponse[$labelId]);
-            $responseArray = split("-", $tabResponseIndex[$labelId]);
+            $rightResponseArray = split('-', $tabRightResponse[$labelId]);
+            $responseArray = split('-', $tabResponseIndex[$labelId]);
             foreach ($responseArray as $responseGiven) {
                 if (in_array($responseGiven, $rightResponseArray)) {
                     $label = $em->getRepository('UJMExoBundle:Label')

--- a/plugin/exo/Services/classes/Interactions/Matching.php
+++ b/plugin/exo/Services/classes/Interactions/Matching.php
@@ -76,17 +76,14 @@ class Matching extends Interaction
         $score = 0;
 
         foreach ($tabRightResponse as $labelId => $value) {
-            if (isset($tabResponseIndex[$labelId]) && $tabRightResponse[$labelId] != null
-                && (!substr_compare($tabRightResponse[$labelId], $tabResponseIndex[$labelId], 0))
-            ) {
-                $label = $em->getRepository('UJMExoBundle:Label')
-                    ->find($labelId);
-                $score += $label->getScoreRightResponse();
-            }
-            if ($tabRightResponse[$labelId] == null && !isset($tabResponseIndex[$labelId])) {
-                $label = $em->getRepository('UJMExoBundle:Label')
-                    ->find($labelId);
-                $score += $label->getScoreRightResponse();
+            $rightResponseArray = split("-", $tabRightResponse[$labelId]);
+            $responseArray = split("-", $tabResponseIndex[$labelId]);
+            foreach ($responseArray as $responseGiven) {
+                if (in_array($responseGiven, $rightResponseArray)) {
+                    $label = $em->getRepository('UJMExoBundle:Label')
+                        ->find($labelId);
+                    $score += $label->getScoreRightResponse();
+                }
             }
         }
 

--- a/plugin/exo/Services/classes/Interactions/Matching.php
+++ b/plugin/exo/Services/classes/Interactions/Matching.php
@@ -76,8 +76,8 @@ class Matching extends Interaction
         $score = 0;
 
         foreach ($tabRightResponse as $labelId => $value) {
-            $rightResponseArray = split('-', $tabRightResponse[$labelId]);
-            $responseArray = split('-', $tabResponseIndex[$labelId]);
+            $rightResponseArray = explode('-', $tabRightResponse[$labelId]);
+            $responseArray = explode('-', $tabResponseIndex[$labelId]);
             foreach ($responseArray as $responseGiven) {
                 if (in_array($responseGiven, $rightResponseArray)) {
                     $label = $em->getRepository('UJMExoBundle:Label')

--- a/plugin/exo/Tests/Controller/Api/ExerciseControllerMatchTest.php
+++ b/plugin/exo/Tests/Controller/Api/ExerciseControllerMatchTest.php
@@ -99,6 +99,9 @@ class ExerciseControllerMatchTest extends TransactionalTestCase
             ['data' => [$propId1.','.$labelId, $propId2.','.$labelId]]
         );
 
+        var_dump($this->client->getResponse());
+        die();
+
         $this->assertEquals(204, $this->client->getResponse()->getStatusCode());
     }
 }

--- a/plugin/exo/Tests/Controller/Api/ExerciseControllerMatchTest.php
+++ b/plugin/exo/Tests/Controller/Api/ExerciseControllerMatchTest.php
@@ -96,7 +96,7 @@ class ExerciseControllerMatchTest extends TransactionalTestCase
             'PUT',
             "/exercise/api/papers/{$pa1->getId()}/questions/{$this->qu1->getId()}",
             $this->john,
-            ['data' => [$propId1.','.$labelId, $propId2.','.$labelId]]
+            ['data' => [$propId1.'-'.$labelId, $propId2.'-'.$labelId]]
         );
         $this->assertEquals(204, $this->client->getResponse()->getStatusCode());
     }

--- a/plugin/exo/Tests/Controller/Api/ExerciseControllerMatchTest.php
+++ b/plugin/exo/Tests/Controller/Api/ExerciseControllerMatchTest.php
@@ -96,8 +96,9 @@ class ExerciseControllerMatchTest extends TransactionalTestCase
             'PUT',
             "/exercise/api/papers/{$pa1->getId()}/questions/{$this->qu1->getId()}",
             $this->john,
-            ['data' => [$propId1.'-'.$labelId, $propId2.'-'.$labelId]]
+            ['data' => [$propId1.','.$labelId, $propId2.','.$labelId]]
         );
+
         $this->assertEquals(204, $this->client->getResponse()->getStatusCode());
     }
 }

--- a/plugin/exo/Tests/Controller/Api/ExerciseControllerMatchTest.php
+++ b/plugin/exo/Tests/Controller/Api/ExerciseControllerMatchTest.php
@@ -99,9 +99,6 @@ class ExerciseControllerMatchTest extends TransactionalTestCase
             ['data' => [$propId1.','.$labelId, $propId2.','.$labelId]]
         );
 
-        var_dump($this->client->getResponse());
-        die();
-
         $this->assertEquals(204, $this->client->getResponse()->getStatusCode());
     }
 }


### PR DESCRIPTION
This commit fixes the following issue: 
https://github.com/claroline/Distribution/issues/463

Now the score set for a label is counted for each right connection.