### PR TITLE
Exo issues fixes

### DIFF
--- a/plugin/exo/Resources/public/js/angular/Correction/Controllers/MatchCorrectionCtrl.js
+++ b/plugin/exo/Resources/public/js/angular/Correction/Controllers/MatchCorrectionCtrl.js
@@ -4,7 +4,7 @@
  * @param {MatchQuestionService} MatchQuestionService
  * @constructor
  */
-var MatchCorrectionCtrl = function MatchCorrectionCtrl(QuestionService) {
+var MatchCorrectionCtrl = function MatchCorrectionCtrl(QuestionService, MatchQuestionService) {
     AbstractCorrectionCtrl.apply(this, arguments);
 
     this.MatchQuestionService = MatchQuestionService;

--- a/plugin/exo/Resources/public/js/angular/Correction/Directives/MatchCorrectionDirective.js
+++ b/plugin/exo/Resources/public/js/angular/Correction/Directives/MatchCorrectionDirective.js
@@ -21,4 +21,4 @@ MatchCorrectionDirective.$inject = [];
 // Register directive into AngularJS
 angular
     .module('Correction')
-    .directive('correctionMatch', MatchCorrectionDirective);
+    .directive('matchCorrection', MatchCorrectionDirective);

--- a/plugin/exo/Resources/public/js/angular/Correction/Partials/match.html
+++ b/plugin/exo/Resources/public/js/angular/Correction/Partials/match.html
@@ -1,37 +1,12 @@
 <table class="table table-striped">
     <thead>
         <tr>
-            <th class="center-text">{{ 'paper_details_table_choice'|trans:{}:'ujm_sequence' }}</th>
             <th class="center-text">{{ 'paper_details_table_expected_answer'|trans:{}:'ujm_sequence' }}</th>
             <th class="center-text">{{ 'paper_details_table_comment'|trans:{}:'ujm_sequence' }}</th>
         </tr>
     </thead>
     <tbody>
         <tr data-ng-repeat="label in matchCorrectionCtrl.question.secondSet">
-            <!-- student answer -->
-            <td class="center-text">
-                <div class="panel" data-ng-class="matchCorrectionCtrl.checkAnswerValidity(label) ? 'panel-success':'panel-danger'">
-                    <div class="panel-heading clearfix">
-                        <h4 class="panel-title pull-left">
-                             <div data-ng-bind-html="label.data | unsafe"></div>
-                        </h4>
-                    </div>
-                    <div class="panel-body">
-                        <ul>
-                            <li data-ng-repeat="item in matchCorrectionCtrl.getStudentAnswers(label)">
-                                <div data-ng-bind-html="item.data | unsafe"></div>
-                                 <!--
-                                 KEEP THIS FOR THE TIME WHEN WE WOULD BE ABLE TO KNOW PROPOSAL / LABEL TYPE (ie HTML vs Text)
-                                <span data-ng-class="correctionMatchCtrl.checkProposalValidity(item.id) ? '':'wrong-label'">{{item.data}}</span>
-                                 -->
-                            </li>
-                            <li data-ng-if="item.length == 0" data-ng-repeat="item in matchCorrectionCtrl.getStudentAnswers(label)">
-                                -
-                            </li>
-                        </ul>
-                    </div>
-                </div>
-            </td>
             <!-- expected answer -->
             <td class="center-text">
                 <div class="panel panel-default">

--- a/plugin/exo/Resources/public/js/angular/Question/Partials/Type/graphic.html
+++ b/plugin/exo/Resources/public/js/angular/Question/Partials/Type/graphic.html
@@ -3,7 +3,8 @@
         <div class="row question-btns">
             <!-- Number of pointers available -->
             <div class="col-md-10 text-left">
-                {{ 'question_graphic_nb_pointers'|transChoice:(graphicQuestionCtrl.question.pointers - graphicQuestionCtrl.answer.length):{ count: graphicQuestionCtrl.question.pointers - graphicQuestionCtrl.answer.length }:'ujm_exo' }}
+                <span>{{ 'question_graphic_nb_pointers'|transChoice:(graphicQuestionCtrl.question.pointers - graphicQuestionCtrl.answer.length):{ count: graphicQuestionCtrl.question.pointers - graphicQuestionCtrl.answer.length }:'ujm_exo' }}</span>
+                <span>{{ 'question_graphic_set_pointers'|trans:{}:'ujm_exo' }}</span>
             </div>
 
             <!-- Reset button -->

--- a/plugin/exo/Resources/translations/ujm_exo.en.yml
+++ b/plugin/exo/Resources/translations/ujm_exo.en.yml
@@ -313,6 +313,7 @@ question_title: Question title (optional)
 question_shared_with: This question is shared with users below
 question_need_manual_correction: This question needs a manual correction
 question_open_keywords_info: Your answer needs to contain the following keywords to get the points
+question_graphic_set_pointers: Click on the picture to place a pointer
 question_graphic_nb_pointers: "{0} There is no more pointer to place on the picture.|{1} There is still %count% pointer to place on the picture.|]1,Inf[ There are still %count% pointers to place on the picture."
 
 # R

--- a/plugin/exo/Resources/translations/ujm_exo.fr.yml
+++ b/plugin/exo/Resources/translations/ujm_exo.fr.yml
@@ -313,6 +313,7 @@ question_title: Titre de la question (facultatif)
 question_shared_with: Cette question est partagée avec les utilisateurs suivants
 question_need_manual_correction: Cette question nécessite une correction manuelle
 question_open_keywords_info: Votre réponse doit contenir les mots clés suivant pour obtenir les points
+question_graphic_set_pointers: Cliquez sur l'image pour placer un pointeur
 question_graphic_nb_pointers: "{0} Il ne reste plus aucun pointeur à placer sur l'image.|{1} Il reste %count% pointeur à placer sur l'image.|]1,Inf[ Il reste %count% pointeurs à placer sur l'image."
 
 # R


### PR DESCRIPTION
This PR fixes two minor issues.

On graphic questions, since the pointers are no longer shown on page load, but appear on click, it seemed important to say it in a descriptive sentence.

On match question, the correction directive wasn't loading; the problem is fixed. The correction used to show a column "your answer", which is useless because we always show it with the question directive, containing these answers.