### PR TITLE
[CoreBundle] Removing update buggy code

### DIFF
--- a/main/core/Library/Installation/OperationExecutor.php
+++ b/main/core/Library/Installation/OperationExecutor.php
@@ -154,14 +154,9 @@ class OperationExecutor
                     }
                 }
             } else {
-                try {
-                    $foundBundle = $this->om->getRepository('ClarolineCoreBundle:Plugin')->findOneByBundleFQCN($bundle);
-                } catch (\Doctrine\DBAL\Exception\TableNotFoundException $e) {
-                    $foundBundle = false;
-                }
                 $previousPackage = $previous->findPackage($currentPackage->getName(), '*');
                 //old <= v6 package detection
-                if (!$previousPackage && !$foundBundle) {
+                if (!$previousPackage) {
                     $this->log("Installation of {$currentPackage->getName()} required");
                     $operation = $this->buildOperation(Operation::INSTALL, $currentPackage);
                     $operation->setToVersion($currentPackage->getVersion());


### PR DESCRIPTION
This didn't work well ($bundle not initialized; I don't get why it worked at some point). I guess we'll wait to work on the much tolerant upgrade to fix this properly. 

It would be nice to be able to find if the plugin is already in the database but that's not the correct way to do it.