### PR TITLE
[CoreBundle] Avoid creating a tmp directory with the template filename

### DIFF
--- a/main/core/Manager/WorkspaceManager.php
+++ b/main/core/Manager/WorkspaceManager.php
@@ -1126,13 +1126,13 @@ class WorkspaceManager
         }
 
         $archive = new \ZipArchive();
-        $fileName = $file->getBasename();
+        $fileName = $file->getBasename('.zip');
         $extractPath = $this->templateDirectory.DIRECTORY_SEPARATOR.$fileName;
 
         if ($archive->open($file->getPathname())) {
             $fs = new FileSystem();
-
             $fs->mkdir($extractPath);
+
             if (!$archive->extractTo($extractPath)) {
                 throw new \Exception("The workspace archive couldn't be extracted");
             }


### PR DESCRIPTION
Currently, when creating a user, the workspace manager tries to extract the personal.zip archive into a directory called personal.zip...