### PR TITLE
[ExoBundle] Get the step definition when added to Exercise

### DIFF
--- a/plugin/exo/Resources/public/js/angular/Exercise/Services/ExerciseService.js
+++ b/plugin/exo/Resources/public/js/angular/Exercise/Services/ExerciseService.js
@@ -217,7 +217,7 @@ ExerciseService.prototype.addStep = function addStep() {
         // Success callback
         .success(function (response) {
             // Get the information of the Step
-            step.id = response.id;
+            angular.merge(step, response);
 
             deferred.resolve(response);
         })


### PR DESCRIPTION
When adding a Step to an Exercise, the whole definition of the created step is not set in Angular. So if you try to edit the Step meta directly after angular crash.

Not a big bug because the data are correctly saved.