### PR TITLE
[PathBundle] Restart path on the last seen step

### DIFF
--- a/plugin/path/Resources/public/js/Path/Service/PathService.js
+++ b/plugin/path/Resources/public/js/Path/Service/PathService.js
@@ -245,7 +245,7 @@
                  * Get the last Step seen by a User
                  * @returns {Object|null}
                  */
-                getLastSeenStep: function getLasttSeenStep() {
+                getLastSeenStep: function getLastSeenStep() {
                     var lastSeen = null;
                     this.browseSteps(path.steps, function (step) {
                         var progression = UserProgressionService.getForStep(step);

--- a/plugin/path/Resources/public/js/Path/Service/PathService.js
+++ b/plugin/path/Resources/public/js/Path/Service/PathService.js
@@ -247,16 +247,18 @@
                  */
                 getLastSeenStep: function getLastSeenStep() {
                     var lastSeen = null;
-                    this.browseSteps(path.steps, function (step) {
+                    this.browseSteps(path.steps, function (parent, step) {
                         var progression = UserProgressionService.getForStep(step);
                         if (progression) {
                             lastSeen = step;
                         }
                     });
 
-                    if (!lastSeen && path.steps && 0 !== path.steps.length) {
+                    if (null === lastSeen && path.steps && 0 !== path.steps.length) {
                         lastSeen = path.steps[0];
                     }
+
+                    console.log(lastSeen);
 
                     return lastSeen;
                 },

--- a/plugin/path/Resources/public/js/Path/Service/PathService.js
+++ b/plugin/path/Resources/public/js/Path/Service/PathService.js
@@ -11,7 +11,8 @@
         '$location',
         'AlertService',
         'StepService',
-        function PathService($http, $q, $timeout, $location, AlertService, StepService) {
+        'UserProgressionService',
+        function PathService($http, $q, $timeout, $location, AlertService, StepService, UserProgressionService) {
             /**
              * ID of the Path
              * @type {Number}
@@ -235,11 +236,32 @@
                 setCompleteBlockingCondition: function setCompleteBlockingCondition(value) {
                     completeBlockingCondition = value;
                 },
+
                 isCompleteBlockingCondition: function isCompleteBlockingCondition() {
                     return completeBlockingCondition;
                 },
 
                 /**
+                 * Get the last Step seen by a User
+                 * @returns {Object|null}
+                 */
+                getLastSeenStep: function getLasttSeenStep() {
+                    var lastSeen = null;
+                    this.browseSteps(path.steps, function (step) {
+                        var progression = UserProgressionService.getForStep(step);
+                        if (progression) {
+                            lastSeen = step;
+                        }
+                    });
+
+                    if (!lastSeen && path.steps && 0 !== path.steps.length) {
+                        lastSeen = path.steps[0];
+                    }
+
+                    return lastSeen;
+                },
+
+				/**
                  * Set path total steps
                  * @param {Number} value
                  */

--- a/plugin/path/Resources/public/js/PathSummary/Controller/PathSummaryBaseCtrl.js
+++ b/plugin/path/Resources/public/js/PathSummary/Controller/PathSummaryBaseCtrl.js
@@ -16,6 +16,7 @@ var PathSummaryBaseCtrl = function PathSummaryBaseCtrl($routeParams, PathService
         // Set the structure of the path
         this.structure = path.steps;
     }
+
     return this;
 };
 

--- a/plugin/path/Resources/public/js/PathSummary/Controller/PathSummaryShowCtrl.js
+++ b/plugin/path/Resources/public/js/PathSummary/Controller/PathSummaryShowCtrl.js
@@ -3,13 +3,12 @@
  * @returns {PathSummaryShowCtrl}
  * @constructor
  */
-var PathSummaryShowCtrl = function PathSummaryShowCtrl($routeParams, PathService, UserProgressionService, AlertService) {
+var PathSummaryShowCtrl = function PathSummaryShowCtrl($routeParams, PathService, UserProgressionService) {
     PathSummaryBaseCtrl.apply(this, arguments);
 
     // Get Progression of the current User
     this.userProgressionService = UserProgressionService;
     this.userProgression = this.userProgressionService.get();
-    this.alertService = AlertService;
     this.evaluation = null;
     this.totalSteps = this.pathService.getTotalSteps();
     //this.totalProgression = this.userProgressionService.getTotalProgression();

--- a/plugin/path/Resources/public/js/wizards.app.js
+++ b/plugin/path/Resources/public/js/wizards.app.js
@@ -108,9 +108,6 @@
             }
         ],
         /**
-         * get return values of promises made in PathService to be available elsewhere
-         */
-        /**
          * list of all user group in Claro
          */
         allgroups: [

--- a/plugin/path/Resources/public/js/wizards.app.js
+++ b/plugin/path/Resources/public/js/wizards.app.js
@@ -198,7 +198,36 @@
                                     return { granted: true };
                                 }
                             ]
-                        }, resolveRootFunctions)
+                        }, resolveRootFunctions, {
+                            step: [
+                                '$route',
+                                'PathService',
+                                function getLastSeenStep($route, PathService) {
+                                    // Get the last seen step or the root if none
+                                    var currentStep = PathService.getLastSeenStep();
+                                    if (currentStep) {
+                                        $route.current.params.stepId = currentStep.id;
+                                    }
+
+                                    return currentStep;
+                                }
+                            ],
+                            inheritedResources: [
+                                'PathService',
+                                function getLastSeenInheritedResources(PathService) {
+                                    var inherited = [];
+
+                                    var path = PathService.getPath();
+                                    var currentStep = PathService.getLastSeenStep();
+                                    if (angular.isObject(path) && angular.isObject(path.steps) && angular.isObject(currentStep)) {
+                                        // Grab inherited resources
+                                        inherited = PathService.getStepInheritedResources(path.steps, currentStep);
+                                    }
+
+                                    return inherited;
+                                }
+                            ]
+                        })
                     })
                     .when('/:stepId?', {
                         templateUrl: AngularApp.webDir + 'bundles/innovapath/js/Step/Partial/show.html',


### PR DESCRIPTION
In order to fix the #593.

In the player if no step is specified in the URL (default behavior when you open a Path), the User is sent to the last Step he has seen or the last step he has set a manual progression (done / to do / to redo).

Implementation remark : the `wizard.app.js` starts to become quite ugly. I will need to split it to a player and editor entry points as the behavior of the router is no longer the same in the 2 apps. Will require some works and tests so it will be done later.

ping @eddymarques @ptsavdar 