### PR TITLE
Add ESLint check on ES6 files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,16 @@
+{
+  "env": {
+    "browser": true,
+    "es6": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "rules": {
+    "indent": [2, 2],
+    "linebreak-style": [2, "unix"],
+    "quotes": [2, "single"],
+    "semi": [2, "never"]
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,8 @@ script:
   - $ROOT/vendor/bin/phpmd --exclude main/core/Resources/bundle-creator,main/web-installer `cat git_diff_files.txt | xargs | sed -e :a -e '$!N; s/ /,/; ta'` text phpmd.xml
   # dry run php-cs-fixer on modified files (fail on violation)
   - $ROOT/vendor/bin/php-cs-fixer fix --dry-run --diff --config-file=main/dev/Resources/travis/php-cs.php
+  # launch eslint on ES6 files
+  - $ROOT/node_modules/.bin/eslint `cat git_diff_files.txt | grep 'Resources/modules/.\+\.js' | tr '\n' ' '`
   # launch the whole test suite
   - SYMFONY_DEPRECATIONS_HELPER=weak $ROOT/vendor/bin/phpunit
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bower": "^1.7.7",
     "colors": "^1.1.2",
     "cssnano": "^3.4.0",
+    "eslint": "^2.13.1",
     "filesystem-bower-resolver": "^1.2.0",
     "less": "^2.5.3",
     "mocha": "^2.4.5",


### PR DESCRIPTION
See #693. 

- the check will be applied to js files within *Resources/modules/** directories
- standard used is described in https://github.com/claroline/Distribution/issues/693#issuecomment-227124134 (I've added single quotes preference and unix-style line endings as per ESLint suggestion)

Note that this PR just adds the check, it doesn't fix any actual errors. Those will have to be fixed on each modified files prior to a PR submission. 

There're currently 8000+ infractions to the standard. Most of them are indent and semi-colons issues that can be fixed automatically by ESLint using the `--fix` option. The remaining ones are mainly:

- unknown globals (ESLint requires globals to be specified explicitely to prevent leakage)
- missing import statements
- unused variables
- variables defined more than once
- console statements

cc @claroline/commiters 