### PR TITLE
Require array shortands and ordered use statements

### DIFF
--- a/main/dev/Resources/travis/php-cs.php
+++ b/main/dev/Resources/travis/php-cs.php
@@ -28,4 +28,7 @@ $files = array_map(function ($filePath) use ($pkgDir) {
 
 $finder = Symfony\CS\Finder\DefaultFinder::create()->append($files);
 
-return Symfony\CS\Config\Config::create()->finder($finder);
+return Symfony\CS\Config\Config::create()
+    ->level(Symfony\CS\FixerInterface::SYMFONY_LEVEL)
+    ->fixers(['ordered_use', 'short_array_syntax'])
+    ->finder($finder);


### PR DESCRIPTION
See #693. @claroline/commiters, you'll have to update your editor config and/or your git hooks accordingly.