### PR TITLE
Add linter pass + phpmd rule in .travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,8 @@ before_script:
 script:
   # launch phpmd on modified files
   - $ROOT/vendor/bin/phpmd --exclude main/core/Resources/bundle-creator,main/web-installer `cat git_diff_files.txt | xargs | sed -e :a -e '$!N; s/ /,/; ta'` text phpmd.xml
+  # launch md on modified files
+  - $ROOT/vendor/bin/md `cat git_diff_files.txt | tr '\n' ' '`
   # dry run php-cs-fixer on modified files (fail on violation)
   - $ROOT/vendor/bin/php-cs-fixer fix --dry-run --diff --config-file=main/dev/Resources/travis/php-cs.php
   # launch eslint on ES6 files

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -11,12 +11,11 @@
     <description>Code checks</description>
 
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
+    <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
 
     <!-- MUST HAVE -->
 
-    <!-- <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/> -->
     <!-- <rule ref="rulesets/design.xml/ExitExpression"/> -->
-    <!-- <rule ref="rulesets/design.xml/EvalExpression"/> -->
 
     <!-- NICE TO HAVE -->
 


### PR DESCRIPTION
Follows claroline/Claroline#892. Fixes #286 and #693.

- enable PHPMD rule disallowing unused local variables or private fields
- add new MD linter tool to reject problematic stuff often seen in PRs, like loose comparisons, commented code, etc. (complete list [here](http://github.com/stefk/md/issues/1))

cc @claroline/commiters 