### PR TITLE
[DevBundle] Add git pre-commit hooks

### DIFF
--- a/main/dev/Resources/hooks/pre-commit
+++ b/main/dev/Resources/hooks/pre-commit
@@ -1,0 +1,36 @@
+#!/bin/sh
+# to use, copy this file into your .git/hooks folder in your git repo
+# make sure to add execute permissions using: chmod +x .git/hooks/pre-commit
+
+HOOKS="pre-commit-phpcs pre-commit-md pre-commit-phpmd pre-commit-eslint"
+
+###########################################################
+# There should be no need to change anything below this line.
+
+# exit on error
+set -e
+
+# Absolute path to this script, e.g. /home/user/bin/foo.sh
+SCRIPT="$(readlink -f "$0")"
+
+# Absolute path this script is in, thus /home/user/bin
+SCRIPTPATH="$(dirname "$SCRIPT")"
+
+for hook in $HOOKS
+do
+    echo "Running hook: $hook"
+    # run hook if it exists
+    # if it returns with nonzero exit with 1 and thus abort the commit
+    if [ -f "$SCRIPTPATH/$hook" ]; then
+        "$SCRIPTPATH/$hook"
+        if [ $? != 0 ]; then
+            exit 1
+        fi
+    else
+        echo "Error: file $hook not found."
+        echo "Aborting commit. Make sure the hook is in $SCRIPTPATH and executable."
+        echo "You can disable it by removing it from the list in $SCRIPT."
+        echo "You can skip all pre-commit hooks with --no-verify (not recommended)."
+        exit 1
+    fi
+done

--- a/main/dev/Resources/hooks/pre-commit-eslint
+++ b/main/dev/Resources/hooks/pre-commit-eslint
@@ -1,0 +1,31 @@
+#!/usr/bin/php
+<?php
+
+/**
+ * This pre-commit hook checks for ESLint errors.
+ */
+
+$moduleBinDir = __DIR__.'/../../../../../../../node_modules/.bin';
+$eslint = realpath("{$moduleBinDir}/eslint");
+
+if (!$eslint) {
+    echo "Cannot found eslint (looked in {$moduleBinDir}) \n";
+    exit(1);
+}
+
+// collect all files which have been added, copied or
+// modified and store them in an array called output
+exec('git diff --cached --name-status --diff-filter=ACM', $files);
+
+foreach ($files as $file) {
+    $fileName = trim(substr($file, 1));
+
+    if (preg_match('#Resources/modules/.+\.js$#', $fileName)) {
+        exec("{$eslint} {$fileName}", $output, $code);
+
+        if ($code !== 0) {
+            echo implode("\n", $output)."\n";
+            exit(1);
+        }
+    }
+}

--- a/main/dev/Resources/hooks/pre-commit-md
+++ b/main/dev/Resources/hooks/pre-commit-md
@@ -1,0 +1,31 @@
+#!/usr/bin/php
+<?php
+
+/**
+ * This pre-commit hook checks for MD errors.
+ */
+
+$binDir = __DIR__.'/../../../../../../bin';
+$md = realpath("{$binDir}/md");
+
+if (!$md) {
+    echo "Cannot found md (looked in {$binDir}) \n";
+    exit(1);
+}
+
+// collect all files which have been added, copied or
+// modified and store them in an array called output
+exec('git diff --cached --name-status --diff-filter=ACM', $files);
+
+foreach ($files as $file) {
+    $fileName = trim(substr($file, 1));
+
+    if (pathinfo($fileName, PATHINFO_EXTENSION) === 'php') {
+        exec("{$md} {$fileName}", $output, $code);
+
+        if ($code !== 0) {
+            echo implode("\n", $output)."\n";
+            exit(1);
+        }
+    }
+}

--- a/main/dev/Resources/hooks/pre-commit-phpcs
+++ b/main/dev/Resources/hooks/pre-commit-phpcs
@@ -1,0 +1,38 @@
+#!/usr/bin/php
+<?php
+
+/**
+ * This pre-commit hook checks for PHP-CS-fixer errors.
+ *
+ * @authors Mardix  http://github.com/mardix, Donovan Tengblad http://github.com/purplefish32
+ * @since   Sept 4 2012
+ */
+
+$binDir = __DIR__.'/../../../../../../bin';
+$csFixer = realpath("{$binDir}/php-cs-fixer");
+
+if (!$csFixer) {
+    echo "Cannot found php-cs-fixer (looked in {$binDir}) \n";
+    exit(1);
+}
+
+// collect all files which have been added, copied or
+// modified and store them in an array called output
+exec('git diff --cached --name-status --diff-filter=ACM', $files);
+
+foreach ($files as $file) {
+    $fileName = trim(substr($file, 1));
+
+    if (pathinfo($fileName, PATHINFO_EXTENSION) === 'php') {
+        // check there's no syntax errors
+        exec('php -l '.escapeshellarg($fileName), $output, $return);
+
+        if ($return === 0) {
+            // fix file and add it back
+            exec("php-cs-fixer fix {$fileName} --level=symfony --fixers=ordered_use,short_array_syntax; git add {$fileName}");
+        } else {
+           echo implode("\n", $output)."\n";
+           exit(1);
+        }
+    }
+}

--- a/main/dev/Resources/hooks/pre-commit-phpmd
+++ b/main/dev/Resources/hooks/pre-commit-phpmd
@@ -1,0 +1,31 @@
+#!/usr/bin/php
+<?php
+
+/**
+ * This pre-commit hook checks for PHPMD errors.
+ */
+
+$binDir = __DIR__.'/../../../../../../bin';
+$phpmd = realpath("{$binDir}/phpmd");
+
+if (!$phpmd) {
+    echo "Cannot found php-cs-fixer (looked in {$binDir}) \n";
+    exit(1);
+}
+
+// collect all files which have been added, copied or
+// modified and store them in an array called output
+exec('git diff --cached --name-status --diff-filter=ACM', $files);
+
+foreach ($files as $file) {
+    $fileName = trim(substr($file, 1));
+
+    if (pathinfo($fileName, PATHINFO_EXTENSION) === 'php') {
+        exec("{$phpmd} {$fileName} text phpmd.xml", $output, $code);
+
+        if ($code !== 0) {
+            echo implode("\n", $output)."\n";
+            exit(1);
+        }
+    }
+}


### PR DESCRIPTION
Depend on #735.

Reuse files from http://github.com/claroline/git-hooks and add/modify hooks to cover current constraints:
- php-cs-fixer
- phpmd
- md
- eslint

Hooks can be enabled by a simple symlink:

```
cd .git/hooks
ln -s ../../main/dev/Resources/hooks/pre-commit
```

**NOTE**: currently hooks won't be triggered with the `--amend` option

cc @claroline/commiters 