### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "doctrine/orm": "~2.4",
         "friendsofsymfony/jsrouting-bundle": "~1.5",
         "friendsofsymfony/oauth-server-bundle": "~1.4",
-        "friendsofsymfony/rest-bundle": "~1.4",
+        "friendsofsymfony/rest-bundle": "1.7.9",
         "gedmo/doctrine-extensions": "~2.3",
         "gregwar/captcha-bundle": "1.0.12",
         "guzzle/http": "~3.1",


### PR DESCRIPTION
rest-bundle 1.8.0 doesn't work with jms serializer (it crashed everything for me, probably because the jms serializer version wasn't the correct one anymore).

This is the easy fix.