### PR TITLE
[ExoBundle] Fix question sharing and categories management

### DIFF
--- a/plugin/exo/Controller/InteractionGraphicController.php
+++ b/plugin/exo/Controller/InteractionGraphicController.php
@@ -227,9 +227,14 @@ class InteractionGraphicController extends Controller
         );
 
         $formHandler = new InteractionGraphicHandler(
-            $editForm, $this->get('request'), $this->getDoctrine()->getManager(),
-            $this->container->get('ujm.exo_exercise'), $this->container->get('ujm.exo_category'),
-            $this->container->get('security.token_storage')->getToken()->getUser(), -1,
+            $editForm,
+            $this->get('request'),
+            $this->getDoctrine()->getManager(),
+            $this->container->get('ujm.exo_exercise'),
+            $this->container->get('ujm.exo_category'),
+            $this->container->get('security.token_storage')->getToken()->getUser(),
+            -1,
+            -1,
             $this->get('translator')
         );
 

--- a/plugin/exo/Controller/InteractionHoleController.php
+++ b/plugin/exo/Controller/InteractionHoleController.php
@@ -205,15 +205,20 @@ class InteractionHoleController extends Controller
         }
 
         $editForm = $this->createForm(
-                new InteractionHoleType(
+            new InteractionHoleType(
                 $this->container->get('security.token_storage')->getToken()->getUser(), $catID
-                ), $interHole
+            ), $interHole
         );
         $formHandler = new InteractionHoleHandler(
-                $editForm, $this->get('request'), $this->getDoctrine()->getManager(),
-                $this->container->get('ujm.exo_exercise'), $this->container->get('ujm.exo_category'),
-                $this->container->get('security.token_storage')->getToken()->getUser(),
-                $exoID, $this->get('translator')
+            $editForm,
+            $this->get('request'),
+            $this->getDoctrine()->getManager(),
+            $this->container->get('ujm.exo_exercise'),
+            $this->container->get('ujm.exo_category'),
+            $this->container->get('security.token_storage')->getToken()->getUser(),
+            -1,
+            -1,
+            $this->get('translator')
         );
 
         $formHandler->setValidator($this->get('validator'));

--- a/plugin/exo/Controller/InteractionMatchingController.php
+++ b/plugin/exo/Controller/InteractionMatchingController.php
@@ -249,9 +249,14 @@ class InteractionMatchingController extends Controller
             ), $interMatching
         );
         $formHandler = new InteractionMatchingHandler(
-            $editForm, $this->get('request'), $this->getDoctrine()->getManager(),
-            $this->container->get('ujm.exo_exercise'), $this->container->get('ujm.exo_category'),
-            $this->container->get('security.token_storage')->getToken()->getUser(), -1,
+            $editForm,
+            $this->get('request'),
+            $this->getDoctrine()->getManager(),
+            $this->container->get('ujm.exo_exercise'),
+            $this->container->get('ujm.exo_category'),
+            $this->container->get('security.token_storage')->getToken()->getUser(),
+            -1,
+            -1,
             $this->get('translator')
         );
 

--- a/plugin/exo/Controller/InteractionOpenController.php
+++ b/plugin/exo/Controller/InteractionOpenController.php
@@ -222,9 +222,14 @@ class InteractionOpenController extends Controller
         );
 
         $formHandler = new InteractionOpenHandler(
-            $editForm, $this->get('request'), $this->getDoctrine()->getManager(),
-            $this->container->get('ujm.exo_exercise'), $this->container->get('ujm.exo_category'),
-            $this->container->get('security.token_storage')->getToken()->getUser(), -1,
+            $editForm,
+            $this->get('request'),
+            $this->getDoctrine()->getManager(),
+            $this->container->get('ujm.exo_exercise'),
+            $this->container->get('ujm.exo_category'),
+            $this->container->get('security.token_storage')->getToken()->getUser(),
+            -1,
+            -1,
             $this->get('translator')
         );
 

--- a/plugin/exo/Controller/InteractionQCMController.php
+++ b/plugin/exo/Controller/InteractionQCMController.php
@@ -226,9 +226,14 @@ class InteractionQCMController extends Controller
             ), $interQCM
         );
         $formHandler = new InteractionQCMHandler(
-            $editForm, $this->get('request'), $this->getDoctrine()->getManager(),
-            $this->container->get('ujm.exo_exercise'), $this->container->get('ujm.exo_category'),
-            $this->container->get('security.token_storage')->getToken()->getUser(), -1,
+            $editForm,
+            $this->get('request'),
+            $this->getDoctrine()->getManager(),
+            $this->container->get('ujm.exo_exercise'),
+            $this->container->get('ujm.exo_category'),
+            $this->container->get('security.token_storage')->getToken()->getUser(),
+            -1,
+            -1,
             $this->get('translator')
         );
 

--- a/plugin/exo/Entity/Question.php
+++ b/plugin/exo/Entity/Question.php
@@ -290,7 +290,7 @@ class Question
     /**
      * @param Category $category
      */
-    public function setCategory(Category $category)
+    public function setCategory(Category $category = null)
     {
         $this->category = $category;
     }

--- a/plugin/exo/Form/InteractionGraphicHandler.php
+++ b/plugin/exo/Form/InteractionGraphicHandler.php
@@ -100,6 +100,9 @@ class InteractionGraphicHandler extends QuestionHandler
         if ($this->request->getMethod() == 'POST') {
             $this->form->handleRequest($this->request);
 
+            // Uses the default category if no category selected
+            $this->checkCategory();
+
             if ($this->form->isValid()) {
                 $this->onSuccessUpdate($this->form->getData(), $originalHints);
 

--- a/plugin/exo/Form/InteractionGraphicHandler.php
+++ b/plugin/exo/Form/InteractionGraphicHandler.php
@@ -15,7 +15,7 @@ class InteractionGraphicHandler extends QuestionHandler
             $this->form->handleRequest($this->request);
             $data = $this->form->getData();
             //Uses the default category if no category selected
-            $this->checkCategory($data);
+            $this->checkCategory();
             //If title null, uses the first 50 characters of "invite" (enuncicate)
             $this->checkTitle();
             if ($this->validateNbClone() === false) {

--- a/plugin/exo/Form/InteractionHoleHandler.php
+++ b/plugin/exo/Form/InteractionHoleHandler.php
@@ -108,6 +108,9 @@ class InteractionHoleHandler extends QuestionHandler
         if ($this->request->getMethod() == 'POST') {
             $this->form->handleRequest($this->request);
 
+            // Uses the default category if no category selected
+            $this->checkCategory();
+
             if ($this->form->isValid()) {
                 foreach ($this->form->getData()->getHoles() as $h) {
                     foreach ($h->getWordResponses() as $wr) {

--- a/plugin/exo/Form/InteractionMatchingHandler.php
+++ b/plugin/exo/Form/InteractionMatchingHandler.php
@@ -106,6 +106,9 @@ class InteractionMatchingHandler extends QuestionHandler
         if ($this->request->getMethod()  == 'POST') {
             $this->form->handleRequest($this->request);
 
+            // Uses the default category if no category selected
+            $this->checkCategory();
+
             if ($this->form->isValid()) {
                 $this->onSuccessUpdate($this->form->getData(), $originalLabel, $originalProposal, $originalHints);
 

--- a/plugin/exo/Form/InteractionOpenHandler.php
+++ b/plugin/exo/Form/InteractionOpenHandler.php
@@ -79,6 +79,9 @@ class InteractionOpenHandler extends QuestionHandler
         if ($this->request->getMethod() == 'POST') {
             $this->form->handleRequest($this->request);
 
+            // Uses the default category if no category selected
+            $this->checkCategory();
+
             if ($this->form->isValid()) {
                 $this->onSuccessUpdate($this->form->getData(), $originalWrs, $originalHints);
 

--- a/plugin/exo/Form/InteractionQCMHandler.php
+++ b/plugin/exo/Form/InteractionQCMHandler.php
@@ -91,6 +91,9 @@ class InteractionQCMHandler extends QuestionHandler
         if ($this->request->getMethod() == 'POST') {
             $this->form->handleRequest($this->request);
 
+            // Uses the default category if no category selected
+            $this->checkCategory();
+
             if ($this->form->isValid()) {
                 $this->onSuccessUpdate($this->form->getData(), $originalChoices, $originalHints);
 

--- a/plugin/exo/Form/QuestionHandler.php
+++ b/plugin/exo/Form/QuestionHandler.php
@@ -8,6 +8,8 @@ use Doctrine\ORM\EntityManager;
 use UJM\ExoBundle\Entity\Category;
 use Symfony\Component\Translation\TranslatorInterface;
 use Claroline\CoreBundle\Entity\User;
+use UJM\ExoBundle\Services\classes\CategoryService;
+use UJM\ExoBundle\Services\classes\ExerciseServices;
 
 abstract class QuestionHandler
 {
@@ -18,6 +20,7 @@ abstract class QuestionHandler
     protected $catServ;
     protected $user;
     protected $exercise;
+    protected $step;
     protected $isClone = false;
     protected $translator;
 
@@ -25,17 +28,26 @@ abstract class QuestionHandler
      * Constructor.
      *
      *
-     * @param \Symfony\Component\Form\Form                     $form     for an Interaction
+     * @param \Symfony\Component\Form\Form                     $form       for an Interaction
      * @param \Symfony\Component\HttpFoundation\Request        $request
      * @param Doctrine EntityManager                           $em
      * @param \UJM\ExoBundle\Services\classes\exerciseServices $exoServ
      * @param \UJM\ExoBundle\Services\classes\CategoryService  $catServ
      * @param \Claroline\CoreBundle\Entity\User                $user
-     * @param UJM\ExoBundle\Entity\Exercise                    $exercise instance of Exercise if the Interaction is created or modified since an exercise if since the bank $exercise=-1
-     * @param UJM\ExoBundle\Entity\Step
-     * @param Translation $translator
+     * @param \UJM\ExoBundle\Entity\Exercise                   $exercise   instance of Exercise if the Interaction is created or modified since an exercise if since the bank $exercise=-1
+     * @param \UJM\ExoBundle\Entity\Step                       $step
+     * @param TranslatorInterface                              $translator
      */
-    public function __construct(Form $form = null, Request $request = null, EntityManager $em, $exoServ, $catServ, User $user, $exercise = -1, $step = -1, TranslatorInterface $translator = null)
+    public function __construct(
+        Form $form = null,
+        Request $request = null,
+        EntityManager $em,
+        ExerciseServices $exoServ,
+        CategoryService $catServ,
+        User $user,
+        $exercise = -1,
+        $step = -1,
+        TranslatorInterface $translator = null)
     {
         $this->form = $form;
         $this->request = $request;

--- a/plugin/exo/Resources/config/services.yml
+++ b/plugin/exo/Resources/config/services.yml
@@ -36,7 +36,7 @@ services:
 
     ujm.exo_category:
         class: UJM\ExoBundle\Services\classes\CategoryService
-        arguments: [@doctrine, @security.token_storage]
+        arguments: [@doctrine, @security.token_storage, @translator]
         
     ujm.exo_docimology:
         class: UJM\ExoBundle\Services\classes\Docimology

--- a/plugin/exo/Resources/views/Question/search.html.twig
+++ b/plugin/exo/Resources/views/Question/search.html.twig
@@ -42,8 +42,7 @@
                         <td class="classic">{{ user.firstName }}</td>
                         <td class="classic"><input id="allowToEditQ_{{ user.id }}" type="checkbox" /></td>
                         <td class="classic">
-                            <a class="btn btn-default" href="#" onclick="shareQuestionUser('{{ path('ujm_question_shareQuestionUser') }}','{{ user.id }}'
-                            ,'{{ 'already' | trans({}, 'ujm_exo') }} ...','{{ 'self' | trans({}, 'ujm_exo') }} ...');"><i class="fa fa-share"></i>
+                            <a class="btn btn-default" href="#" onclick="shareQuestionUser('{{ path('ujm_question_shareQuestionUser') }}',{{ user.id }});"><i class="fa fa-share"></i>
                             </a>
                         </td>
                     </tr>
@@ -67,7 +66,7 @@
 
 <script type="text/javascript" src="{{ asset('bundles/ujmexo/js/sortAndSearch.js') }}"></script>
 <script type="text/javascript">
-    function shareQuestionUser(path, uid, already, Self){
+    function shareQuestionUser(path, uid){
         var allowToModify = 0;
         var qId = document.getElementById('QID').innerHTML;
 
@@ -90,9 +89,9 @@
                 var action = data.substr(data.indexOf(';')+1);
 
                 if (alreadyShared == 'yes') {
-                    alert(already);
+                    alert("{{ 'already' | trans({}, 'ujm_exo') }}");
                 } else if (alreadyShared == 'self') {
-                    alert(Self);
+                    alert("{{ 'self' | trans({}, 'ujm_exo') }}");
                 } else {
                     window.location.href = action;
                 }

--- a/plugin/exo/Services/classes/CategoryService.php
+++ b/plugin/exo/Services/classes/CategoryService.php
@@ -6,22 +6,24 @@
 
 namespace UJM\ExoBundle\Services\classes;
 
+use Claroline\CoreBundle\Entity\User;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Translation\TranslatorInterface;
+use UJM\ExoBundle\Entity\Category;
 
 class CategoryService
 {
     private $doctrine;
     private $tokenStorage;
+    private $translator;
 
     /**
      * Constructor.
      *
-     *
      * @param \Doctrine\Bundle\DoctrineBundle\Registry                                            $doctrine     Dependency Injection;
      * @param \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface $tokenStorage Dependency Injection
-     * @param \Symfony\Component\Translation\TranslatorInterface
+     * @param \Symfony\Component\Translation\TranslatorInterface                                  $translator
      */
     public function __construct(
             Registry $doctrine,
@@ -91,19 +93,40 @@ class CategoryService
      */
     public function ctrlCategory($question)
     {
-        $em = $this->doctrine->getManager();
-        $user = $this->tokenStorage->getToken()->getUser()->getId();
+        $user = $this->tokenStorage->getToken()->getUser();
         $category = $question->getCategory();
-        $ownerCategory = $category->getUser()->getId();
+        if ($category->getUser()->getId() !== $user->getId()) {
+            $userDefaultCategory = $this->doctrine->getManager()->getRepository('UJMExoBundle:Category')->findOneBy([
+                'user' => $user,
+                'locker' => true,
+            ]);
 
-        if ($ownerCategory != $user) {
-            $userDefaultCategory = $em->getRepository('UJMExoBundle:Category')
-                    ->findOneBy(array('user' => $user, 'locker' => true));
             if (!$userDefaultCategory) {
-                $default = $this->translator->trans('default', array(), 'ujm_exo');
-                $userDefaultCategory = $this->createCategoryDefault($default);
+                $default = $this->translator->trans('default', [], 'ujm_exo');
+                $userDefaultCategory = $this->createCategoryDefault($default, $user);
             }
+
             $question->setCategory($userDefaultCategory);
         }
+    }
+
+    /**
+     * Create the default category for the user.
+     *
+     * @param string $default name of default's category
+     * @param User   $user
+     *
+     * @return \UJM\ExoBundle\Entity\Category
+     */
+    private function createCategoryDefault($default, User $user)
+    {
+        $newCategory = new Category();
+        $newCategory->setValue($default);
+        $newCategory->setLocker(1);
+        $newCategory->setUser($user);
+        $this->doctrine->getManager()->persist($newCategory);
+        $this->doctrine->getManager()->flush();
+
+        return $newCategory;
     }
 }

--- a/plugin/exo/Services/classes/CategoryService.php
+++ b/plugin/exo/Services/classes/CategoryService.php
@@ -8,6 +8,7 @@ namespace UJM\ExoBundle\Services\classes;
 
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class CategoryService
 {
@@ -20,13 +21,16 @@ class CategoryService
      *
      * @param \Doctrine\Bundle\DoctrineBundle\Registry                                            $doctrine     Dependency Injection;
      * @param \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface $tokenStorage Dependency Injection
+     * @param \Symfony\Component\Translation\TranslatorInterface
      */
     public function __construct(
             Registry $doctrine,
-            TokenStorageInterface $tokenStorage
+            TokenStorageInterface $tokenStorage,
+            TranslatorInterface $translator
     ) {
         $this->doctrine = $doctrine;
         $this->tokenStorage = $tokenStorage;
+        $this->translator = $translator;
     }
 
     /**


### PR DESCRIPTION
This PR fixes the saring feature of the Bank which was buggy in the last version.
It also fixes the #737. 

I've just made the existing code work, but the feature seems a little weird to me : 

The categories are specific to a User. 
If you edit a question which have been shared with you it loads the list of your categories.
So the previous category doesn't exist (that's the origin of the original bug). 
In this case, the implementation replaces the original category by a default one linked to the current User.

The weird part is it overrides the original categorization made by the User who have shared the question.

As we will need to rewrite the Bank in Angular for the 16.09, I have kept it but IMHO we will need to rethink this part.