### PR TITLE
Exo question add fields

### DIFF
--- a/plugin/exo/Entity/ObjectQuestion.php
+++ b/plugin/exo/Entity/ObjectQuestion.php
@@ -21,7 +21,7 @@ class ObjectQuestion
 
     /**
      * @ORM\Id
-     * @ORM\ManyToOne(targetEntity="UJM\ExoBundle\Entity\Question")
+     * @ORM\ManyToOne(targetEntity="UJM\ExoBundle\Entity\Question", inversedBy="objects")
      * @ORM\JoinColumn(onDelete="CASCADE")
      */
     private $question;
@@ -31,7 +31,7 @@ class ObjectQuestion
      *
      * @ORM\Column(name="ordre", type="integer")
      */
-    private $ordre;
+    private $order;
 
     /**
      * @ORM\Column(type="text", nullable=true)
@@ -61,7 +61,7 @@ class ObjectQuestion
         return $this->exercise;
     }
 
-    public function setQuestion(Question $question)
+    public function setQuestion(Question $question = null)
     {
         $this->question = $question;
     }
@@ -74,11 +74,11 @@ class ObjectQuestion
     /**
      * Set ordre.
      *
-     * @param int $ordre
+     * @param int $order
      */
-    public function setOrdre($ordre)
+    public function setOrdre($order)
     {
-        $this->ordre = $ordre;
+        $this->order = $order;
     }
 
     /**
@@ -88,7 +88,7 @@ class ObjectQuestion
      */
     public function getOrdre()
     {
-        return $this->ordre;
+        return $this->order;
     }
 
     /**
@@ -121,5 +121,21 @@ class ObjectQuestion
     public function getType()
     {
         return $this->type;
+    }
+
+    /**
+     * @return ResourceNode
+     */
+    public function getResourceNode()
+    {
+        return $this->resourceNode;
+    }
+
+    /**
+     * @param ResourceNode $resourceNode
+     */
+    public function setResourceNode(ResourceNode $resourceNode)
+    {
+        $this->resourceNode = $resourceNode;
     }
 }

--- a/plugin/exo/Entity/ObjectQuestion.php
+++ b/plugin/exo/Entity/ObjectQuestion.php
@@ -3,6 +3,7 @@
 namespace UJM\ExoBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Claroline\CoreBundle\Entity\Resource\ResourceNode;
 
 /**
  * UJM\ExoBundle\Entity\ObjectQuestion.

--- a/plugin/exo/Entity/ObjectQuestion.php
+++ b/plugin/exo/Entity/ObjectQuestion.php
@@ -2,8 +2,8 @@
 
 namespace UJM\ExoBundle\Entity;
 
-use Doctrine\ORM\Mapping as ORM;
 use Claroline\CoreBundle\Entity\Resource\ResourceNode;
+use Doctrine\ORM\Mapping as ORM;
 
 /**
  * UJM\ExoBundle\Entity\ObjectQuestion.

--- a/plugin/exo/Entity/Question.php
+++ b/plugin/exo/Entity/Question.php
@@ -96,7 +96,12 @@ class Question
     private $hints;
 
     /**
-     * Note: used for joins only.
+     * @ORM\OneToMany(targetEntity="ObjectQuestion", mappedBy="question", orphanRemoval=true)
+     */
+    private $objects;
+    
+    /**
+     * Note: used for joins only., orphanRemoval=true
      *
      * @ORM\OneToMany(targetEntity="StepQuestion", mappedBy="question")
      */
@@ -105,6 +110,7 @@ class Question
     public function __construct()
     {
         $this->hints = new ArrayCollection();
+        $this->objects = new ArrayCollection();
         $this->stepQuestions = new ArrayCollection();
         $this->dateCreate = new \DateTime();
     }
@@ -119,7 +125,7 @@ class Question
         $this->type = $type;
     }
 
-    /**
+    /**, orphanRemoval=true
      * @return string
      */
     public function getType()
@@ -183,6 +189,27 @@ class Question
         return $this->invite;
     }
 
+    public function getObjects()
+    {
+        return $this->objects;
+    }
+    
+    public function addObject(ObjectQuestion $object)
+    {
+        if (!$this->objects->contains($object)) {
+            $this->objects->add($object);
+            $object->setQuestion($this);
+        }
+    }
+    
+    public function removeObject(ObjectQuestion $object)
+    {
+        if ($this->objects->contains($object)) {
+            $this->objects->removeElement($object);
+            $object->setQuestion(null);
+        }
+    }
+    
     /**
      * @param string $feedback
      */

--- a/plugin/exo/Entity/Question.php
+++ b/plugin/exo/Entity/Question.php
@@ -125,7 +125,7 @@ class Question
         $this->type = $type;
     }
 
-    /**, orphanRemoval=true
+    /**
      * @return string
      */
     public function getType()

--- a/plugin/exo/Entity/Question.php
+++ b/plugin/exo/Entity/Question.php
@@ -193,7 +193,7 @@ class Question
     {
         return $this->objects;
     }
-    
+
     public function addObject(ObjectQuestion $object)
     {
         if (!$this->objects->contains($object)) {
@@ -201,7 +201,7 @@ class Question
             $object->setQuestion($this);
         }
     }
-    
+
     public function removeObject(ObjectQuestion $object)
     {
         if ($this->objects->contains($object)) {
@@ -209,7 +209,7 @@ class Question
             $object->setQuestion(null);
         }
     }
-    
+
     /**
      * @param string $feedback
      */

--- a/plugin/exo/Entity/Question.php
+++ b/plugin/exo/Entity/Question.php
@@ -99,9 +99,9 @@ class Question
      * @ORM\OneToMany(targetEntity="ObjectQuestion", mappedBy="question", orphanRemoval=true)
      */
     private $objects;
-    
+
     /**
-     * Note: used for joins only., orphanRemoval=true
+     * Note: used for joins only., orphanRemoval=true.
      *
      * @ORM\OneToMany(targetEntity="StepQuestion", mappedBy="question")
      */

--- a/plugin/exo/Manager/QuestionManager.php
+++ b/plugin/exo/Manager/QuestionManager.php
@@ -110,6 +110,8 @@ class QuestionManager
         $data->title = $question->getTitle();
         $data->description = $question->getDescription();
         $data->invite = $question->getInvite();
+        $data->supplementary = $question->getSupplementary();
+        $data->specification = $question->getSpecification();
         $data->objects = array_map(function ($object) use ($rm) {
             $resourceObjectData = new \stdClass();
             $resourceObjectData->id = (string) $object->getResourceNode()->getId();

--- a/plugin/exo/Manager/QuestionManager.php
+++ b/plugin/exo/Manager/QuestionManager.php
@@ -119,13 +119,13 @@ class QuestionManager
             $resourceObjectData->name = $object->getResourceNode()->getName();
             $resourceObjectData->path = $object->getResourceNode()->getPathForDisplay();
             switch ($object->getResourceNode()->getMimeType()) {
-                case "custom/hevinci_url":
+                case 'custom/hevinci_url':
                     $resourceObjectData->resourceUrl = $rm->getResourceFromNode($object->getResourceNode())->getUrl();
                     break;
                 default:
                     $resourceObjectData->resourceUrl = $rm->getResourceFromNode($object->getResourceNode())->getHashName();
             }
-            
+
             return $resourceObjectData;
         }, $question->getObjects()->toArray());
 

--- a/plugin/exo/Manager/QuestionManager.php
+++ b/plugin/exo/Manager/QuestionManager.php
@@ -2,10 +2,10 @@
 
 namespace UJM\ExoBundle\Manager;
 
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Claroline\CoreBundle\Manager\ResourceManager;
 use Doctrine\Common\Persistence\ObjectManager;
 use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use UJM\ExoBundle\Entity\Exercise;
 use UJM\ExoBundle\Entity\Hint;
 use UJM\ExoBundle\Entity\Paper;
@@ -130,7 +130,7 @@ class QuestionManager
                 default:
                     $resourceObjectData->url = $this->router->generate(
                         'claro_resource_open',
-                        array('resourceType' => $object->getResourceNode()->getResourceType()->getName(), 'node' => $object->getResourceNode()->getId())
+                        ['resourceType' => $object->getResourceNode()->getResourceType()->getName(), 'node' => $object->getResourceNode()->getId()]
                     );
             }
 

--- a/plugin/exo/Resources/modules/question/Partials/show.html
+++ b/plugin/exo/Resources/modules/question/Partials/show.html
@@ -100,6 +100,16 @@
                     data-include-correction="questionShowCtrl.includeCorrection">
             </graphic-question>
         </div>
+        
+        <div class="question-info" data-ng-if="questionShowCtrl.question.specification">
+            <h5>{{ 'question_specification'|trans:{}:'ujm_sequence' }}</h5>
+            <div>{{ questionShowCtrl.question.specification }}</div>
+        </div>
+        
+        <div class="question-info" data-ng-if="questionShowCtrl.question.supplementary">
+            <h5>{{ 'question_supplementary'|trans:{}:'ujm_sequence' }}</h5>
+            <div>{{ questionShowCtrl.question.supplementary }}</div>
+        </div>
 
         <!-- Display solution of the Question -->
         <div class="correction-container" data-ng-if="questionShowCtrl.includeCorrection && questionShowCtrl.question.solutions && questionShowCtrl.question.solutions.length > 0">

--- a/plugin/exo/Resources/modules/question/Partials/show.html
+++ b/plugin/exo/Resources/modules/question/Partials/show.html
@@ -47,7 +47,10 @@
         </div>
         <div class="question-info" data-ng-if="questionShowCtrl.question.objects.length > 0">
             <h5>{{ 'question_object'|trans:{}:'ujm_sequence' }}</h5>
-            <div data-ng-repeat="object in questionShowCtrl.question.objects">{{ object.resourceUrl }}</div>
+            <div data-ng-repeat="object in questionShowCtrl.question.objects">
+                <iframe src="{{ object.url }}"></iframe>
+                <span data-ng-if="object.type === 'text'">{{ object.data }}</span>
+            </div>
         </div>
 
         <!-- Display specificity of the Question -->

--- a/plugin/exo/Resources/modules/question/Partials/show.html
+++ b/plugin/exo/Resources/modules/question/Partials/show.html
@@ -45,6 +45,10 @@
             <!-- Description of the Question -->
             <div data-ng-bind="questionShowCtrl.question.description"></div>
         </div>
+        <div class="question-info" data-ng-if="questionShowCtrl.question.objects.length > 0">
+            <h5>{{ 'question_object'|trans:{}:'ujm_sequence' }}</h5>
+            <div data-ng-repeat="object in questionShowCtrl.question.objects">{{ object.resourceUrl }}</div>
+        </div>
 
         <!-- Display specificity of the Question -->
         <h5 data-ng-if="questionShowCtrl.includeCorrection && ((questionShowCtrl.question.solutions && questionShowCtrl.question.solutions.length > 0) || questionShowCtrl.question.stats)">

--- a/plugin/exo/Resources/translations/ujm_sequence.en.yml
+++ b/plugin/exo/Resources/translations/ujm_sequence.en.yml
@@ -92,6 +92,8 @@ question_hints: Hints
 question_hint_label: Hint
 question_hint_show_title: Show hint
 question_object: Object of the question
+question_specification: Consigne pédagogique
+question_supplementary: Information complémentaire
 question_show_hint_confirm: Are you sure you want to see this hint ? <br/> This will give you a penalty of %1% points.
 
 # s

--- a/plugin/exo/Resources/translations/ujm_sequence.en.yml
+++ b/plugin/exo/Resources/translations/ujm_sequence.en.yml
@@ -92,8 +92,8 @@ question_hints: Hints
 question_hint_label: Hint
 question_hint_show_title: Show hint
 question_object: Object of the question
-question_specification: Consigne pédagogique
-question_supplementary: Information complémentaire
+question_specification: Specification
+question_supplementary: Supplementary information
 question_show_hint_confirm: Are you sure you want to see this hint ? <br/> This will give you a penalty of %1% points.
 
 # s

--- a/plugin/exo/Resources/translations/ujm_sequence.en.yml
+++ b/plugin/exo/Resources/translations/ujm_sequence.en.yml
@@ -91,6 +91,7 @@ points: Points
 question_hints: Hints
 question_hint_label: Hint
 question_hint_show_title: Show hint
+question_object: Object of the question
 question_show_hint_confirm: Are you sure you want to see this hint ? <br/> This will give you a penalty of %1% points.
 
 # s

--- a/plugin/exo/Resources/translations/ujm_sequence.fr.yml
+++ b/plugin/exo/Resources/translations/ujm_sequence.fr.yml
@@ -92,6 +92,7 @@ points: Points
 question_hints: Indices
 question_hint_label: Indice
 question_hint_show_title: Voir l'indice
+question_object: Objet de la question
 question_show_hint_confirm: Êtes vous sûr de vouloir utiliser l'indice ? <br/> Cela entrainera une pénalité de %1% points.
 
 # s

--- a/plugin/exo/Resources/translations/ujm_sequence.fr.yml
+++ b/plugin/exo/Resources/translations/ujm_sequence.fr.yml
@@ -93,6 +93,8 @@ question_hints: Indices
 question_hint_label: Indice
 question_hint_show_title: Voir l'indice
 question_object: Objet de la question
+question_specification: Specification
+question_supplementary: Supplementary information
 question_show_hint_confirm: Êtes vous sûr de vouloir utiliser l'indice ? <br/> Cela entrainera une pénalité de %1% points.
 
 # s

--- a/plugin/exo/Resources/translations/ujm_sequence.fr.yml
+++ b/plugin/exo/Resources/translations/ujm_sequence.fr.yml
@@ -93,8 +93,8 @@ question_hints: Indices
 question_hint_label: Indice
 question_hint_show_title: Voir l'indice
 question_object: Objet de la question
-question_specification: Specification
-question_supplementary: Supplementary information
+question_specification: Consigne pédagogique
+question_supplementary: Information complémentaire
 question_show_hint_confirm: Êtes vous sûr de vouloir utiliser l'indice ? <br/> Cela entrainera une pénalité de %1% points.
 
 # s


### PR DESCRIPTION
This adds some fields we used in V5 at innovalangues.

The fields are set as follow:
- Functional instruction is set on the "description" field.
- Object of the question uses the ObjectQuestion entity, refering to a question and a resourceNode.
- Pedagogic instruction is set on the "specification" field.
- Complementary information is set on the "supplementary" field.

This PR doesn't update the editor in order to fill these fields, it only allows to show existing data in the player.