### PR TITLE
Allow jquery and jquery-ui to be required through imports

### DIFF
--- a/main/core/Resources/modules/jquery/index.js
+++ b/main/core/Resources/modules/jquery/index.js
@@ -1,0 +1,11 @@
+/**
+ * This module simply makes the global jQuery instance (injected via a script
+ * tag for compatibily reasons) available to other modules. It is aliased in the
+ * webpack config so that importing "jquery" will amount to importing this
+ * module.
+ *
+ * Obviously this is temporary and should go as soon as a global jQuery instance
+ * isn't necessary anymore (i.e. when it's only required via module imports).
+ */
+
+export default window.$

--- a/main/core/Resources/scripts/lib/webpack.js
+++ b/main/core/Resources/scripts/lib/webpack.js
@@ -60,13 +60,17 @@ function configure(rootDir, packages, isWatchMode) {
 
   const loaders = [
     makeJsLoader(isProd),
-    makeRawLoader()
+    makeRawLoader(),
+    makeJqueryUiLoader()
   ]
 
   return {
     entry: entries,
     output: output,
-    resolve: { root: root },
+    resolve: {
+      root: root,
+      alias: { jquery: __dirname + '/../../modules/jquery' }
+    },
     plugins: plugins,
     module: { loaders: loaders },
     devServer: {
@@ -263,6 +267,20 @@ function makeRawLoader() {
   return {
     test: /\.html$/,
     loader: 'raw'
+  }
+}
+
+/**
+ * This loader disables AMD for jQuery UI modules. The reason is that these
+ * modules try to load jQuery via AMD first but get a version of jQuery which
+ * isn't the one made globally available, causing several issues. This loader
+ * could probably be removed when jQuery is required only through module
+ * imports.
+ */
+function makeJqueryUiLoader() {
+  return {
+    test: /jquery-ui/,
+    loader: 'imports?define=>false'
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cssnano": "^3.4.0",
     "eslint": "^2.13.1",
     "filesystem-bower-resolver": "^1.2.0",
+    "imports-loader": "^0.6.5",
     "less": "^2.5.3",
     "mocha": "^2.4.5",
     "postcss-cli": "^2.5.0",


### PR DESCRIPTION
Related to #734. Ideally when writing js modules, we should require everything needed through imports statements. However, we are currently stuck with a global instance of jquery injected via a script tag. Rather than allowing the use of this implicit global, this PR makes it available through the module system, so that:
- modules that consume jquery are correctly written even if jquery is not really managed by webpack
- when we're ready to remove the script tag or if we find a better config, nothing must be changed in the modules themselves
- eslint is happy

The PR also allows jquery ui modules to be loaded correctly.

**TLDR**:

```js
import $ from 'jquery'
import 'jquery-ui/ui/draggable'
import 'jquery-ui/ui/droppable'

$('#foo').draggable()
$('.bar').droppable()
```