### PR TITLE
[PathBundle] Fixes for resource iframe in PathBundle

### DIFF
--- a/main/core/Resources/views/Workspace/layout.html.twig
+++ b/main/core/Resources/views/Workspace/layout.html.twig
@@ -120,7 +120,7 @@
 
             setInterval(function() {
                 var newHeight = getIframeWindowHeight();
-                
+    
                 if (newHeight !== null && newHeight !== oldHeight) {
                     postHeight(newHeight);
                     oldHeight = newHeight;

--- a/main/core/Resources/views/Workspace/layout.html.twig
+++ b/main/core/Resources/views/Workspace/layout.html.twig
@@ -121,10 +121,8 @@
             setInterval(function() {
                 var newHeight = getIframeWindowHeight();
 
-                if (newHeight =! null) {
-                    if (newHeight != oldHeight) {
-                        postHeight(newHeight);
-                    }
+                if (newHeight !== null && newHeight !== oldHeight) {
+                    postHeight(newHeight);
                     oldHeight = newHeight;
                 }
 

--- a/main/core/Resources/views/Workspace/layout.html.twig
+++ b/main/core/Resources/views/Workspace/layout.html.twig
@@ -120,7 +120,7 @@
 
             setInterval(function() {
                 var newHeight = getIframeWindowHeight();
-
+                
                 if (newHeight !== null && newHeight !== oldHeight) {
                     postHeight(newHeight);
                     oldHeight = newHeight;

--- a/main/core/Resources/views/Workspace/layout.html.twig
+++ b/main/core/Resources/views/Workspace/layout.html.twig
@@ -120,10 +120,14 @@
 
             setInterval(function() {
                 var newHeight = getIframeWindowHeight();
-                if (newHeight != oldHeight) {
-                    postHeight(newHeight);
+
+                if (newHeight =! null) {
+                    if (newHeight != oldHeight) {
+                        postHeight(newHeight);
+                    }
+                    oldHeight = newHeight;
                 }
-                oldHeight = newHeight;
+
             }, 2000);
             /* End of Hack */
 


### PR DESCRIPTION
- In some cases, the iframe content height can't be determined at the right time (with SCORM, for example). The loop will now ignore this situation.
- In some cases, an empty iframe (with no resource attached) occupies space on screen anyway. It is now hidden if empty.