### PR TITLE
[CoreBundle] Fixing rich text parsing if node has no workspace.

### DIFF
--- a/main/core/Library/Transfert/ConfigurationBuilders/Tools/ResourceManagerImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/Tools/ResourceManagerImporter.php
@@ -11,22 +11,22 @@
 
 namespace Claroline\CoreBundle\Library\Transfert\ConfigurationBuilders\Tools;
 
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-use JMS\DiExtraBundle\Annotation as DI;
-use Symfony\Component\Config\Definition\Processor;
-use Claroline\CoreBundle\Library\Transfert\Importer;
-use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
-use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
-use Claroline\CoreBundle\Manager\RightsManager;
-use Claroline\CoreBundle\Manager\ResourceManager;
-use Claroline\CoreBundle\Manager\RoleManager;
-use Claroline\CoreBundle\Manager\MaskManager;
-use Claroline\CoreBundle\Persistence\ObjectManager;
 use Claroline\CoreBundle\Entity\Resource\Directory;
 use Claroline\CoreBundle\Entity\Resource\ResourceNode;
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Entity\Role;
+use Claroline\CoreBundle\Entity\Workspace\Workspace;
+use Claroline\CoreBundle\Library\Transfert\Importer;
+use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
+use Claroline\CoreBundle\Manager\MaskManager;
+use Claroline\CoreBundle\Manager\ResourceManager;
+use Claroline\CoreBundle\Manager\RightsManager;
+use Claroline\CoreBundle\Manager\RoleManager;
+use Claroline\CoreBundle\Persistence\ObjectManager;
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\File\File;
 
@@ -123,7 +123,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
          * The implementation will change later (if we need to change the perms of
          * ROLE_USER and ROLE_ANONYMOUS) but it's easier to code it that way.
          */
-        $createdResources = array();
+        $createdResources = [];
 
         if ($fullImport) {
             $directories[$data['data']['root']['uid']] = $root;
@@ -168,7 +168,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                     $workspace,
                     null,
                     $icon,
-                    array(),
+                    [],
                     $isDirectoryPublished
                 );
 
@@ -204,13 +204,13 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
         /* RESOURCES */
         /*************/
 
-        $created = array();
+        $created = [];
 
         if (isset($data['data']['items'])) {
             $this->log('Importing resources...');
             foreach ($data['data']['items'] as $item) {
                 //THIS IS WHERE RES COME FROM !
-                $res = array();
+                $res = [];
                 if (isset($item['item']['data'])) {
                     $res['data'] = $item['item']['data'];
                 }
@@ -254,7 +254,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                             $workspace,
                             null,
                             $icon,
-                            array(),
+                            [],
                             $isPublished
                         );
 
@@ -310,10 +310,10 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
         //first we get the root
         $root = $this->resourceManager->getWorkspaceRoot($workspace);
         $rootRights = $root->getRights();
-        $_data['root'] = array(
+        $_data['root'] = [
             'uid' => $root->getId(),
             'roles' => $this->getPermsArray($root),
-        );
+        ];
         $directory = $this->resourceManager->getResourceTypeByName('directory');
         $resourceNodes = $this->resourceManager->getByWorkspaceAndResourceType($workspace, $directory);
 
@@ -341,7 +341,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
 
     public function exportResources(Workspace $workspace, array $resourceNodes, array &$_files)
     {
-        $_data = array();
+        $_data = [];
 
         foreach ($resourceNodes as $resourceNode) {
             $resourceTypeName = $resourceNode->getResourceType()->getName();
@@ -469,7 +469,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                                                         function ($v) use ($availableRoleName) {
                                                             return call_user_func_array(
                                                                 __CLASS__.'::roleNameExists',
-                                                                array($v, $availableRoleName)
+                                                                [$v, $availableRoleName]
                                                             );
                                                         }
                                                     )
@@ -498,7 +498,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                                                 function ($v) use ($rootPath) {
                                                     return call_user_func_array(
                                                         __CLASS__.'::fileNotExists',
-                                                        array($v, $rootPath)
+                                                        [$v, $rootPath]
                                                     );
                                                 }
                                             )
@@ -511,7 +511,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                                                 function ($v) use ($availableCreators) {
                                                     return call_user_func_array(
                                                         __CLASS__.'::creatorExists',
-                                                        array($v, $availableCreators)
+                                                        [$v, $availableCreators]
                                                     );
                                                 }
                                             )
@@ -525,7 +525,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                                                 function ($v) use ($availableParents) {
                                                     return call_user_func_array(
                                                         __CLASS__.'::parentExists',
-                                                        array($v, $availableParents)
+                                                        [$v, $availableParents]
                                                     );
                                                 }
                                             )
@@ -544,7 +544,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                                                                     function ($v) use ($availableRoleName) {
                                                                         return call_user_func_array(
                                                                             __CLASS__.'::roleNameExists',
-                                                                            array($v, $availableRoleName)
+                                                                            [$v, $availableRoleName]
                                                                         );
                                                                     }
                                                                 )
@@ -577,7 +577,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                                                 function ($v) use ($rootPath) {
                                                     return call_user_func_array(
                                                         __CLASS__.'::fileNotExists',
-                                                        array($v, $rootPath)
+                                                        [$v, $rootPath]
                                                     );
                                                 }
                                             )
@@ -590,7 +590,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                                             function ($v) use ($availableParents) {
                                                 return call_user_func_array(
                                                     __CLASS__.'::parentExists',
-                                                    array($v, $availableParents)
+                                                    [$v, $availableParents]
                                                 );
                                             }
                                         )
@@ -618,7 +618,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                                                                     function ($v) use ($availableRoleName) {
                                                                         return call_user_func_array(
                                                                             __CLASS__.'::roleNameExists',
-                                                                            array($v, $availableRoleName)
+                                                                            [$v, $availableRoleName]
                                                                         );
                                                                     }
                                                                 )
@@ -670,7 +670,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
 
     private function getCreationRightsArray($rights)
     {
-        $creations = array();
+        $creations = [];
 
         if ($rights !== null) {
             foreach ($rights as $el) {
@@ -696,14 +696,14 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                 //creation rights are missing here but w/e
                 $name = $this->roleManager->getWorkspaceRoleBaseName($right->getRole());
 
-                $data = array(
+                $data = [
                     'name' => $name,
                     'rights' => $perms,
-                );
+                ];
 
                 //don't keep the role manager
                 if (!strpos('_'.$name, 'ROLE_WS_MANAGER')) {
-                    $roles[] = array('role' => $data);
+                    $roles[] = ['role' => $data];
                 }
             }
         }
@@ -715,7 +715,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
     {
         $creations = (isset($role['role']['rights']['create'])) ?
             $this->getCreationRightsArray($role['role']['rights']['create']) :
-            array();
+            [];
 
         $uow = $this->om->getUnitOfWork();
         $map = $uow->getIdentityMap();
@@ -780,7 +780,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
             $parentId = null;
         }
 
-        $resElement = array('directory' => array(
+        $resElement = ['directory' => [
             'name' => $resourceNode->getName(),
             'creator' => null,
             'parent' => $parentId,
@@ -788,7 +788,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
             'uid' => $resourceNode->getId(),
             'roles' => $this->getPermsArray($resourceNode),
             'index' => $resourceNode->getIndex(),
-        ));
+        ]];
 
         if ($icon = $this->getIcon($resourceNode, $_files)) {
             $resElement['directory']['icon'] = $icon;
@@ -799,23 +799,23 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
 
     public function getResourceElement(
         ResourceNode $resourceNode,
-        Workspace $workspace,
-        &$_files,
-        &$_data,
+        $workspace = null,
+        &$_files = [],
+        &$_data = [],
         $setParentNull = false
     ) {
         $parentId = $resourceNode->getParent() ? $resourceNode->getParent()->getId() : null;
         $resourceNode = $this->resourceManager->getRealTarget($resourceNode, false);
 
-        $data = array();
-        $resElement = array();
+        $data = [];
+        $resElement = [];
 
         $resource = $this->resourceManager->getResourceFromNode($resourceNode);
 
         if ($resource) {
             // We are not processing an orphan Node so we can run the export of the Resource
             $importer = $this->getImporterByName($resourceNode->getResourceType()->getName());
-            if ($importer) {
+            if ($importer && $workspace) {
                 $importer->setExtendedData($_data);
                 $data = $importer->export(
                     $workspace,
@@ -829,7 +829,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                 $parentId = null;
             }
 
-            $resElement = array('item' => array(
+            $resElement = ['item' => [
                 'name' => $resourceNode->getName(),
                 'creator' => null,
                 'parent' => $parentId,
@@ -838,7 +838,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                 'roles' => $this->getPermsArray($resourceNode),
                 'uid' => $resourceNode->getId(),
                 'data' => $data,
-            ));
+            ]];
 
             if ($icon = $this->getIcon($resourceNode, $_files)) {
                 $resElement['item']['icon'] = $icon;


### PR DESCRIPTION
This should fix #877 

Method `getResourceElement`was changed.