### PR TITLE
[CoreBundle] Can't use already used email as a username.

### DIFF
--- a/main/core/Entity/User.php
+++ b/main/core/Entity/User.php
@@ -11,23 +11,23 @@
 
 namespace Claroline\CoreBundle\Entity;
 
-use Serializable;
-use Symfony\Component\Security\Core\User\AdvancedUserInterface;
-use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Security\Core\User\EquatableInterface;
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Bridge\Doctrine\Validator\Constraints as DoctrineAssert;
-use Doctrine\ORM\Mapping as ORM;
-use Doctrine\Common\Collections\ArrayCollection;
-use Claroline\CoreBundle\Entity\Organization\Organization;
-use Claroline\CoreBundle\Entity\Model\WorkspaceModel;
-use Claroline\CoreBundle\Validator\Constraints as ClaroAssert;
-use Gedmo\Mapping\Annotation as Gedmo;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\Validator\ExecutionContextInterface;
 use Claroline\CoreBundle\Entity\Facet\FieldFacetValue;
+use Claroline\CoreBundle\Entity\Model\WorkspaceModel;
+use Claroline\CoreBundle\Entity\Organization\Organization;
+use Claroline\CoreBundle\Validator\Constraints as ClaroAssert;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+use Gedmo\Mapping\Annotation as Gedmo;
 use JMS\Serializer\Annotation\Groups;
 use JMS\Serializer\Annotation\SerializedName;
+use Serializable;
+use Symfony\Bridge\Doctrine\Validator\Constraints as DoctrineAssert;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Security\Core\User\AdvancedUserInterface;
+use Symfony\Component\Security\Core\User\EquatableInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\ExecutionContextInterface;
 
 /**
  * @ORM\Table(name="claro_user")
@@ -611,7 +611,7 @@ class User extends AbstractRoleSubject implements Serializable, AdvancedUserInte
      */
     public function getEntityRoles($areGroupsIncluded = true)
     {
-        $roles = array();
+        $roles = [];
         if ($this->roles) {
             $roles = $this->roles->toArray();
         }
@@ -724,11 +724,11 @@ class User extends AbstractRoleSubject implements Serializable, AdvancedUserInte
     public function serialize()
     {
         return serialize(
-            array(
+            [
                 'id' => $this->id,
                 'username' => $this->username,
                 'roles' => $this->getRoles(),
-            )
+            ]
         );
     }
 
@@ -840,7 +840,7 @@ class User extends AbstractRoleSubject implements Serializable, AdvancedUserInte
     public function setPlatformRoles($platformRoles)
     {
         $roles = $this->getEntityRoles();
-        $removedRoles = array();
+        $removedRoles = [];
 
         foreach ($roles as $role) {
             if ($role->getType() != Role::WS_ROLE) {
@@ -924,7 +924,7 @@ class User extends AbstractRoleSubject implements Serializable, AdvancedUserInte
 
     public function getOrderableFields()
     {
-        return array('id', 'username', 'lastName', 'firstName', 'mail');
+        return ['id', 'username', 'lastName', 'firstName', 'mail'];
     }
 
     public function isAccountNonExpired()
@@ -1025,7 +1025,7 @@ class User extends AbstractRoleSubject implements Serializable, AdvancedUserInte
     {
         // Search for whitespaces
         if (preg_match("/\s/", $this->getPublicUrl())) {
-            $context->addViolationAt('publicUrl', 'public_profile_url_not_valid', array(), null);
+            $context->addViolationAt('publicUrl', 'public_profile_url_not_valid', [], null);
         }
     }
 
@@ -1083,7 +1083,7 @@ class User extends AbstractRoleSubject implements Serializable, AdvancedUserInte
 
     public static function getEditableProperties()
     {
-        return array(
+        return [
             'username' => false,
             'firstName' => false,
             'lastName' => false,
@@ -1092,7 +1092,7 @@ class User extends AbstractRoleSubject implements Serializable, AdvancedUserInte
             'phone' => true,
             'picture' => true,
             'description' => true,
-        );
+        ];
     }
 
     public function getOptions()
@@ -1178,13 +1178,13 @@ class User extends AbstractRoleSubject implements Serializable, AdvancedUserInte
 
     public static function getUserSearchableFields()
     {
-        return array(
+        return [
             'firstName',
             'lastName',
             'mail',
             'administrativeCode',
             'username',
-        );
+        ];
     }
 
     public static function getSearchableFields()

--- a/main/core/Resources/translations/platform.en.yml
+++ b/main/core/Resources/translations/platform.en.yml
@@ -1062,6 +1062,7 @@ user_removed: 'User %user% removed'
 user_selector: 'User picker'
 user_visit: 'Audience/user visits'
 username: Username
+username_already_used: 'Username %username% is already used'
 username_and_email_from_two_different_users: 'Username %username% and email %email% are both in use and don''t refer to the same user.'
 username_found_at: 'The username %username% was found at lines: %lines%'
 username_or_email: 'Username or email'

--- a/main/core/Resources/translations/platform.fr.yml
+++ b/main/core/Resources/translations/platform.fr.yml
@@ -1061,6 +1061,7 @@ user_public_profile_not_visible: 'Votre profil public n''est visible par personn
 user_selector: 'Sélecteur d''utilisateurs'
 user_visit: 'Audience/Visites utilisateurs'
 username: 'Identifiant'
+username_already_used: 'L''identifiant %username% est déjà utilisé'
 username_and_email_from_two_different_users: 'Le nom d''utilisateur %username% et le courriel %email% sont tous deux utilisés et n''appartiennent pas au même utilisateur.'
 username_found_at: 'Le nom d''utilisateur %username% a été trouvé aux lignes: %lines%'
 username_or_email: 'Nom d''utilisateur ou courriel'

--- a/main/core/Validator/Constraints/CsvUserValidator.php
+++ b/main/core/Validator/Constraints/CsvUserValidator.php
@@ -12,11 +12,11 @@
 namespace Claroline\CoreBundle\Validator\Constraints;
 
 use Claroline\CoreBundle\Entity\User;
-use Claroline\CoreBundle\Manager\AuthenticationManager;
-use Claroline\CoreBundle\Manager\UserManager;
-use Claroline\CoreBundle\Manager\GroupManager;
-use Claroline\CoreBundle\Persistence\ObjectManager;
 use Claroline\CoreBundle\Library\Utilities\ClaroUtilities;
+use Claroline\CoreBundle\Manager\AuthenticationManager;
+use Claroline\CoreBundle\Manager\GroupManager;
+use Claroline\CoreBundle\Manager\UserManager;
+use Claroline\CoreBundle\Persistence\ObjectManager;
 use Doctrine\ORM\NonUniqueResultException;
 use JMS\DiExtraBundle\Annotation as DI;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -84,8 +84,8 @@ class CsvUserValidator extends ConstraintValidator
             }
         }
 
-        $usernames = array();
-        $mails = array();
+        $usernames = [];
+        $mails = [];
 
         if ($mode === 1) {
             $currentDate = new \DateTime();
@@ -138,10 +138,10 @@ class CsvUserValidator extends ConstraintValidator
                 }
 
                 (!array_key_exists($email, $mails)) ?
-                    $mails[$email] = array($i + 1) :
+                    $mails[$email] = [$i + 1] :
                     $mails[$email][] = $i + 1;
                 (!array_key_exists($username, $usernames)) ?
-                    $usernames[$username] = array($i + 1) :
+                    $usernames[$username] = [$i + 1] :
                     $usernames[$username][] = $i + 1;
 
                 $existingUser = null;
@@ -155,15 +155,15 @@ class CsvUserValidator extends ConstraintValidator
                     } catch (NonUniqueResultException $e) {
                         $msg = $this->translator->trans(
                             'line_number',
-                            array('%line%' => $i + 1),
+                            ['%line%' => $i + 1],
                             'platform'
                         );
                         $msg .= ' '.$this->translator->trans(
                             'username_and_email_from_two_different_users',
-                            array(
+                            [
                                 '%username%' => $username,
                                 '%email%' => $email,
-                            ),
+                            ],
                             'platform'
                         );
                         $this->context->addViolation($msg);
@@ -197,7 +197,7 @@ class CsvUserValidator extends ConstraintValidator
                     $existingUser->setPhone($phone);
                     $errors = $this->validator->validate(
                         $existingUser,
-                        array('registration', 'Default')
+                        ['registration', 'Default']
                     );
                     $existingUser->setUsername($username);
                     $existingUser->setMail($email);
@@ -210,14 +210,14 @@ class CsvUserValidator extends ConstraintValidator
                     $newUser->setMail($email);
                     $newUser->setAdministrativeCode($code);
                     $newUser->setPhone($phone);
-                    $errors = $this->validator->validate($newUser, array('registration', 'Default'));
+                    $errors = $this->validator->validate($newUser, ['registration', 'Default']);
                 }
 
                 if ($authentication) {
                     if (!in_array($authentication, $authDrivers)) {
                         $msg = $this->translator->trans(
                             'authentication_invalid',
-                            array('%authentication%' => $authentication, '%line%' => $i + 1),
+                            ['%authentication%' => $authentication, '%line%' => $i + 1],
                             'platform'
                         ).' ';
 
@@ -227,7 +227,7 @@ class CsvUserValidator extends ConstraintValidator
 
                 foreach ($errors as $error) {
                     $this->context->addViolation(
-                        $this->translator->trans('line_number', array('%line%' => $i + 1), 'platform').' '.
+                        $this->translator->trans('line_number', ['%line%' => $i + 1], 'platform').' '.
                         $error->getInvalidValue().' : '.$error->getMessage()
                     );
                 }
@@ -240,7 +240,7 @@ class CsvUserValidator extends ConstraintValidator
             if (!$model) {
                 $msg = $this->translator->trans(
                     'model_invalid',
-                    array('%model%' => $modelName, '%line%' => $i + 1),
+                    ['%model%' => $modelName, '%line%' => $i + 1],
                     'platform'
                 ).' ';
                 $this->context->addViolation($msg);
@@ -252,13 +252,13 @@ class CsvUserValidator extends ConstraintValidator
             $isValid = false;
 
             if ($group) {
-                $isValid = $this->groupManager->validateAddUsersToGroup(array($user), $group);
+                $isValid = $this->groupManager->validateAddUsersToGroup([$user], $group);
             }
 
             if (!$isValid) {
                 $msg = $this->translator->trans(
                     'group_invalid',
-                    array('%group%' => $groupName, '%line%' => $i + 1),
+                    ['%group%' => $groupName, '%line%' => $i + 1],
                     'platform'
                 ).' ';
                 $this->context->addViolation($msg);
@@ -269,7 +269,7 @@ class CsvUserValidator extends ConstraintValidator
             if (count($lines) > 1) {
                 $msg = $this->translator->trans(
                     'username_found_at',
-                    array('%username%' => $username, '%lines%' => $this->getLines($lines)),
+                    ['%username%' => $username, '%lines%' => $this->getLines($lines)],
                     'platform'
                 ).' ';
                 $this->context->addViolation($msg);
@@ -280,7 +280,7 @@ class CsvUserValidator extends ConstraintValidator
             if (count($lines) > 1) {
                 $msg = $this->translator->trans(
                     'email_found_at',
-                    array('%email%' => $mail, '%lines%' => $this->getLines($lines)),
+                    ['%email%' => $mail, '%lines%' => $this->getLines($lines)],
                     'platform'
                 ).' ';
                 $this->context->addViolation($msg);


### PR DESCRIPTION
Only the translation files and the UsernameValidator were changed. Others are checkstyles.

Fix #873 