### PR TITLE
[CoreBundle] AssetPath updated (uses the config domain name)

### DIFF
--- a/main/core/Resources/views/layout.html.twig
+++ b/main/core/Resources/views/layout.html.twig
@@ -40,7 +40,6 @@
     {% set homeAsset = protocol ~ '://' ~ host ~ app.request.getBasePath() ~ '/' %}
 
     <div id="homeAsset" class="hide">{{ homeAsset }}</div>
-    <div id="homeAsset" class="hide">{{ app.request.getSchemeAndHttpHost() ~ app.request.getBasePath() ~ '/' }}</div>
     <div id="baseAsset" class="hide">{{ asset('') }}</div>
     <div id="homeLocale" class="hide">{% spaceless %}
             {% if asset_exists("bundles/stfalcontinymce/vendor/tinymce/langs/" ~ app.request.locale ~ ".js") %}

--- a/main/core/Resources/views/layout.html.twig
+++ b/main/core/Resources/views/layout.html.twig
@@ -25,6 +25,21 @@
 {% block layout %}
     <div id="sf-environement" data-env="{{ app.environment }}" class="hide"></div>
     <div id="homePath" class="hide">{{ path("claro_index") }}</div>
+    {% if app.request.isSecure() %}
+        {% set protocol = 'http' %}
+    {% else %}
+        {% set protocol = 'https' %}
+    {% endif %}
+
+    {% if config.getParameter('domain_name') %}
+        {% set host = config.getParameter('domain_name') %}
+    {% else %}
+        {% set host = app.request.headers.get('host') %}
+    {% endif %}
+
+    {% set homeAsset = protocol ~ '://' ~ host ~ app.request.getBasePath() ~ '/' %}
+
+    <div id="homeAsset" class="hide">{{ homeAsset }}</div>
     <div id="homeAsset" class="hide">{{ app.request.getSchemeAndHttpHost() ~ app.request.getBasePath() ~ '/' }}</div>
     <div id="baseAsset" class="hide">{{ asset('') }}</div>
     <div id="homeLocale" class="hide">{% spaceless %}


### PR DESCRIPTION
Certaines configurations de serveur empêchent symfony2 de récupérer le nom de domaine facilement (si des proxy sont utilisés).

Ici on bypass symfony en allant récupérer le nom de domaine depuis la config s'il existe (et comme ça, plus de problème).