### PR TITLE
[CoreBundle] event soft delete

### DIFF
--- a/main/core/Manager/ResourceManager.php
+++ b/main/core/Manager/ResourceManager.php
@@ -929,12 +929,11 @@ class ResourceManager
         $count = count($nodes);
         $nodes[] = $resourceNode;
         $softDelete = $this->platformConfigHandler->getParameter('resource_soft_delete');
-        $eventSoftDelete = false;
-
         $this->om->startFlushSuite();
         $this->log('Looping through '.$count.' children...');
 
         foreach ($nodes as $node) {
+            $eventSoftDelete = false;
             $this->log('Removing '.$node->getName().'['.$node->getResourceType()->getName().':id:'.$node->getId().']');
             $resource = $this->getResourceFromNode($node);
             /*

--- a/main/core/Manager/ResourceManager.php
+++ b/main/core/Manager/ResourceManager.php
@@ -929,6 +929,7 @@ class ResourceManager
         $count = count($nodes);
         $nodes[] = $resourceNode;
         $softDelete = $this->platformConfigHandler->getParameter('resource_soft_delete');
+        $eventSoftDelete = false;
 
         $this->om->startFlushSuite();
         $this->log('Looping through '.$count.' children...');
@@ -948,6 +949,8 @@ class ResourceManager
                         [$resource]
                     );
 
+                    $eventSoftDelete = $event->isSoftDelete();
+                    
                     foreach ($event->getFiles() as $file) {
                         if ($softDelete) {
                             $parts = explode(
@@ -1005,7 +1008,7 @@ class ResourceManager
                 // Delete all associated shortcuts
                 $this->deleteAssociatedShortcuts($node);
 
-                if ($softDelete || $event->isSoftDelete()) {
+                if ($softDelete || $eventSoftDelete) {
                     $node->setActive(false);
                     $this->om->persist($node);
                 } else {

--- a/main/core/Manager/ResourceManager.php
+++ b/main/core/Manager/ResourceManager.php
@@ -949,7 +949,7 @@ class ResourceManager
                     );
 
                     $eventSoftDelete = $event->isSoftDelete();
-                    
+
                     foreach ($event->getFiles() as $file) {
                         if ($softDelete) {
                             $parts = explode(


### PR DESCRIPTION
$event isn't always defined so this is the monkey patch.

Maybe the $node->setActive() block should be in the `if ($node->getClass() !== 'Claroline\CoreBundle\Entity\Resource\ResourceShortcut') {`condition. I don't know.