### PR TITLE
[PathBundle] manages deleted resources + add id in structure

### DIFF
--- a/plugin/path/Installation/AdditionalInstaller.php
+++ b/plugin/path/Installation/AdditionalInstaller.php
@@ -37,9 +37,15 @@ class AdditionalInstaller extends BaseInstaller
         }
 
         if (version_compare($currentVersion, '5.1.0', '<') && version_compare($targetVersion, '5.1.0', '>=')) {
-            $updater010209 = new Updater\Updater050100($this->container);
-            $updater010209->setLogger($this->logger);
-            $updater010209->postUpdate();
+            $updater050100 = new Updater\Updater050100($this->container);
+            $updater050100->setLogger($this->logger);
+            $updater050100->postUpdate();
+        }
+
+        if (version_compare($currentVersion, '7.1.0', '<')) {
+            $updater080000 = new Updater\Updater070100($this->container);
+            $updater080000->setLogger($this->logger);
+            $updater080000->postUpdate();
         }
 
         return $this;

--- a/plugin/path/Installation/Updater/Updater070100.php
+++ b/plugin/path/Installation/Updater/Updater070100.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Innova\PathBundle\Installation\Updater;
+
+use Claroline\InstallationBundle\Updater\Updater;
+use Innova\PathBundle\Entity\Path\Path;
+
+/**
+ * Inject the ID of the Path into the JSON structure
+ * This is not needed for the published ones as the structure is created from the real data.
+ */
+class Updater070100 extends Updater
+{
+    private $container;
+
+    public function __construct($container)
+    {
+        $this->container = $container;
+    }
+
+    public function postUpdate()
+    {
+        $om = $this->container->get('claroline.persistence.object_manager');
+
+        $toPublishPaths = $om->getRepository('InnovaPathBundle:Path\Path')->findPlatformPaths(true);
+
+        /** @var Path $path */
+        foreach ($toPublishPaths as $path) {
+            $structure = json_decode($path->getStructure());
+            if (empty($structure->id)) {
+                $structure->id = $path->getId();
+                $path->setStructure(json_encode($structure));
+
+                $om->persist($path);
+            }
+        }
+
+        $om->flush();
+    }
+}


### PR DESCRIPTION
This PR attempts to fix 2 bugs in Path : 
- The last version of the Angular UI get the ID of the path from the JSON structure, but for old path this property was not set.
- The copy didn't check if the resources (primary & secondary) exist, so if one is deleted there is an error. Now, the deleted resource is deleted in the structure of the copy.