### PR TITLE
[CoreBundle] resource copy less string

### DIFF
--- a/main/core/Manager/ResourceManager.php
+++ b/main/core/Manager/ResourceManager.php
@@ -788,6 +788,7 @@ class ResourceManager
     ) {
         $this->log("Copying {$node->getName()} from type {$node->getResourceType()->getName()}");
         $resource = $this->getResourceFromNode($node);
+        $env = $this->container->get('kernel')->getEnvironment();
 
         if ($resource instanceof ResourceShortcut) {
             $copy = $this->om->factory('Claroline\CoreBundle\Entity\Resource\ResourceShortcut');
@@ -796,11 +797,14 @@ class ResourceManager
             $copy->setResourceNode($newNode);
         } else {
             if (!$resource) {
-                $message = 'The resource '.$node->getName().' was not found';
-                $this->container
-                    ->get('logger')
-                    ->error($message);
-                throw new ResourceNotFoundException($message);
+                if ($env === 'dev') {
+                    $message = 'The resource '.$node->getName().' was not found (node id is '.$node->getId().')';
+                    $this->container->get('logger')->error($message);
+                    throw new ResourceNotFoundException($message);
+                } else {
+                    //if something is malformed in production, try to not break everything if we don't need to. Just retun null.
+                    return;
+                }
             }
 
             $event = $this->dispatcher->dispatch(


### PR DESCRIPTION
In production, copying a broken resource will just do nothing and return null with this fix.

I had an issue where a document from a dropzone/collecticiel wasn't removed properly and broke the workspace creation through a model (but copying the directory containing the resource would have the same issue).