### PR TITLE
[ResourceManager] fixes non standard style for unpublished resource 

### DIFF
--- a/main/core/Resources/less/layout.less
+++ b/main/core/Resources/less/layout.less
@@ -776,7 +776,7 @@ ul.desktop-parameters-menu
             margin: 5px 0 5px 15%;
             cursor: pointer;
             &.unpublished {
-                opacity: 0.4;
+                opacity: 0.5;
             }
         }
 

--- a/main/core/Resources/less/layout.less
+++ b/main/core/Resources/less/layout.less
@@ -776,13 +776,7 @@ ul.desktop-parameters-menu
             margin: 5px 0 5px 15%;
             cursor: pointer;
             &.unpublished {
-                -webkit-filter: grayscale(100%);
-                -moz-filter: grayscale(100%);
-                -ms-filter: grayscale(100%);
-                -o-filter: grayscale(100%);
-                filter: grayscale(100%);
-                filter: url(grayscale.svg); /* Firefox 4+ */
-                filter: gray; /* IE 6-9 */
+                opacity: 0.4;
             }
         }
 


### PR DESCRIPTION
The property `filter` is not supported in many browser.
It has been replaced by `opacity: 0.4`.

The value can be discussed.