### PR TITLE
[PathBundle] fixes save button always disabled after publish

### DIFF
--- a/plugin/path/Resources/modules/path/Controller/PathEditCtrl.js
+++ b/plugin/path/Resources/modules/path/Controller/PathEditCtrl.js
@@ -41,9 +41,7 @@ export default class PathEditCtrl extends PathBaseCtrl {
 
       if (!empty && updated) {
         // Initialization is already done, so mark path as unsaved for each modification
-        if (this.published !== true) {
-          this.unsaved = true
-        }
+        this.unsaved = true
       }
     }, true)
   }


### PR DESCRIPTION
If you modify a path after publishing it, the save button was never enabled.