### PR TITLE
[CoreBundle] replaces webpack img loader by url loader

### DIFF
--- a/main/core/Resources/scripts/lib/webpack.js
+++ b/main/core/Resources/scripts/lib/webpack.js
@@ -66,7 +66,7 @@ function configure(rootDir, packages, isWatchMode) {
     makeRawLoader(),
     makeJqueryUiLoader(),
     makeCssLoader(),
-    makeFileLoader()
+    makeUrlLoader()
   ]
 
   return {
@@ -279,13 +279,10 @@ function makeCssLoader() {
   }
 }
 
-function makeFileLoader() {
+function makeUrlLoader() {
   return {
-    test: /\.(jpe?g|png|gif|svg)$/i,
-    loaders: [
-      'file?hash=sha512&digest=hex&name=[hash].[ext]',
-      'image-webpack?bypassOnDebug&optimizationLevel=7&interlaced=false'
-    ]
+    test: /\.(jpe?g|png|gif|svg)$/,
+    loader: 'url?limit=25000'
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "webpack": "^1.12.13",
     "webpack-dev-server": "^1.14.1",
     "webpack-fail-plugin": "^1.0.4",
-    "image-webpack-loader": "^2.0.0"
+    "url-loader": "^0.5.7"
   },
   "scripts": {
     "test": "mocha Resources/scripts/test"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

The image loader only copies the original into the `dist` directory and return an URL to this file.
The url loader includes the image directly into the JS file (base64 encoded based on what I've seen). This is more convenient.



