### PR TITLE
[ExoBundle] Fix score computation when no solutions are given

### DIFF
--- a/plugin/exo/Resources/modules/question/Services/Type/GraphicQuestionService.js
+++ b/plugin/exo/Resources/modules/question/Services/Type/GraphicQuestionService.js
@@ -82,8 +82,10 @@ GraphicQuestionService.prototype.getAreaStats = function getAreaStats(question, 
 GraphicQuestionService.prototype.getTotalScore = function (question) {
   let total = 0
 
-  for (let i = 0; i < question.solutions.length; i++) {
-    total += question.solutions[i].score
+  if (question.solutions) {
+    for (let i = 0; i < question.solutions.length; i++) {
+      total += question.solutions[i].score
+    }
   }
 
   return total
@@ -107,7 +109,7 @@ GraphicQuestionService.prototype.getAnswerScore = function (question, answer) {
 GraphicQuestionService.prototype.getFoundSolutions = function (question, answer) {
   let found = []
 
-  if (answer && 0 !== answer.length) {
+  if (answer && 0 !== answer.length && question.solutions) {
     for (let i = 0; i < question.solutions.length; i++) {
       for (let j = 0; j < answer.length; j++) {
         let areaFound = this.ImageAreaService.isInArea(question.solutions[i], answer[j])

--- a/plugin/exo/Resources/modules/question/Services/Type/MatchQuestionService.js
+++ b/plugin/exo/Resources/modules/question/Services/Type/MatchQuestionService.js
@@ -139,8 +139,10 @@ MatchQuestionService.prototype.initDragMatchQuestion = function initDragMatchQue
 MatchQuestionService.prototype.getTotalScore = function (question) {
   let total = 0
 
-  for (let i = 0; i < question.solutions.length; i++) {
-    total += question.solutions[i].score
+  if (question.solutions) {
+    for (let i = 0; i < question.solutions.length; i++) {
+      total += question.solutions[i].score
+    }
   }
 
   return total
@@ -163,7 +165,7 @@ MatchQuestionService.prototype.getAnswerScore = function (question, answer) {
 
 MatchQuestionService.prototype.getFoundSolutions = function (question, answer) {
   const found = []
-  if (answer) {
+  if (answer && question.solutions) {
     for (var j = 0; j < question.solutions.length; j++) {
       for (var i = 0; i < answer.length; i++) {
         let parts = answer[i].split(',')

--- a/plugin/exo/Resources/modules/question/Services/Type/OpenQuestionService.js
+++ b/plugin/exo/Resources/modules/question/Services/Type/OpenQuestionService.js
@@ -93,27 +93,32 @@ OpenQuestionService.prototype.getTotalScore = function (question) {
   let total = 0
 
   switch (question.typeOpen) {
-  case 'long': {
-    total = question.score.success
-    break
-  }
-  case 'oneWord': {
-    let maxScore = 0
-    for (let i = 0; i < question.solutions.length; i++) {
-      if (question.solutions[i].score > maxScore) {
-        maxScore = question.solutions[i].score
+    case 'long': {
+      total = question.score.success
+      break
+    }
+    case 'oneWord': {
+      let maxScore = 0
+
+      if (question.solutions) {
+        for (let i = 0; i < question.solutions.length; i++) {
+          if (question.solutions[i].score > maxScore) {
+            maxScore = question.solutions[i].score
+          }
+        }
       }
+
+      total = maxScore
+      break
     }
-  
-    total = maxScore
-    break
-  }
-  case 'short': {
-    for (let i = 0; i < question.solutions.length; i++) {
-      total += question.solutions[i].score
+    case 'short': {
+      if (question.solutions) {
+        for (let i = 0; i < question.solutions.length; i++) {
+          total += question.solutions[i].score
+        }
+      }
+      break
     }
-    break
-  }
   }
 
   return total


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

<!-- please add a description here if needed -->

Some parts of the code currently assume that a `solution` property is always present on `question` objects, leading to "xyz is not defined" errors and eventually breaking whole exercises. 

