### PR TITLE
[FormulaBundle] Exclude non element nodes from inspection

### DIFF
--- a/plugin/formula/Resources/views/Formula/plugin.js.html.twig
+++ b/plugin/formula/Resources/views/Formula/plugin.js.html.twig
@@ -64,7 +64,9 @@
                 onPostRender: function () {
                     var _this = this;   // reference to the button itself
                     editor.on('NodeChange', function (e) {
-                        _this.active(e.element.className.indexOf('fm-editor-equation') > -1 && e.element.nodeName.toLowerCase() == "img");
+                        if (e.element.nodeType === Node.ELEMENT_NODE) {
+                            _this.active(e.element.className.indexOf('fm-editor-equation') > -1 && e.element.nodeName.toLowerCase() == "img");
+                        }
                     })
                 }
             });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

<!-- please add a description here if needed -->

It seems that the `NodeChange` event triggered at initialization time is also applied to comment nodes, leading to an "undefined" error on `className` access when the original html value contains comments.
