### PR TITLE
Fixed check for ROLE_ADMIN

### DIFF
--- a/main/core/Manager/UserManager.php
+++ b/main/core/Manager/UserManager.php
@@ -1379,9 +1379,8 @@ class UserManager
     private function generateRoleRestrictions(User $user)
     {
         $restrictions = [];
-        $adminRole = $this->roleManager->getRoleByUserAndRoleName($user, 'ROLE_ADMIN');
 
-        if (is_null($adminRole)) {
+        if (!$user->hasRole('ROLE_ADMIN')) {
             $wsRoles = $this->roleManager->getWorkspaceRolesByUser($user);
 
             foreach ($wsRoles as $wsRole) {
@@ -1412,9 +1411,8 @@ class UserManager
     private function generateGroupRestrictions(User $user)
     {
         $restrictions = [];
-        $adminRole = $this->roleManager->getRoleByUserAndRoleName($user, 'ROLE_ADMIN');
 
-        if (is_null($adminRole)) {
+        if (!$user->hasRole('ROLE_ADMIN')) {
             $restrictions = $user->getGroups()->toArray();
         }
 
@@ -1424,9 +1422,8 @@ class UserManager
     private function generateWorkspaceRestrictions(User $user)
     {
         $restrictions = [];
-        $adminRole = $this->roleManager->getRoleByUserAndRoleName($user, 'ROLE_ADMIN');
 
-        if (is_null($adminRole)) {
+        if (!$user->hasRole('ROLE_ADMIN')) {
             $restrictions = $this->workspaceManager->getWorkspacesByUser($user);
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Changed control for 'ROLE_ADMIN' from 
``` $this->roleManager->getRoleByUserAndRoleName($user, 'ROLE_ADMIN');``` 
to just ``` $user->hasRole('ROLE_ADMIN') ```
This way even if someone acquires the ROLE_ADMIN through a group he's enrolled in, he gets the same rights as the rest of the admin users.



