### PR TITLE
[ExoBundle] fixes path to tests data

### DIFF
--- a/plugin/exo/Tests/Transfer/Json/ValidatorTest.php
+++ b/plugin/exo/Tests/Transfer/Json/ValidatorTest.php
@@ -82,7 +82,7 @@ class ValidatorTest extends TransactionalTestCase
 
     public function testValidateExercise()
     {
-        $data = file_get_contents("{$this->formatDir}/quiz/examples/valid/one-question-step.json");
+        $data = file_get_contents("{$this->formatDir}/quiz/examples/valid/content-and-question-steps.json");
         $quiz = json_decode($data);
         $this->assertEquals(0, count($this->validator->validateExercise($quiz)));
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

The recent changes in `json-quiz/json-quiz` have broken the ExoBundle tests.
This is needed in order to fix the travis build.



