### PR TITLE
[CoreBundle] Avoid mysql implicit cast

### DIFF
--- a/main/core/Repository/ResourceNodeRepository.php
+++ b/main/core/Repository/ResourceNodeRepository.php
@@ -41,16 +41,27 @@ class ResourceNodeRepository extends MaterializedPathRepository implements Conta
         $this->builder->setBundles($bundles);
     }
 
+    /**
+     * Finds a resource node by its id or guid.
+     *
+     * @param string|int $id The id or guid of the node
+     *
+     * @return ResourceNode|null
+     */
     public function find($id)
     {
-        $dql = '
-            SELECT n FROM Claroline\CoreBundle\Entity\Resource\ResourceNode n
-            WHERE n.id = :id OR n.guid LIKE :id
-        ';
-        $query = $this->_em->createQuery($dql);
-        $query->setParameter('id', $id);
+        $qb = $this->createQueryBuilder('n');
 
-        return $query->getOneOrNullResult();
+        if (preg_match('/^\d+$/', $id)) {
+            $qb->where('n.id = :id');
+        } else {
+            $qb->where('n.guid = :id');
+        }
+
+        return $qb
+            ->getQuery()
+            ->setParameter('id', $id)
+            ->getOneOrNullResult();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes/no

<!-- please add a description here if needed -->

Individual resource nodes can be retrieved either by id or guid. The problem is the current query uses a disjunction with the same bound parameter in both cases, although the corresponding column types are different (integer vs string). This causes an implicit cast by MySQL, which can lead to surprising results and eventually hard-to-track bugs:

```sql
SELECT name, id, guid FROM claro_resource_node
WHERE id = '6FCB9336-7338-442C-B400-9E6A103422F2' OR guid = '6FCB9336-7338-442C-B400-9E6A103422F2'
```


|name	|id	|guid
|-------------|-----|-----------------
|Ex 1	|6	|4107AC6F-9082-4257-A0CD-89734558BD26
|Ex 2	|19	|6FCB9336-7338-442C-B400-9E6A103422F2

...

This PR simply splits the original query to avoid such scenarios.
