### PR TITLE
Locks twig version to v1.24.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
         "symfony/twig-bundle": "~2.0",
         "symfony/yaml": "*",
         "twig/extensions": "1.2.0",
+        "twig/twig": "1.24.2",
         "werkint/jsmin": "1.0.0",
         "white-october/pagerfanta-bundle": "1.0.2",
         "willdurand/js-translation-bundle": "~2.1",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

It prevents twig/twig from updating to version 1.25.0 which generates compatibility issues


