### PR TITLE
Add controls on audio/video player

### DIFF
--- a/plugin/video-player/Resources/views/player.html.twig
+++ b/plugin/video-player/Resources/views/player.html.twig
@@ -2,6 +2,7 @@
     <div class="span12">
         <div>
             <video
+                controls
                 class="video-js vjs-big-play-centered vjs-default-skin vjs-16-9"
                 data-setup='{}'
                 >


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Fixed tickets | #1181 

This fixes the n°1181 issue. There was no buttons on the video player, which was confusing, in particular when playing an audio file.



