### PR TITLE
Add mbstring to required extensions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "ext-fileinfo": "*",
         "ext-gd": "*",
         "ext-intl": "*",
+        "ext-mbstring": "*",
         "ext-pdo_mysql": "*",
         "besimple/sso-auth-bundle": "*",
         "cocur/slugify": "~1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no

<!-- please add a description here if needed -->

`mbstring` is already used in many places in the current codebase. This PR just makes the dependency explicit. 
