### PR TITLE
[CoreBundle] Iframe resizing.

### DIFF
--- a/main/core/Resources/views/Workspace/layout.html.twig
+++ b/main/core/Resources/views/Workspace/layout.html.twig
@@ -116,12 +116,16 @@
             var getIframeWindowHeight = function() {
                 return $("iframe#embeddedActivity").contents().find('body').first().height();
             }
+
             var oldHeight= getIframeWindowHeight();
 
             setInterval(function() {
                 var newHeight = getIframeWindowHeight();
 
-                if (newHeight !== null && newHeight !== oldHeight) {
+                //dont resize if it's not that much different
+                var interval = 150;
+
+                if (newHeight !== null && newHeight > oldHeight + interval) {
                     postHeight(newHeight);
                     oldHeight = newHeight;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets |  #1208

#1208 goes into infinite loop because there is always a 150px difference between the old and the new height (I don't know why, maybe the scorm automatically does something similar) so I added a 150px interval and it fixes it.

I ran into some similar issues before but I only had to add a 5px difference (so it's totally ok). It's really huge here.


