### PR TITLE
[CursusBundle] Adds a command to delete all courses that are not associated to a cursus

### DIFF
--- a/plugin/cursus/Command/RemoveCoursesCommand.php
+++ b/plugin/cursus/Command/RemoveCoursesCommand.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\CursusBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Removes courses from the platform.
+ */
+class RemoveCoursesCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this->setName('claroline:courses:delete')
+            ->setDescription('Deletes courses that are not associated to a cursus. Sessions and associated workspaces are also deleted');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $om = $this->getContainer()->get('claroline.persistence.object_manager');
+        $cursusManager = $this->getContainer()->get('claroline.manager.cursus_manager');
+        $coursesToDelete = $cursusManager->getIndependentCourses();
+        $om->startFlushSuite();
+        $i = 1;
+
+        foreach ($coursesToDelete as $course) {
+            $sessionsToDelete = $course->getSessions();
+
+            foreach ($sessionsToDelete as $session) {
+                $sessionName = $session->getName();
+                $output->writeln("<info> Deleting training session [$sessionName]... </info>");
+                $cursusManager->deleteCourseSession($session, true);
+
+                if ($i % 100 === 0) {
+                    $om->forceFlush();
+                    $om->clear();
+                }
+                ++$i;
+            }
+            $courseTitle = $course->getTitle();
+            $output->writeln("<info> Deleting training [$courseTitle]... </info>");
+            $cursusManager->deleteCourse($course);
+
+            if ($i % 100 === 0) {
+                $om->forceFlush();
+                $om->clear();
+            }
+            ++$i;
+        }
+        $om->endFlushSuite();
+    }
+}

--- a/plugin/cursus/Command/RemoveCoursesCommand.php
+++ b/plugin/cursus/Command/RemoveCoursesCommand.php
@@ -44,7 +44,6 @@ class RemoveCoursesCommand extends ContainerAwareCommand
 
                 if ($i % 100 === 0) {
                     $om->forceFlush();
-                    $om->clear();
                 }
                 ++$i;
             }
@@ -54,7 +53,6 @@ class RemoveCoursesCommand extends ContainerAwareCommand
 
             if ($i % 100 === 0) {
                 $om->forceFlush();
-                $om->clear();
             }
             ++$i;
         }

--- a/plugin/cursus/Manager/CursusManager.php
+++ b/plugin/cursus/Manager/CursusManager.php
@@ -4703,6 +4703,11 @@ class CursusManager
         return $this->courseRepo->findCourseByCodeWithoutId($code, $id);
     }
 
+    public function getIndependentCourses()
+    {
+        return $this->courseRepo->findIndependentCourses();
+    }
+
     /******************************************
      * Access to CursusUserRepository methods *
      ******************************************/

--- a/plugin/cursus/Repository/CourseRepository.php
+++ b/plugin/cursus/Repository/CourseRepository.php
@@ -312,4 +312,21 @@ class CourseRepository extends EntityRepository
 
         return $executeQuery ? $query->getOneOrNullResult() : $query;
     }
+
+    public function findIndependentCourses()
+    {
+        $dql = '
+            SELECT c
+            FROM Claroline\CursusBundle\Entity\Course c
+            WHERE NOT EXISTS (
+                SELECT cu
+                FROM Claroline\CursusBundle\Entity\Cursus cu
+                JOIN cu.course cuc
+                WHERE cuc = c
+            )
+        ';
+        $query = $this->_em->createQuery($dql);
+
+        return $query->getResult();
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no

The command delete all courses that are not linked to a cursus. The related sessions and associated workspaces are also deleted.



