### PR TITLE
[CoreBundle] Fixes inacessible links in my workspaces widget. Closes #1287

### DIFF
--- a/main/core/Resources/translations/platform.en.yml
+++ b/main/core/Resources/translations/platform.en.yml
@@ -1126,6 +1126,7 @@ with_tutor: Tutored
 workspace: Workspace
 workspace.create: 'Create a new workspace'
 workspace.name_not_blank: 'The workspace''s name is required.'
+workspace_access_disabled: Your access to the workspace is disabled.
 workspace_activity_overview: 'Overview of recent activities in %workspaceName%'
 workspace_administration: Administration
 workspace_classification: 'Workspace classification'

--- a/main/core/Resources/translations/platform.fr.yml
+++ b/main/core/Resources/translations/platform.fr.yml
@@ -1125,6 +1125,7 @@ with_tutor: Tutoré
 workspace: 'Espace d''activités'
 workspace.create: 'Créer un nouvel espace d''activités'
 workspace.name_not_blank: 'Veuillez spécifier un nom pour cet espace d''activités.'
+workspace_access_disabled: Votre accès à cet espace d'activités est désactivé
 workspace_activity_overview: 'Aperçu des activités récentes de %workspaceName%'
 workspace_administration: Administration
 workspace_classification: 'Classification des espaces d''activités'

--- a/main/core/Resources/views/Widget/desktopWidgetMyWorkspaces.html.twig
+++ b/main/core/Resources/views/Widget/desktopWidgetMyWorkspaces.html.twig
@@ -19,19 +19,28 @@
         <div class="alert alert-warning">{{ 'no_workspace'|trans({}, 'platform') }}</div>
     {% else %}
         {% for workspace in workspaces %}
+            {% set hasWsAccess = has_access_to_workspace(workspace.getId()) %}
             <div>
-                <a {% if has_access_to_workspace(workspace.getId()) %}
-                       href="{{ path('claro_workspace_open', {'workspaceId': workspace.getId()}) }}"
-                   {% endif %}
-                >
-                    <i class="fa fa-book"></i>
-                    {{ workspace.getName() }}
-                    <span>
-                        <small>
-                            ({{ workspace.getCode() }})
-                        </small>
-                    </span>
-                </a>
+                {% if hasWsAccess %}
+                    <a href="{{ path('claro_workspace_open', {'workspaceId': workspace.getId()}) }}">
+                {% endif %}
+                <i class="fa fa-book"></i>
+                {{ workspace.getName() }}
+                <span>
+                    <small>
+                        ({{ workspace.getCode() }})
+                    </small>
+                </span>
+                {% if hasWsAccess %}
+                    </a>
+                {% else %}
+                    <i class="fa fa-warning pointer-hand"
+                       data-toggle="tooltip"
+                       data-placement="top"
+                       title="{{ 'workspace_access_disabled'|trans({}, 'platform') }}"
+                    >
+                    </i>
+                {% endif %}
             </div>
         {% endfor %}
     {% endif %}

--- a/main/core/Resources/views/Widget/displayMyWorkspacesWidget.html.twig
+++ b/main/core/Resources/views/Widget/displayMyWorkspacesWidget.html.twig
@@ -2,19 +2,29 @@
     <div class="alert alert-warning">{{ 'no_workspace'|trans({}, 'platform') }}</div>
 {% else %}
     {% for workspace in workspaces %}
+        {% set hasWsAccess = has_access_to_workspace(workspace.getId()) %}
         <div>
-            <a {% if has_access_to_workspace(workspace.getId()) %}
-                   href="{{ path('claro_workspace_open', {'workspaceId': workspace.getId()}) }}"
-               {% endif %}
-            >
-                <i class="fa fa-book"></i>
-                {{ workspace.getName() }}
-                <span>
-                    <small>
-                        ({{ workspace.getCode() }})
-                    </small>
-                </span>
-            </a>
+            {% if hasWsAccess %}
+                <a href="{{ path('claro_workspace_open', {'workspaceId': workspace.getId()}) }}">
+            {% endif %}
+            <i class="fa fa-book"></i>
+            {{ workspace.getName() }}
+            <span>
+                <small>
+                    ({{ workspace.getCode() }})
+                </small>
+            </span>
+
+            {% if hasWsAccess %}
+                </a>
+            {% else %}
+                <i class="fa fa-warning pointer-hand"
+                   data-toggle="tooltip"
+                   data-placement="top"
+                   title="{{ 'workspace_access_disabled'|trans({}, 'platform') }}"
+                >
+                </i>
+            {% endif %}
         </div>
     {% endfor %}
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #1287 

When an user had a role in a workspace but had access to no tool, the workspace appeared in the "my workspaces" widget but it was impossible to click on the link.

