### PR TITLE
[CoreBundle] Updating user logger from csv.

### DIFF
--- a/main/core/Command/Import/CreateUserFromCsvCommand.php
+++ b/main/core/Command/Import/CreateUserFromCsvCommand.php
@@ -14,6 +14,7 @@ namespace Claroline\CoreBundle\Command\Import;
 use Claroline\CoreBundle\Command\Traits\BaseCommandTrait;
 use Claroline\CoreBundle\Library\Logger\ConsoleLogger;
 use Claroline\CoreBundle\Listener\DoctrineDebug;
+use Psr\Log\LogLevel;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;

--- a/main/core/Command/Import/CreateUserFromCsvCommand.php
+++ b/main/core/Command/Import/CreateUserFromCsvCommand.php
@@ -67,8 +67,8 @@ class CreateUserFromCsvCommand extends ContainerAwareCommand
         $userManager->importUsers(
             $users,
             false,
-            function ($message) use ($output) {
-                $output->writeln($message);
+            function ($message) use ($consoleLogger) {
+                $consoleLogger->log(LogLevel::DEBUG, $message);
             },
             [],
             false,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

When run from a php script triggered by a bash one, the output isn't visible otherwise.

ie:
myscript.php
```
    ...
     php app/console mycommand
    ....
```

mybash.sh
```
...
php myscript.php
...
```

This PR fixes it (better logging support then).
