### PR TITLE
[CoreBundle] Copies several options when creating workspace from a model

### DIFF
--- a/main/core/Manager/WorkspaceManager.php
+++ b/main/core/Manager/WorkspaceManager.php
@@ -929,7 +929,7 @@ class WorkspaceManager
                 $workspace->setRegistrationValidation($registrationValidation);
                 $workspace->setGuid($guid);
                 if ($endDate) {
-                    $workspace->setEndDate($date);
+                    $workspace->setEndDate($endDate);
                 }
                 $date = new \Datetime(date('d-m-Y H:i'));
                 $workspace->setCreationDate($date->getTimestamp());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #1278 

When creating a workspace from a model the following options are now copied too :
- The workspace options (background color, hide tool menu option, hide breadcrumbs option)
- The color of the home tabs
- The text color of a widget


