### PR TITLE
[exo-v2] updates and fixes api

### DIFF
--- a/plugin/exo/Controller/Api/ExerciseController.php
+++ b/plugin/exo/Controller/Api/ExerciseController.php
@@ -92,7 +92,7 @@ class ExerciseController
     {
         $this->assertHasPermission('ADMINISTRATE', $exercise);
 
-        return new JsonResponse($this->exerciseManager->exportExercise($exercise));
+        return new JsonResponse($this->exerciseManager->export($exercise, ['includeSolutions' => true]));
     }
 
     /**
@@ -109,7 +109,7 @@ class ExerciseController
     {
         $this->assertHasPermission('OPEN', $exercise);
 
-        return new JsonResponse($this->exerciseManager->exportExerciseMinimal($exercise));
+        return new JsonResponse($this->exerciseManager->export($exercise, ['minimal' => true]));
     }
 
     /**
@@ -145,7 +145,7 @@ class ExerciseController
             }
         }
 
-        return new JsonResponse($this->exerciseManager->export($exercise));
+        return new JsonResponse($this->exerciseManager->export($exercise, ['includeSolutions' => true]));
     }
 
     /**

--- a/plugin/exo/Entity/AbstractInteraction.php
+++ b/plugin/exo/Entity/AbstractInteraction.php
@@ -36,6 +36,8 @@ abstract class AbstractInteraction implements QuestionTypeProviderInterface
     final public function setQuestion(Question $question)
     {
         $this->question = $question;
+
+        $question->setInteraction($this);
         $question->setType(static::getQuestionType());
     }
 

--- a/plugin/exo/Entity/Hole.php
+++ b/plugin/exo/Entity/Hole.php
@@ -184,6 +184,20 @@ class Hole
     }
 
     /**
+     * Sets keywords collection.
+     *
+     * @param array $keywords
+     */
+    public function setKeywords(array $keywords)
+    {
+        $this->keywords = new ArrayCollection(array_map(function (WordResponse $keyword) {
+            $keyword->setHole($this);
+
+            return $keyword;
+        }, $keywords));
+    }
+
+    /**
      * Adds a keyword.
      *
      * @param WordResponse $keyword

--- a/plugin/exo/Entity/InteractionHole.php
+++ b/plugin/exo/Entity/InteractionHole.php
@@ -38,7 +38,7 @@ class InteractionHole extends AbstractInteraction
      *     cascade={"persist", "remove"},
      *     orphanRemoval=true
      * )
-     * @ORM\OrderBy({"order" = "ASC"})
+     * @ORM\OrderBy({"position" = "ASC"})
      */
     private $holes;
 

--- a/plugin/exo/Entity/InteractionOpen.php
+++ b/plugin/exo/Entity/InteractionOpen.php
@@ -21,11 +21,7 @@ class InteractionOpen extends AbstractInteraction
     private $typeopenquestion;
 
     /**
-     * @ORM\OneToMany(
-     *     targetEntity="WordResponse",
-     *     mappedBy="interactionopen",
-     *     cascade={"remove"}
-     * )
+     * @ORM\OneToMany(targetEntity="WordResponse", mappedBy="interactionopen", cascade={"persist", "remove"}, orphanRemoval=true)
      */
     private $keywords;
 
@@ -71,6 +67,20 @@ class InteractionOpen extends AbstractInteraction
     public function getKeywords()
     {
         return $this->keywords;
+    }
+
+    /**
+     * Sets keywords collection.
+     *
+     * @param array $keywords
+     */
+    public function setKeywords(array $keywords)
+    {
+        $this->keywords = new ArrayCollection(array_map(function (WordResponse $keyword) {
+            $keyword->setInteractionOpen($this);
+
+            return $keyword;
+        }, $keywords));
     }
 
     /**

--- a/plugin/exo/Entity/Question.php
+++ b/plugin/exo/Entity/Question.php
@@ -10,11 +10,14 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * @ORM\Entity(repositoryClass="UJM\ExoBundle\Repository\QuestionRepository")
  * @ORM\Table(name="ujm_question")
+ * @ORM\EntityListeners({"\UJM\ExoBundle\Listener\Entity\QuestionListener"})
  * @ORM\HasLifecycleCallbacks()
  */
 class Question
 {
     /**
+     * @var int
+     *
      * @ORM\Column(type="integer")
      * @ORM\Id
      * @ORM\GeneratedValue(strategy="AUTO")
@@ -22,51 +25,74 @@ class Question
     private $id;
 
     /**
-     * @ORM\Column
+     * @var string
+     *
+     * @ORM\Column("uuid", type="string", length=36)
+     */
+    protected $uuid;
+
+    /**
+     * @var string
+     *
+     * @ORM\Column()
      */
     private $type;
 
     /**
      * The mime type of the Question type.
      *
-     * @ORM\Column("mime_type", type="string")
-     *
      * @var string
+     *
+     * @ORM\Column("mime_type", type="string")
      */
     private $mimeType;
 
     /**
-     * @ORM\Column
+     * @var string
+     *
+     * @ORM\Column("title", type="string", nullable=true)
      */
     private $title;
 
     /**
+     * @var string
+     *
      * @ORM\Column(type="text", nullable=true)
      */
     private $description;
 
     /**
+     * @var string
+     *
      * @ORM\Column(type="text")
      * @Assert\NotBlank
      */
     private $invite;
 
     /**
+     * @var string
+     *
      * @ORM\Column(type="text", nullable=true)
      */
     private $feedback;
 
     /**
+     * @var \DateTime
+     *
      * @ORM\Column(name="date_create", type="datetime")
      */
     private $dateCreate;
 
     /**
+     * @var \DateTime
+     *
      * @ORM\Column(name="date_modify", type="datetime", nullable=true)
      */
     private $dateModify;
 
     /**
+     * @var bool
+     *
      * @ORM\Column(type="boolean")
      */
     private $model = false;
@@ -113,6 +139,14 @@ class Question
      */
     private $stepQuestions;
 
+    /**
+     * The linked interaction entity.
+     * This is populated by Doctrine Lifecycle events.
+     *
+     * @var AbstractInteraction
+     */
+    private $interaction = null;
+
     public function __construct()
     {
         $this->hints = new ArrayCollection();
@@ -121,6 +155,34 @@ class Question
         $this->stepQuestions = new ArrayCollection();
         $this->dateCreate = new \DateTime();
         $this->dateModify = new \DateTime();
+    }
+
+    /**
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * Gets UUID.
+     *
+     * @return string
+     */
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+
+    /**
+     * Sets UUID.
+     *
+     * @param $uuid
+     */
+    public function setUuid($uuid)
+    {
+        $this->uuid = $uuid;
     }
 
     /**
@@ -159,14 +221,6 @@ class Question
     public function setMimeType($mimeType)
     {
         $this->mimeType = $mimeType;
-    }
-
-    /**
-     * @return int
-     */
-    public function getId()
-    {
-        return $this->id;
     }
 
     /**
@@ -358,6 +412,16 @@ class Question
     /**
      * @return bool
      */
+    public function isModel()
+    {
+        return $this->model;
+    }
+
+    /**
+     * @deprecated use isModel() instead
+     *
+     * @return bool
+     */
     public function getModel()
     {
         return $this->model;
@@ -454,5 +518,21 @@ class Question
     public function getSpecification()
     {
         return $this->specification;
+    }
+
+    /**
+     * @return AbstractInteraction
+     */
+    public function getInteraction()
+    {
+        return $this->interaction;
+    }
+
+    /**
+     * @param AbstractInteraction $interaction
+     */
+    public function setInteraction(AbstractInteraction $interaction)
+    {
+        $this->interaction = $interaction;
     }
 }

--- a/plugin/exo/Entity/Step.php
+++ b/plugin/exo/Entity/Step.php
@@ -85,7 +85,7 @@ class Step
     /**
      * @var ArrayCollection
      *
-     * @ORM\OneToMany(targetEntity="StepQuestion", mappedBy="step", cascade={"all"})
+     * @ORM\OneToMany(targetEntity="StepQuestion", mappedBy="step", cascade={"persist", "remove"}, orphanRemoval=true)
      * @ORM\OrderBy({"order" = "ASC"})
      */
     private $stepQuestions;

--- a/plugin/exo/Entity/StepQuestion.php
+++ b/plugin/exo/Entity/StepQuestion.php
@@ -21,7 +21,7 @@ class StepQuestion
 
     /**
      * @ORM\Id
-     * @ORM\ManyToOne(targetEntity="UJM\ExoBundle\Entity\Question", inversedBy="stepQuestions")
+     * @ORM\ManyToOne(targetEntity="UJM\ExoBundle\Entity\Question", inversedBy="stepQuestions", cascade={"persist"})
      * @ORM\JoinColumn(onDelete="CASCADE")
      */
     private $question;

--- a/plugin/exo/Installation/Updater/Updater070100.php
+++ b/plugin/exo/Installation/Updater/Updater070100.php
@@ -12,15 +12,27 @@ class Updater070100
 
     private $connection;
 
+    private $om;
+
+    private $ut;
+
     public function __construct(ContainerInterface $container)
     {
         $this->connection = $container->get('doctrine.dbal.default_connection');
+        $this->om = $container->get('claroline.persistence.object_manager');
+        $this->ut = $container->get('claroline.utilities.misc');
+    }
+
+    public function postUpdate()
+    {
+        $this->addMimeTypeToQuestions();
+        $this->initializeUuid();
     }
 
     /**
      * Sets questions mime type.
      */
-    public function postUpdate()
+    private function addMimeTypeToQuestions()
     {
         $this->log('Add mime-type to Questions...');
 
@@ -57,5 +69,45 @@ class Updater070100
         // Update match questions
         $query = 'UPDATE ujm_question SET mime_type= "'.QuestionType::MATCH.'" WHERE type="InteractionMatch"';
         $this->connection->query($query);
+
+        $this->log('done !');
+    }
+
+    private function initializeUuid()
+    {
+        $classes = [
+            'UJM\ExoBundle\Entity\Question',
+        ];
+
+        foreach ($classes as $class) {
+            $this->setUuidForClass($class);
+        }
+    }
+
+    public function setUuidForClass($class)
+    {
+        $entities = $this->om->getRepository($class)->findAll();
+        $totalObjects = count($entities);
+        $i = 0;
+        $this->log("Adding UUID for {$totalObjects} {$class}...");
+
+        foreach ($entities as $entity) {
+            if (!$entity->getUuid()) {
+                $entity->setUuid($this->ut->generateGuid());
+                $this->om->persist($entity);
+            }
+            ++$i;
+
+            if ($i % 300 === 0) {
+                $this->log("Flushing [{$i}/{$totalObjects}]");
+                $this->om->flush();
+            }
+        }
+
+        $this->om->flush();
+        $this->log("UUID added for {$totalObjects} {$class} !");
+        $this->log('Clearing object manager...');
+        $this->om->clear();
+        $this->log('done !');
     }
 }

--- a/plugin/exo/Library/Serializer/SerializerInterface.php
+++ b/plugin/exo/Library/Serializer/SerializerInterface.php
@@ -17,13 +17,11 @@ interface SerializerInterface
     /**
      * Converts raw data into entities.
      *
-     * If `$options['entity']` is set, it will be populated,
-     * else, a new object is created.
-     *
-     * @param \stdClass $data
-     * @param array     $options
+     * @param \stdClass $data    - the data to deserialize
+     * @param mixed     $entity  - the entity to populate (if null, a new one is created)
+     * @param array     $options - the deserialization options
      *
      * @return mixed
      */
-    public function deserialize($data, array $options = []);
+    public function deserialize($data, $entity = null, array $options = []);
 }

--- a/plugin/exo/Library/Testing/Persister.php
+++ b/plugin/exo/Library/Testing/Persister.php
@@ -97,6 +97,7 @@ class Persister
     public function qcmQuestion($title, array $choices = [], $description = '')
     {
         $question = new Question();
+        $question->setUuid('3532D05C-CAE9-4ED2-9A55-6D7216C166EE');
         $question->setMimeType(QuestionType::CHOICE);
         $question->setTitle($title);
         $question->setInvite('Invite...');
@@ -132,6 +133,7 @@ class Persister
     public function openQuestion($title)
     {
         $question = new Question();
+        $question->setUuid('864FF1A6-68E3-411C-9C76-B341DE79ADCA');
         $question->setMimeType(QuestionType::OPEN);
         $question->setTitle($title);
         $question->setInvite('Invite...');
@@ -171,6 +173,7 @@ class Persister
     public function matchQuestion($title, $labels = [], $proposals = [])
     {
         $question = new Question();
+        $question->setUuid('7C676890-F800-443E-B98C-2B5FF815FD3B');
         $question->setMimeType(QuestionType::MATCH);
         $question->setTitle($title);
         $question->setInvite('Invite...');

--- a/plugin/exo/Listener/Entity/QuestionListener.php
+++ b/plugin/exo/Listener/Entity/QuestionListener.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace UJM\ExoBundle\Listener\Entity;
+
+use Doctrine\ORM\Event\LifecycleEventArgs;
+use UJM\ExoBundle\Entity\Question;
+
+/**
+ * Question Listener.
+ *
+ * Manages Life cycle of the Question.
+ */
+class QuestionListener
+{
+    /**
+     * Loads the entity that holds the question type data when a Question is loaded.
+     *
+     * @param Question           $question
+     * @param LifecycleEventArgs $event
+     */
+    public function postLoad(Question $question, LifecycleEventArgs $event)
+    {
+        $repository = $event
+            ->getEntityManager()
+            ->getRepository('UJMExoBundle:'.$question->getType());
+
+        /** @var \UJM\ExoBundle\Entity\AbstractInteraction $typeEntity */
+        $typeEntity = $repository->findOneBy([
+            'question' => $question,
+        ]);
+
+        if (!empty($typeEntity)) {
+            $question->setInteraction($typeEntity);
+        }
+    }
+
+    /**
+     * Persists the entity that holds the question type data when a Question is persisted.
+     *
+     * @param Question           $question
+     * @param LifecycleEventArgs $event
+     */
+    public function prePersist(Question $question, LifecycleEventArgs $event)
+    {
+        $event->getEntityManager()->persist($question->getInteraction());
+    }
+
+    /**
+     * Deletes the entity that holds the question type data when a Question is deleted.
+     *
+     * @param Question           $question
+     * @param LifecycleEventArgs $event
+     */
+    public function preRemove(Question $question, LifecycleEventArgs $event)
+    {
+        $event->getEntityManager()->remove($question->getInteraction());
+    }
+}

--- a/plugin/exo/Manager/ExerciseManager.php
+++ b/plugin/exo/Manager/ExerciseManager.php
@@ -106,7 +106,7 @@ class ExerciseManager
         }
 
         // Update Exercise with new data
-        $this->serializer->deserialize($data, ['entity' => $exercise]);
+        $this->serializer->deserialize($data, $exercise);
 
         // Save to DB
         $this->om->persist($exercise);

--- a/plugin/exo/Manager/HintManager.php
+++ b/plugin/exo/Manager/HintManager.php
@@ -90,7 +90,7 @@ class HintManager
         }
 
         // Update Exercise with new data
-        $this->serializer->deserialize($data, ['entity' => $hint]);
+        $this->serializer->deserialize($data, $hint);
 
         // Save to DB
         $this->om->persist($hint);

--- a/plugin/exo/Manager/QuestionManager.php
+++ b/plugin/exo/Manager/QuestionManager.php
@@ -148,7 +148,7 @@ class QuestionManager
         }
 
         // Update Exercise with new data
-        $this->serializer->deserialize($data, ['entity' => $question]);
+        $this->serializer->deserialize($data, $question);
 
         // Save to DB
         $this->om->persist($question);

--- a/plugin/exo/Manager/StepManager.php
+++ b/plugin/exo/Manager/StepManager.php
@@ -106,7 +106,7 @@ class StepManager
         }
 
         // Update Step with new data
-        $this->serializer->deserialize($data, ['entity' => $step]);
+        $this->serializer->deserialize($data, $step);
 
         // Save to DB
         $this->om->persist($step);

--- a/plugin/exo/Migrations/pdo_mysql/Version20161010174239.php
+++ b/plugin/exo/Migrations/pdo_mysql/Version20161010174239.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace UJM\ExoBundle\Migrations\pdo_mysql;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution.
+ *
+ * Generation date: 2016/10/10 05:42:42
+ */
+class Version20161010174239 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql('
+            ALTER TABLE ujm_question CHANGE title title VARCHAR(255) DEFAULT NULL
+        ');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql('
+            ALTER TABLE ujm_question CHANGE title title VARCHAR(255) NOT NULL COLLATE utf8_unicode_ci
+        ');
+    }
+}

--- a/plugin/exo/Migrations/pdo_mysql/Version20161010214401.php
+++ b/plugin/exo/Migrations/pdo_mysql/Version20161010214401.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace UJM\ExoBundle\Migrations\pdo_mysql;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution.
+ *
+ * Generation date: 2016/10/10 09:44:04
+ */
+class Version20161010214401 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql('
+            ALTER TABLE ujm_question 
+            ADD uuid VARCHAR(36) NOT NULL
+        ');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql('
+            ALTER TABLE ujm_question 
+            DROP uuid
+        ');
+    }
+}

--- a/plugin/exo/README.md
+++ b/plugin/exo/README.md
@@ -51,7 +51,7 @@ class ExerciseSerializer implements SerializerInterface
 
 A Serializer exposes 2 methods : 
 - `serialize($entity, array $options = [])` : converts `$entity` into raw data (e.g. array, stdClass)
-- `deserialize($data, array $options = [])` : converts `$data` into symfony entities
+- `deserialize($data, $entity = null, array $options = [])` : converts `$data` into symfony entities
 
 The `$options` parameters can contain a `$options['entity']`. If it is set, the deserialization will populate this entity
 instead of creating a new one.

--- a/plugin/exo/Serializer/HintSerializer.php
+++ b/plugin/exo/Serializer/HintSerializer.php
@@ -41,13 +41,16 @@ class HintSerializer implements SerializerInterface
      * {@inheritdoc}
      *
      * @param \stdClass $data
+     * @param Hint      $hint
      * @param array     $options
      *
      * @return Hint
      */
-    public function deserialize($data, array $options = [])
+    public function deserialize($data, $hint = null, array $options = [])
     {
-        $hint = !empty($options['entity']) ? $options['entity'] : new Hint();
+        if (empty($hint)) {
+            $hint = new Hint();
+        }
 
         if (!empty($data->penalty) || 0 === $data->penalty) {
             $hint->setPenalty($data->penalty);

--- a/plugin/exo/Serializer/Question/Type/ChoiceTypeSerializer.php
+++ b/plugin/exo/Serializer/Question/Type/ChoiceTypeSerializer.php
@@ -67,7 +67,7 @@ class ChoiceTypeSerializer implements QuestionHandlerInterface, SerializerInterf
         $questionData->multiple = $choiceQuestion->getTypeQCM()->getCode() === 1;
 
         // Serializes choices
-        $this->serializeChoices($choiceQuestion, $options);
+        $questionData->choices = $this->serializeChoices($choiceQuestion, $options);
 
         // Serializes score type
         $questionData->score = new \stdClass();
@@ -89,14 +89,17 @@ class ChoiceTypeSerializer implements QuestionHandlerInterface, SerializerInterf
     /**
      * Converts raw data into a Choice question entity.
      *
-     * @param \stdClass $data
-     * @param array     $options
+     * @param \stdClass      $data
+     * @param InteractionQCM $choiceQuestion
+     * @param array          $options
      *
      * @return InteractionQCM
      */
-    public function deserialize($data, array $options = [])
+    public function deserialize($data, $choiceQuestion = null, array $options = [])
     {
-        $choiceQuestion = !empty($options['entity']) ? $options['entity'] : new InteractionQCM();
+        if (empty($choiceQuestion)) {
+            $choiceQuestion = new InteractionQCM();
+        }
 
         $subTypeCode = $data->multiple ? 1 : 2;
         $subType = $this->om->getRepository('UJMExoBundle:TypeQCM')->findOneByCode($subTypeCode);
@@ -121,16 +124,14 @@ class ChoiceTypeSerializer implements QuestionHandlerInterface, SerializerInterf
      * Shuffles and serializes the Question choices.
      * To avoid shuffling, set `$options['randomize']` to false (eg. we don't want shuffle for papers).
      *
-     * @param InteractionQCM $questionType
+     * @param InteractionQCM $choiceQuestion
      * @param array          $options
      *
      * @return array
      */
-    private function serializeChoices(InteractionQCM $questionType, array $options = [])
+    private function serializeChoices(InteractionQCM $choiceQuestion, array $options = [])
     {
-        return array_map(function ($choice) use ($options) {
-            /* @var Choice $choice */
-
+        return array_map(function (Choice $choice) use ($options) {
             $node = $choice->getResourceNode();
             if (!empty($node)) {
                 $choiceData = $this->resourceContentSerializer->serialize($node, $options);
@@ -142,7 +143,7 @@ class ChoiceTypeSerializer implements QuestionHandlerInterface, SerializerInterf
             }
 
             return $choiceData;
-        }, $questionType->getChoices()->toArray());
+        }, $choiceQuestion->getChoices()->toArray());
     }
 
     /**

--- a/plugin/exo/Serializer/Question/Type/GraphicTypeSerializer.php
+++ b/plugin/exo/Serializer/Question/Type/GraphicTypeSerializer.php
@@ -49,19 +49,22 @@ class GraphicTypeSerializer implements QuestionHandlerInterface, SerializerInter
     /**
      * Converts raw data into a Graphic question entity.
      *
-     * @param \stdClass $data
-     * @param array     $options
+     * @param \stdClass          $data
+     * @param InteractionGraphic $graphicQuestion
+     * @param array              $options
      *
      * @return InteractionGraphic
      */
-    public function deserialize($data, array $options = [])
+    public function deserialize($data, $graphicQuestion = null, array $options = [])
     {
-        $entity = !empty($options['entity']) ? $options['entity'] : new InteractionGraphic();
+        if (empty($graphicQuestion)) {
+            $graphicQuestion = new InteractionGraphic();
+        }
 
-        $this->deserializeImage($entity, $data->image);
-        $this->deserializeAreas($entity, $data->solutions);
+        $this->deserializeImage($graphicQuestion, $data->image);
+        $this->deserializeAreas($graphicQuestion, $data->solutions);
 
-        return $entity;
+        return $graphicQuestion;
     }
 
     /**
@@ -152,17 +155,6 @@ class GraphicTypeSerializer implements QuestionHandlerInterface, SerializerInter
 
             $graphicQuestion->addArea($area);
         }
-
-        array_map(function (Coords $area) {
-            $solutionData = new \stdClass();
-            $solutionData->area = $this->serializeArea($area);
-            $solutionData->score = $area->getScore();
-            if ($area->getFeedback()) {
-                $solutionData->feedback = $area->getFeedback();
-            }
-
-            return $solutionData;
-        }, $graphicQuestion->getAreas()->toArray());
 
         // Remaining areas are no longer in the question
         foreach ($areaEntities as $areaToRemove) {

--- a/plugin/exo/Serializer/Question/Type/MatchTypeSerializer.php
+++ b/plugin/exo/Serializer/Question/Type/MatchTypeSerializer.php
@@ -43,9 +43,24 @@ class MatchTypeSerializer implements QuestionHandlerInterface, SerializerInterfa
         return $questionData;
     }
 
-    public function deserialize($data, array $options = [])
+    /**
+     * Converts raw data into a Match question entity.
+     *
+     * @param \stdClass           $data
+     * @param InteractionMatching $matchQuestion
+     * @param array               $options
+     *
+     * @return InteractionMatching
+     */
+    public function deserialize($data, $matchQuestion = null, array $options = [])
     {
+        if (empty($matchQuestion)) {
+            $matchQuestion = new InteractionMatching();
+        }
+
         // TODO: Implement deserialize() method.
+
+        return $matchQuestion;
     }
 
     private function serializeSolutions($questionType)

--- a/plugin/exo/Serializer/ResourceContentSerializer.php
+++ b/plugin/exo/Serializer/ResourceContentSerializer.php
@@ -112,17 +112,18 @@ class ResourceContentSerializer implements SerializerInterface
      * The only purpose of this serializer is to expose a common data representation of a resource,
      * it's not made to create/update them so the deserialization only returns an existing ResourceNode
      *
-     * @param \stdClass $data
-     * @param array     $options
+     * @param \stdClass    $data
+     * @param ResourceNode $resourceNode
+     * @param array        $options
      *
      * @return mixed
      */
-    public function deserialize($data, array $options = [])
+    public function deserialize($data, $resourceNode = null, array $options = [])
     {
-        if (!empty($options['entity'])) {
-            return $options['entity'];
-        } else {
-            return $this->om->getRepository('ClarolineCoreBundle:Resource\ResourceNode')->find($data->id);
+        if (empty($resourceNode)) {
+            $resourceNode = $this->om->getRepository('ClarolineCoreBundle:Resource\ResourceNode')->find($data->id);
         }
+
+        return $resourceNode;
     }
 }

--- a/plugin/exo/Tests/Controller/Api/ExerciseControllerCommonTest.php
+++ b/plugin/exo/Tests/Controller/Api/ExerciseControllerCommonTest.php
@@ -98,8 +98,8 @@ class ExerciseControllerCommonTest extends TransactionalTestCase
 
         $content = json_decode($this->client->getResponse()->getContent());
         $this->assertEquals($this->ex1->getId(), $content->id);
-        $this->assertEquals('ex1', $content->meta->title);
-        $this->assertEquals('qu1', $content->steps[0]->items[0]->title);
+        $this->assertEquals('ex1', $content->title);
+        $this->assertEquals('Invite...', $content->steps[0]->items[0]->content);
     }
 
     /**
@@ -112,7 +112,7 @@ class ExerciseControllerCommonTest extends TransactionalTestCase
         $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
         $content = json_decode($this->client->getResponse()->getContent());
         $this->assertEquals($this->ex1->getId(), $content->id);
-        $this->assertEquals('ex1', $content->meta->title);
+        $this->assertEquals('ex1', $content->title);
         $this->assertFalse(property_exists($content, 'steps'));
     }
 

--- a/plugin/exo/Tests/Data/json/misc/keyword/invalid/collection-with-invalid-keyword.json
+++ b/plugin/exo/Tests/Data/json/misc/keyword/invalid/collection-with-invalid-keyword.json
@@ -2,8 +2,7 @@
   {
     "text": "lorem",
     "caseSensitive": false,
-    "score": 2,
-    "unauthorized-property": "unauthorized"
+    "score": "12"
   },
   {
     "text": "ipsum",

--- a/plugin/exo/Tests/Data/json/question/base/invalid/no-score.json
+++ b/plugin/exo/Tests/Data/json/question/base/invalid/no-score.json
@@ -1,0 +1,20 @@
+{
+  "id": "1",
+  "type": "application/x.choice+json",
+  "content": "Question ?",
+  "description": null,
+  "choices": [
+    {
+      "id": "1",
+      "type": "text/html",
+      "data": "True"
+    },
+    {
+      "id": "2",
+      "type": "text/html",
+      "data": "False"
+    }
+  ],
+  "random": false,
+  "multiple": false
+}

--- a/plugin/exo/Tests/Data/json/question/base/invalid/unknown-type.json
+++ b/plugin/exo/Tests/Data/json/question/base/invalid/unknown-type.json
@@ -1,5 +1,8 @@
 {
   "id": "123",
-  "title": "question title",
-  "type": "application/x.unknown+json"
+  "content": "question title",
+  "type": "application/x.unknown+json",
+  "score": {
+    "type": "sum"
+  }
 }

--- a/plugin/exo/Tests/Data/json/question/cloze/invalid/invalid-number-of-solutions.json
+++ b/plugin/exo/Tests/Data/json/question/cloze/invalid/invalid-number-of-solutions.json
@@ -1,0 +1,31 @@
+{
+  "id": "1",
+  "type": "application/x.cloze+json",
+  "content": "Question ?",
+  "text": "Lorem [[1]] dolor sit [[2]].",
+  "score": {
+    "type": "sum"
+  },
+  "holes": [
+    {
+      "id": "1",
+      "choices": ["foo", "ipsum", "bar"]
+    },
+    {
+      "id": "2",
+      "size": 10
+    }
+  ],
+  "solutions": [
+    {
+      "holeId": "1",
+      "answers": [
+        {
+          "text": "ipsum",
+          "caseSensitive": false,
+          "score": 1.5
+        }
+      ]
+    }
+  ]
+}

--- a/plugin/exo/Tests/Transfer/Json/ValidatorTest.php
+++ b/plugin/exo/Tests/Transfer/Json/ValidatorTest.php
@@ -77,6 +77,7 @@ class ValidatorTest extends TransactionalTestCase
     {
         $data = file_get_contents("{$this->formatDir}/question/$dataFilename");
         $question = json_decode($data);
+
         $this->assertEquals(0, count($this->validator->validateQuestion($question)));
     }
 
@@ -97,7 +98,6 @@ class ValidatorTest extends TransactionalTestCase
             ['choice/examples/valid/solutions.json'],
             ['match/examples/valid/solutions.json'],
             ['cloze/examples/valid/multiple-answers.json'],
-            ['short/examples/valid/multiple-answers.json'],
         ];
     }
 }

--- a/plugin/exo/Tests/Validator/JsonSchema/Misc/KeywordValidatorTest.php
+++ b/plugin/exo/Tests/Validator/JsonSchema/Misc/KeywordValidatorTest.php
@@ -74,8 +74,10 @@ class KeywordValidatorTest extends JsonSchemaTestCase
         // Test with option not set (expects no schema validation error)
         $this->assertEquals(0, count($validator->validateCollection($collectionData)));
 
+        $errors = $validator->validateCollection($collectionData, ['validateSchema' => true]);
+
         // Test with option set to `true` (expects schema validation errors)
-        $this->assertGreaterThan(0, count($validator->validateCollection($collectionData, ['validateSchema' => true])));
+        $this->assertGreaterThan(0, count($errors));
     }
 
     /**

--- a/plugin/exo/Tests/Validator/JsonSchema/Question/QuestionValidatorTest.php
+++ b/plugin/exo/Tests/Validator/JsonSchema/Question/QuestionValidatorTest.php
@@ -83,6 +83,22 @@ class QuestionValidatorTest extends JsonSchemaTestCase
     }
 
     /**
+     * The validator MUST return an error if question has no score.
+     */
+    public function testMissingScoreThrowsError()
+    {
+        $questionData = $this->loadTestData('question/base/invalid/no-score.json');
+
+        $errors = $this->validator->validate($questionData);
+
+        $this->assertGreaterThan(0, count($errors));
+        $this->assertTrue(in_array([
+            'path' => '/score',
+            'message' => 'Question score is required',
+        ], $errors));
+    }
+
+    /**
      * The validator MUST return an error if question has no solution and the `solutionsRequired` option is set to true.
      */
     public function testMissingSolutionsWhenRequiredThrowsError()

--- a/plugin/exo/Tests/Validator/JsonSchema/Question/Type/ClozeTypeValidatorTest.php
+++ b/plugin/exo/Tests/Validator/JsonSchema/Question/Type/ClozeTypeValidatorTest.php
@@ -34,6 +34,22 @@ class ClozeTypeValidatorTest extends JsonSchemaTestCase
     }
 
     /**
+     * The validator MUST return an error if there is not the same number of solutions and holes.
+     */
+    public function testInvalidNumberOfSolutionsThrowsError()
+    {
+        $questionData = $this->loadTestData('question/cloze/invalid/invalid-number-of-solutions.json');
+
+        $errors = $this->validator->validate($questionData, ['solutionsRequired' => true]);
+
+        $this->assertGreaterThan(0, count($errors));
+        $this->assertTrue(in_array([
+            'path' => '/solutions',
+            'message' => 'there must be the same number of solutions and holes',
+        ], $errors));
+    }
+
+    /**
      * The validator MUST execute validation for its keywords when `solutionRequired`.
      */
     public function testSolutionKeywordsAreValidatedToo()

--- a/plugin/exo/Tests/Validator/JsonSchema/Question/Type/WordsTypeValidatorTest.php
+++ b/plugin/exo/Tests/Validator/JsonSchema/Question/Type/WordsTypeValidatorTest.php
@@ -41,8 +41,7 @@ class WordsTypeValidatorTest extends JsonSchemaTestCase
         $questionData = $this->loadExampleData('question/words/examples/valid/multiple-answers.json');
 
         $this->keywordValidator->expects($this->exactly(1))
-            ->method('validateCollection')
-            ->with(['keywords' => $questionData->solutions, 'options' => ['validateScore' => true]]);
+            ->method('validateCollection');
 
         $this->validator->validate($questionData, ['solutionsRequired' => true]);
     }

--- a/plugin/exo/Validator/JsonSchema/ExerciseValidator.php
+++ b/plugin/exo/Validator/JsonSchema/ExerciseValidator.php
@@ -39,7 +39,7 @@ class ExerciseValidator extends JsonSchemaValidator
         $errors = [];
 
         if (isset($exercise->parameters)) {
-            array_merge($errors, $this->validateParameters($exercise->parameters));
+            $errors = array_merge($errors, $this->validateParameters($exercise->parameters));
         }
 
         if (isset($exercise->steps)) {

--- a/plugin/exo/Validator/JsonSchema/Misc/KeywordValidator.php
+++ b/plugin/exo/Validator/JsonSchema/Misc/KeywordValidator.php
@@ -48,9 +48,9 @@ class KeywordValidator extends JsonSchemaValidator
         foreach ($keywords as $index => $keyword) {
             // Validate keyword
             if (isset($options['validateSchema']) && $options['validateSchema']) {
-                array_merge($errors, $this->validate($keyword, $options));
+                $errors = array_merge($errors, $this->validate($keyword, $options));
             } else {
-                array_merge($errors, $this->validateAfterSchema($keyword, $options));
+                $errors = array_merge($errors, $this->validateAfterSchema($keyword, $options));
             }
 
             if (empty($errors)) {

--- a/plugin/exo/Validator/JsonSchema/Question/QuestionValidator.php
+++ b/plugin/exo/Validator/JsonSchema/Question/QuestionValidator.php
@@ -65,6 +65,15 @@ class QuestionValidator extends JsonSchemaValidator
             ];
         }
 
+        if (!isset($question->score)) {
+            // No question with no score
+            // this is not in the schema because this will become optional when exercise without scores will be implemented
+            $errors[] = [
+                'path' => '/score',
+                'message' => 'Question score is required',
+            ];
+        }
+
         if (!$this->validatorCollector->hasHandlerForMimeType($question->type)) {
             $errors[] = [
                 'path' => '/type',
@@ -78,7 +87,7 @@ class QuestionValidator extends JsonSchemaValidator
                 ];
             } else {
                 // Forward to the correct handler
-                array_merge($errors, $this->validatorCollector->validateMimeType($question, $options));
+                $errors = array_merge($errors, $this->validatorCollector->validateMimeType($question, $options));
             }
         }
 

--- a/plugin/exo/Validator/JsonSchema/Question/Type/ClozeTypeValidator.php
+++ b/plugin/exo/Validator/JsonSchema/Question/Type/ClozeTypeValidator.php
@@ -72,6 +72,13 @@ class ClozeTypeValidator extends JsonSchemaValidator implements QuestionHandlerI
             return $hole->id;
         }, $question->holes);
 
+        if (count($question->holes) !== count($question->solutions)) {
+            $errors[] = [
+                'path' => '/solutions',
+                'message' => 'there must be the same number of solutions and holes',
+            ];
+        }
+
         foreach ($question->solutions as $index => $solution) {
             if (!in_array($solution->holeId, $holeIds)) {
                 $errors[] = [
@@ -81,7 +88,7 @@ class ClozeTypeValidator extends JsonSchemaValidator implements QuestionHandlerI
             }
 
             // Validates hole keywords
-            array_merge($errors, $this->keywordValidator->validateCollection($solution->answers, ['validateScore' => true]));
+            $errors = array_merge($errors, $this->keywordValidator->validateCollection($solution->answers, ['validateScore' => true]));
         }
 
         return $errors;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no

- Changes the Exercise API "export" endpoint to use the new API (not used by the player and I needed it to test with a REST client).
- Fixes various bugs in update.
- Adds GUID on questions and uses it in the API.
- Adds more tests
- Finishes implementation for Open / Cloze / Words (need to be tested)
- Makes Question::title optional

In the validation of the Question, I've made the property `score` required.
This is a required info for now, but when we will have implemented exercise without scores, it will become optional. That's why I've not made it directly in the schema (I would have need to update all example files).

This needs **migrations and additional installer to be run**.

ping @pitrackster, @stefk 