### PR TITLE
[CoreBundle] CLI doctrine migration handling.

### DIFF
--- a/main/core/Command/DatabaseIntegrity/MigrationsCheckerCommand.php
+++ b/main/core/Command/DatabaseIntegrity/MigrationsCheckerCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\CoreBundle\Command\DatabaseIntegrity;
+
+use Claroline\CoreBundle\Command\Traits\BaseCommandTrait;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrationsCheckerCommand extends ContainerAwareCommand
+{
+    use BaseCommandTrait;
+
+    private $params = [
+        'bundle' => 'The bundle name: ',
+        'version' => 'The migration version: ',
+    ];
+
+    protected function configure()
+    {
+        $this->setName('claroline:migrations:check')
+            ->setDescription('This command allows you to add populate the doctrine migration table. It might be improved later');
+        $this->configureParams();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $version = $input->getArgument('version');
+        $bundle = $input->getArgument('bundle');
+        $manager = $this->getContainer()->get('claroline.manager.migration_manager');
+
+        if (!$manager->exists($bundle, $version)) {
+            $output->writeln('Marking migration...');
+            $manager->mark($bundle, $version);
+        } else {
+            $output->writeln('Migration already exists.');
+        }
+    }
+}

--- a/main/core/Command/Traits/BaseCommandTrait.php
+++ b/main/core/Command/Traits/BaseCommandTrait.php
@@ -11,12 +11,24 @@
 
 namespace Claroline\CoreBundle\Command\Traits;
 
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 trait BaseCommandTrait
 {
     use BaseCommandTrait;
+
+    public function configureParams()
+    {
+        $args = [];
+
+        foreach ($this->params as $param => $def) {
+            $args[] = new InputArgument($param, InputArgument::REQUIRED, $def);
+        }
+
+        $this->setDefinition($args);
+    }
 
     public function interact(InputInterface $input, OutputInterface $output)
     {

--- a/main/core/Manager/MigrationManager.php
+++ b/main/core/Manager/MigrationManager.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\CoreBundle\Manager;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Doctrine\DBAL\Migrations\Version;
+use JMS\DiExtraBundle\Annotation as DI;
+
+/**
+ * @DI\Service("claroline.manager.migration_manager")
+ */
+class MigrationManager
+{
+    /**
+     * @DI\InjectParams({
+     *      "connection" = @DI\Inject("database_connection")
+     * })
+     */
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function exists($bundle, $version)
+    {
+        $version = $this->buildVersion($bundle, $version);
+
+        return $version->isMigrated();
+    }
+
+    public function mark($bundle, $version)
+    {
+        $version = $this->buildVersion($bundle, $version);
+        $version->markMigrated();
+
+        return $this;
+    }
+
+    private function buildVersion($bundle, $version)
+    {
+        $bundle = strtolower($bundle);
+        $config = new Configuration($this->connection);
+        $config->setMigrationsTableName('doctrine_'.$bundle.'_versions');
+        $config->setMigrationsNamespace(ucfirst($bundle)); // required but useless
+        $config->setMigrationsDirectory(ucfirst($bundle)); // idem
+
+        return new Version($config, $version, 'stdClass');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #1028

This simple CLI tool allows us to add entries in doctrine table when they're missing easily without having to go into mysql/phpmyadmin and try to find what we need (because these tables are hard to read).

There is also a manager because we used to do that manually in updaters and we could get it wrong.

`php app/console claroline:migration:check clarolinecorebundle 20150428152724`

The previous line will add the entry in the databse if it doesn't exists.


