### PR TITLE
[CoreBundle] Check if importer exists (Fixes #1433)

### DIFF
--- a/main/core/Manager/TransferManager.php
+++ b/main/core/Manager/TransferManager.php
@@ -256,11 +256,14 @@ class TransferManager
 
         foreach ($data['tools'] as $tool) {
             $importer = $this->getImporterByName($tool['tool']['type']);
-            $importer->setWorkspace($workspace);
 
-            if (isset($tool['tool']['data']) && $importer instanceof RichTextInterface) {
-                $data['data'] = $tool['tool']['data'];
-                $importer->format($data);
+            if ($importer) {
+                $importer->setWorkspace($workspace);
+
+                if (isset($tool['tool']['data']) && $importer instanceof RichTextInterface) {
+                    $data['data'] = $tool['tool']['data'];
+                    $importer->format($data);
+                }
             }
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #1433

There are no activity importer so we have to check the condition.
We might add it later (at least we check it exists now because there isn't an importer for each resource type).


