### PR TITLE
[CoreBundle] User csv validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "friendsofsymfony/jsrouting-bundle": "~1.5",
         "friendsofsymfony/oauth-server-bundle": "~1.4",
         "friendsofsymfony/rest-bundle": "1.7.9",
-        "egulias/email-validator": "2.1.1",
+        "egulias/email-validator": "1.2.13",
         "gedmo/doctrine-extensions": "~2.3",
         "gregwar/captcha-bundle": "1.0.12",
         "guzzle/http": "~3.1",

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "friendsofsymfony/jsrouting-bundle": "~1.5",
         "friendsofsymfony/oauth-server-bundle": "~1.4",
         "friendsofsymfony/rest-bundle": "1.7.9",
+        "egulias/email-validator": "2.1.1",
         "gedmo/doctrine-extensions": "~2.3",
         "gregwar/captcha-bundle": "1.0.12",
         "guzzle/http": "~3.1",

--- a/main/core/Command/Import/CreateUserFromCsvCommand.php
+++ b/main/core/Command/Import/CreateUserFromCsvCommand.php
@@ -87,7 +87,7 @@ class CreateUserFromCsvCommand extends ContainerAwareCommand
         }
 
         $options['ignore-update'] = $input->getOption('ignore-update');
-
+        $options['single-validate'] = !$input->getOption('validate');
         $userManager = $this->getContainer()->get('claroline.manager.user_manager');
         $userManager->importUsers(
             $users,

--- a/main/core/Entity/User.php
+++ b/main/core/Entity/User.php
@@ -134,7 +134,7 @@ class User extends AbstractRoleSubject implements Serializable, AdvancedUserInte
      *
      * @ORM\Column(unique=true)
      * @Assert\NotBlank()
-     * @Assert\Email(checkMX = false)
+     * @Assert\Email(strict = true)
      * @Groups({"api_user", "api_user_min"})
      * @SerializedName("mail")
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no

Better email validation for users (with 3rd party suggested library by symfony2).
Also allows the csv user imports to continue by CLI and show wich users weren't imported due t validations errors. 


