### PR TITLE
[FlashCardBundle] Fix err 500 caused by bad migration (8.x)

### DIFF
--- a/plugin/flashcard/Migrations/pdo_mysql/Version20161103101521.php
+++ b/plugin/flashcard/Migrations/pdo_mysql/Version20161103101521.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Claroline\FlashCardBundle\Migrations\pdo_mysql;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution.
+ *
+ * Generation date: 2016/11/03 10:15:28
+ */
+class Version20161103101521 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql('
+            ALTER TABLE claro_fcbundle_field_value 
+            ADD mimetype VARCHAR(255) NOT NULL, 
+            ADD type_discr VARCHAR(255) NOT NULL, 
+            ADD alt LONGTEXT DEFAULT NULL
+        ');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql('
+            ALTER TABLE claro_fcbundle_field_value 
+            DROP mimetype, 
+            DROP type_discr, 
+            DROP alt
+        ');
+    }
+}

--- a/plugin/flashcard/Resources/modules/flashcard/listNote.partial.html
+++ b/plugin/flashcard/Resources/modules/flashcard/listNote.partial.html
@@ -35,7 +35,7 @@
               <img data-ng-if="fieldValue.type == 'image'"
                    class="img-responsive img-thumbnail"
                    style="width: 80%"
-                   src="{{ fieldValue.value }}"
+                   ng-src="{{ fieldValue.value }}"
                    alt="{{ fieldValue.alt}}" />
             </td>
             <td class="col-xs-2 text-center">
@@ -101,7 +101,7 @@
               <img data-ng-if="question.type == 'image'"
                    class="img-responsive img-thumbnail"
                    style="width: 80%"
-                   src="{{ question.value }}"
+                   ng-src="{{ question.value }}"
                    alt="{{ question.alt}}" />
             </td>
             <td colspan="{{ vm.maxColspan(note) / card.card_type.answers.length }}"
@@ -119,7 +119,7 @@
               <img data-ng-if="answer.type == 'image'"
                    class="img-responsive img-thumbnail"
                    style="width: 80%"
-                   src="{{ answer.value }}"
+                   ng-src="{{ answer.value }}"
                    alt="{{ answer.alt}}" />
             </td>
             <td class="col-xs-2 text-center"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

This PR comes to fix errors found by @CPASimUSante on the 8.x.
- Error 500 on page `create_note` and `list_notes`
- JS error on page `list_notes`

This PR is the same as #1515 but for the 8.x branch. This is a correction of the #1521.