### PR TITLE
[CoreBundle] Added 'use strict' inside script for old-themes, removed from npm command

### DIFF
--- a/main/core/Resources/scripts/build-old-themes.js
+++ b/main/core/Resources/scripts/build-old-themes.js
@@ -1,3 +1,4 @@
+'use strict'
 const path = require('path')
 const fs = require('fs')
 const shell = require('shelljs')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | 

Added 'use strict' inside build-old-themes.js script and removed it from npm command in package.json



