### PR TITLE
Small ui fixes in desktop tools and notification configuration

### DIFF
--- a/main/core/Resources/views/Tool/desktop/parameters/toolProperties.html.twig
+++ b/main/core/Resources/views/Tool/desktop/parameters/toolProperties.html.twig
@@ -97,7 +97,7 @@
                 </tbody>
             </table>
 
-            <div class="panel-footer text-right">
+            <div class="panel-footer">
                 <button id="edit-tools-btn" type="submit" class="btn btn-primary">
                     {{ 'edit'|trans({}, 'platform') }}
                 </button>

--- a/main/core/Resources/views/Tool/desktop/parameters/toolProperties.html.twig
+++ b/main/core/Resources/views/Tool/desktop/parameters/toolProperties.html.twig
@@ -25,89 +25,90 @@
     }}
 {% endblock %}
 
-{% block section_content %}
-
-    <div class="panel-heading">
-        <h3 class="panel-title">{{ title }}</h3>
-    </div>
-    <div class="panel-body">
-        <form id="desktop-tool-form" action="{{ path('claro_desktop_tools_roles_edit', {'type': type}) }}">
-            <div class="table-responsive">
-                <table id="tool-table"  class="table table-striped table-bordered table-condensed">
-                    <thead>
-                        <tr>
-                            <th>{{ 'tool'|trans({}, 'platform') }}</th>
-                            <th>{{ 'visible'|trans({}, 'platform') }}</th>
-                        </tr>
-                    </thead>
-                    <tbody id="tools-table-body">
-                        {% for adminOrderedTool in adminOrderedTools %}
-                            {% set tool = adminOrderedTool.getTool() %}
-                            {% set toolName = tool.getName() %}
-                            <tr class="row-locked-tool text-muted">
-                                <td>
-                                    <i class="fa fa-{{ tool.getClass() }}"></i>
-                                    {% if toolName == 'parameters' %}
-                                        {{ 'preferences'|trans({}, 'platform') }}
-                                    {% else %}
-                                        {{ toolName|lower|trans({}, 'tools') }}
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    <input
-                                        type="checkbox"
-                                        class="chk-tool-visible"
-                                        value="1"
-                                        disabled
-                                        {% if adminOrderedTool.isVisibleInDesktop() %} checked {% endif %}
-                                    />
-                                </td>
-                            </tr>
-                        {% endfor %}
-
-                        {% for orderedTool in orderedTools %}
-                            {% set tool = orderedTool.getTool() %}
-                            {% set toolName = tool.getName() %}
-                            <tr class="row-tool-config"
-                                data-tool-id="{{ tool.getId () }}"
-                                data-ordered-tool-id="{{ orderedTool.getId () }}"
-                            >
-                                <td>
-                                    <span class="fa fa-sort text-muted"></span>
-                                    &nbsp;
-                                    &nbsp;
-                                    <i class="fa fa-{{ tool.getClass() }}"></i>
-                                    {% if toolName == 'parameters' %}
-                                        {{ 'preferences'|trans({}, 'platform') }}
-                                    {% else %}
-                                        {{ toolName|lower|trans({}, 'tools') }}
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    <input
-                                        type="checkbox"
-                                        class="chk-tool-visible"
-                                        value="1"
-                                        name="chk-tool-{{ tool.getId() }}"
-                                        {% if tool.isDesktopRequired() or tool.getName() == 'home' %} disabled {% endif %}
-                                        {% if tool.isVisible() %} checked {% endif %}
-                                    />
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+{% block section_panel %}
+    <form id="desktop-tool-form" action="{{ path('claro_desktop_tools_roles_edit', {'type': type}) }}">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">{{ title }}</h3>
             </div>
-            <button id="edit-tools-btn" href="{{ path('claro_desktop_parameters_menu') }}" class="btn btn-primary">
-                {{ 'edit'|trans({}, 'platform') }}
-            </button>
-            <a class="btn btn-default" href="{{ path('claro_desktop_parameters_menu') }}">
-                {{ 'cancel'|trans({}, 'platform') }}
-            </a>
-        </form>
-    </div>
-    <div id="datas-box" data-type="{{ type }}">
-    </div>
+
+            <table id="tool-table" class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>{{ 'tool'|trans({}, 'platform') }}</th>
+                        <th>{{ 'visible'|trans({}, 'platform') }}</th>
+                    </tr>
+                </thead>
+                <tbody id="tools-table-body">
+                {% for adminOrderedTool in adminOrderedTools %}
+                    {% set tool = adminOrderedTool.getTool() %}
+                    {% set toolName = tool.getName() %}
+                    <tr class="row-locked-tool text-muted">
+                        <td>
+                            <i class="fa fa-{{ tool.getClass() }}"></i>
+                            {% if toolName == 'parameters' %}
+                                {{ 'preferences'|trans({}, 'platform') }}
+                            {% else %}
+                                {{ toolName|lower|trans({}, 'tools') }}
+                            {% endif %}
+                        </td>
+                        <td>
+                            <input
+                                    type="checkbox"
+                                    class="chk-tool-visible"
+                                    value="1"
+                                    disabled
+                                    {% if adminOrderedTool.isVisibleInDesktop() %} checked {% endif %}
+                            />
+                        </td>
+                    </tr>
+                {% endfor %}
+
+                {% for orderedTool in orderedTools %}
+                    {% set tool = orderedTool.getTool() %}
+                    {% set toolName = tool.getName() %}
+                    <tr class="row-tool-config"
+                        data-tool-id="{{ tool.getId () }}"
+                        data-ordered-tool-id="{{ orderedTool.getId () }}"
+                    >
+                        <td>
+                            <span class="fa fa-fw fa-sort text-muted"></span>
+                            &nbsp;
+                            &nbsp;
+                            <i class="fa fa-fw fa-{{ tool.getClass() }}"></i>
+                            {% if toolName == 'parameters' %}
+                                {{ 'preferences'|trans({}, 'platform') }}
+                            {% else %}
+                                {{ toolName|lower|trans({}, 'tools') }}
+                            {% endif %}
+                        </td>
+                        <td>
+                            <input
+                                    type="checkbox"
+                                    class="chk-tool-visible"
+                                    value="1"
+                                    name="chk-tool-{{ tool.getId() }}"
+                                    {% if tool.isDesktopRequired() or tool.getName() == 'home' %} disabled {% endif %}
+                                    {% if tool.isVisible() %} checked {% endif %}
+                            />
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+
+            <div class="panel-footer text-right">
+                <button id="edit-tools-btn" type="submit" class="btn btn-primary">
+                    {{ 'edit'|trans({}, 'platform') }}
+                </button>
+                <a class="btn btn-default" href="{{ path('claro_desktop_parameters_menu') }}">
+                    {{ 'cancel'|trans({}, 'platform') }}
+                </a>
+            </div>
+        </div>
+    </form>
+
+    <div id="datas-box" data-type="{{ type }}"></div>
 {% endblock %}
 {% block javascripts %}
     {{ parent() }}

--- a/plugin/notification/Resources/views/Parameters/config.html.twig
+++ b/plugin/notification/Resources/views/Parameters/config.html.twig
@@ -70,7 +70,7 @@
                 </tbody>
             </table>
 
-            <div class="panel-footer text-right">
+            <div class="panel-footer">
                 <button type="submit" id="edit-tools-btn" class="btn btn-primary">
                     {{ 'edit'|trans({}, 'platform') }}
                 </button>

--- a/plugin/notification/Resources/views/Parameters/config.html.twig
+++ b/plugin/notification/Resources/views/Parameters/config.html.twig
@@ -3,7 +3,7 @@
 {% set title = 'notification_user_configuration' %}
 
 {% block title %}
-    {{ parent() ~ ' - ' ~ title | trans({}, "platform") | striptags | raw }}
+    {{ parent() ~ ' - ' ~ title | trans({}, 'notification') | striptags | raw }}
 {% endblock %}
 
 {% block breadcrumb %}
@@ -21,62 +21,68 @@
     }}
 {% endblock %}
 
-{% block section_content %}
-    <div class="panel-heading">
-        <h3 class="panel-title">{{ title|trans({}, 'notification') }}</h3>
-    </div>
-    <div class="panel-body">
-        <form id="notification-user-parameters-form" action="{{ path('icap_notification_save_user_parameters') }}" method="post">
-            <div class="table-responsive">
-                <table id="notification-parameters-types-table" class="table table-striped table-bordered table-condensed">
-                    <thead>
-                        <tr>
-                            <th>{{ 'type'|trans({}, 'platform') }}</th>
-                            <th>{{ 'visible'|trans({}, 'platform') }}</th>
-                            <th><a class="text-primary" href="{{ path("icap_notification_rss", {"rssId" : rssId}) }}" target="_blank">{{ 'rss_visible'|trans({}, 'notification') }} <i class="fa fa-rss"></i></a></th>
-                        </tr>
-                    </thead>
-                    <tbody class="types-table-body">
-                        {% for type in types %}
-                            <tr>
-                                <td>
-                                    {{ type.name|trans({}, 'notification')|trans({}, 'resource') }}
-                                </td>
-                                <td>
-                                    <input
-                                        type="checkbox"
-                                        class="chk-type-visible"
-                                        value="visible"
-                                        name="{{ type.name }}[]"
-                                        {% if type.visible %} checked {% endif %}
-                                    />
-                                </td>
-                                <td>
-                                    <input
-                                        type="checkbox"
-                                        class="chk-type-visible"
-                                        value="rss"
-                                        name="{{ type.name }}[]"
-                                        {% if type.rssVisible %} checked {% endif %}
-                                    />
-                                </td>
-                            </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
+{% block section_panel %}
+    <form id="notification-user-parameters-form" action="{{ path('icap_notification_save_user_parameters') }}" method="post">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">{{ title|trans({}, 'notification') }}</h3>
             </div>
-            <button type="submit" id="edit-tools-btn" href="{{ path('claro_desktop_parameters_menu') }}" class="btn btn-primary">
-                {{ 'edit'|trans({}, 'platform') }}
-            </button>
-            <a class="btn btn-success" href="{{ path('icap_notification_regenerate_rss_url') }}">
-                {{ 'rss_url_regenerate'|trans({}, 'notification') }}
-            </a>
-            <a class="btn btn-default" href="{{ path('claro_desktop_parameters_menu') }}">
-                {{ 'cancel'|trans({}, 'platform') }}
-            </a>
-        </form>
-    </div>
 
+            <table id="notification-parameters-types-table" class="table table-striped">
+                <thead>
+                <tr>
+                    <th>{{ 'type'|trans({}, 'platform') }}</th>
+                    <th>{{ 'visible'|trans({}, 'platform') }}</th>
+                    <th>
+                        <a class="text-primary" href="{{ path("icap_notification_rss", {"rssId" : rssId}) }}">
+                            <i class="fa fa-fw fa-rss"></i>
+                            {{ 'rss_visible'|trans({}, 'notification') }}
+                        </a>
+                    </th>
+                </tr>
+                </thead>
+                <tbody class="types-table-body">
+                {% for type in types %}
+                    <tr>
+                        <td>
+                            {{ type.name|trans({}, 'notification')|trans({}, 'resource') }}
+                        </td>
+                        <td>
+                            <input
+                                    type="checkbox"
+                                    class="chk-type-visible"
+                                    value="visible"
+                                    name="{{ type.name }}[]"
+                                    {% if type.visible %} checked {% endif %}
+                            />
+                        </td>
+                        <td>
+                            <input
+                                    type="checkbox"
+                                    class="chk-type-visible"
+                                    value="rss"
+                                    name="{{ type.name }}[]"
+                                    {% if type.rssVisible %} checked {% endif %}
+                            />
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+
+            <div class="panel-footer text-right">
+                <button type="submit" id="edit-tools-btn" class="btn btn-primary">
+                    {{ 'edit'|trans({}, 'platform') }}
+                </button>
+                <a class="btn btn-default" href="{{ path('icap_notification_regenerate_rss_url') }}">
+                    {{ 'rss_url_regenerate'|trans({}, 'notification') }}
+                </a>
+                <a class="btn btn-default" href="{{ path('claro_desktop_parameters_menu') }}">
+                    {{ 'cancel'|trans({}, 'platform') }}
+                </a>
+            </div>
+        </div>
+    </form>
 {% endblock %}
 
 {% block stylesheets %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Cleans up the DOM and bootstrap classes in desktop tools and notification configuration.
This also adds a missing translation in Notification and slightly enhance responsivity on mobile screen.

Note : in the screenshots, the buttons have been moved to the right. But they are more commonly at the left in the config section so I've placed them back to their original position (I've just not updated the screenshots).

**Tools** [before]
![tool-configuration-old](https://cloud.githubusercontent.com/assets/5363219/20864879/a262bfc4-ba01-11e6-8653-5332ac745f7e.png)


**Tools** [after]
![tool-configuration-new](https://cloud.githubusercontent.com/assets/5363219/20864880/a57bfd9c-ba01-11e6-94b9-dd0fc501dbe8.png)

**Notification** [before]
![notification-configuration-old](https://cloud.githubusercontent.com/assets/5363219/20864884/b62bae80-ba01-11e6-94e1-e85df66ed56e.png)

**Notification** [after]
![notification-configuration-new](https://cloud.githubusercontent.com/assets/5363219/20864881/adb3d5d4-ba01-11e6-952a-2035b0beb41c.png)




