### PR TITLE
[Notification] Fix extra strong tag in rss

### DIFF
--- a/plugin/notification/Resources/views/Notification/rss.xml.twig
+++ b/plugin/notification/Resources/views/Notification/rss.xml.twig
@@ -10,7 +10,7 @@
                 {% set notification = notificationViewer.notification %}
                 <item>
                 {% if notificationViews[notificationViewer.id] is defined %}
-                    <title>{{ notificationViews[notificationViewer.id]|striptags("<strong><span>")|rssMessage }}</title>
+                    <title>{{ notificationViews[notificationViewer.id]|striptags("<span>")|rssMessage }}</title>
                 {% else %}
                     {% set user = null %}
                     {% set resource = null %}
@@ -34,5 +34,3 @@
 
     </channel>
 </rss>
-
-


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | https://github.com/claroline/Distribution/issues/1640

Fix dangling <strong> tag in rss notification



