### PR TITLE
Use travis full VM (increase available memory)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+
 language: php
 
 php:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no

<!-- please add a description here if needed -->

Another attempt at solving memory issues on travis. If we use old VMs instead of docker containers, we should have a few more Go available. https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments 

