### PR TITLE
allows capitalized rootfile for webresource

### DIFF
--- a/plugin/web-resource/Listener/WebResourceListener.php
+++ b/plugin/web-resource/Listener/WebResourceListener.php
@@ -66,6 +66,12 @@ class WebResourceListener
         'web/index.htm',
         'index.html',
         'index.htm',
+        'web/SCO_0001/Default.html',
+        'web/SCO_0001/Default.htm',
+        'web/Index.html',
+        'web/Index.htm',
+        'Index.html',
+        'Index.htm',
     ];
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Fixed tickets | https://github.com/claroline/Distribution/issues/1619

allows index.html, index.htm, default.html, default.htm, Index.html, Index.htm, Default.html, Default.htm as rootfile in a webresource.

I added those files in the whitelist array. I could also have lowerized the check : if (strtolower(....)), but since there was some mixed case in the list, i didn't because i wasn't sure what it could imply in the corresponding file
 
**BEFORE :**
```php
    private $defaultIndexFiles = [
        'web/SCO_0001/default.html',          <=
        'web/SCO_0001/default.htm',           <=
        'web/index.html',
        'web/index.htm',
        'index.html',
        'index.htm',
    ];
```
