### PR TITLE
Fixing import default values

### DIFF
--- a/main/core/Library/Transfert/ConfigurationBuilders/Tools/HomeImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/Tools/HomeImporter.php
@@ -13,17 +13,17 @@ namespace Claroline\CoreBundle\Library\Transfert\ConfigurationBuilders\Tools;
 
 use Claroline\CoreBundle\Entity\Home\HomeTab;
 use Claroline\CoreBundle\Entity\Home\HomeTabConfig;
+use Claroline\CoreBundle\Entity\Widget\WidgetDisplayConfig;
 use Claroline\CoreBundle\Entity\Widget\WidgetHomeTabConfig;
 use Claroline\CoreBundle\Entity\Widget\WidgetInstance;
 use Claroline\CoreBundle\Entity\Workspace\Workspace;
-use Claroline\CoreBundle\Entity\Widget\WidgetDisplayConfig;
-use Claroline\CoreBundle\Persistence\ObjectManager;
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-use JMS\DiExtraBundle\Annotation as DI;
-use Symfony\Component\Config\Definition\Processor;
 use Claroline\CoreBundle\Library\Transfert\Importer;
 use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
+use Claroline\CoreBundle\Persistence\ObjectManager;
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
 
 /**
  * @DI\Service("claroline.tool.home_importer")
@@ -54,12 +54,6 @@ class HomeImporter extends Importer implements ConfigurationInterface, RichTextI
         return $treeBuilder;
     }
 
-    public function getConfigBuilder(ValidateToolConfigEvent $event)
-    {
-        $event->setConfigurationBuilder($this->getConfigTreeBuilder());
-        $event->stopPropagation();
-    }
-
     private function addHomeSection($rootNode)
     {
         $rootNode
@@ -73,7 +67,7 @@ class HomeImporter extends Importer implements ConfigurationInterface, RichTextI
                                         ->children()
                                             ->arrayNode('widget')
                                                 ->children()
-                                                    ->scalarNode('name')->isRequired()->end()
+                                                    ->scalarNode('name')->defaultNull()->end()
                                                     ->scalarNode('type')->isRequired()->end()
                                                     ->scalarNode('row')->defaultNull()->end()
                                                     ->scalarNode('column')->defaultNull()->end()
@@ -107,10 +101,11 @@ class HomeImporter extends Importer implements ConfigurationInterface, RichTextI
     public function validate(array $data)
     {
         $processor = new Processor();
-        $this->result = $processor->processConfiguration($this, $data);
+        $data = $processor->processConfiguration($this, $data);
+
         //home widget validations
-        foreach ($data['data'] as $tab) {
-            foreach ($tab['tab'] as $widgets) {
+        foreach ($data as &$tab) {
+            foreach ($tab['tab'] as &$widgets) {
                 $toolImporter = null;
                 if (isset($widgets['widgets'])) {
                     foreach ($widgets['widgets'] as $widget) {
@@ -122,12 +117,14 @@ class HomeImporter extends Importer implements ConfigurationInterface, RichTextI
 
                         if (isset($widget['widget']['data']) && $toolImporter) {
                             $widgetdata = $widget['widget']['data'];
-                            $toolImporter->validate($widgetdata);
+                            $widget['widget']['data'] = $toolImporter->validate($widgetdata);
                         }
                     }
                 }
             }
         }
+
+        return $data;
     }
 
     public function import(array $array, $workspace)
@@ -155,14 +152,15 @@ class HomeImporter extends Importer implements ConfigurationInterface, RichTextI
                 $widgetType = $this->om->getRepository('ClarolineCoreBundle:Widget\Widget')
                     ->findOneByName($widget['widget']['type']);
                 $widgetInstance = new WidgetInstance();
-                $widgetInstance->setName($widget['widget']['name']);
+                $name = $widget['widget']['name'] ? $widget['widget']['name'] : uniqid();
+                $widgetInstance->setName($name);
                 $widgetInstance->setWidget($widgetType);
                 $widgetInstance->setWorkspace($this->getWorkspace());
                 $widgetInstance->setIsAdmin(false);
                 $widgetInstance->setIsDesktop(false);
                 $this->om->persist($widgetInstance);
-
                 $widgetConfig = new WidgetDisplayConfig();
+
                 if ($widget['widget']['row']) {
                     $widgetConfig->setRow($widget['widget']['row']);
                 }
@@ -227,13 +225,13 @@ class HomeImporter extends Importer implements ConfigurationInterface, RichTextI
 
                 $widgetDisplayConfigs = $this->container->get('claroline.manager.widget_manager')->getWidgetDisplayConfigsByWorkspaceAndWidgets(
                     $workspace,
-                    array($widgetConfig->getWidgetInstance())
+                    [$widgetConfig->getWidgetInstance()]
                 );
 
                 $widgetDisplayConfig = isset($widgetDisplayConfigs[0]) ? $widgetDisplayConfigs[0] : null;
 
                 //export the widget content here
-                $widgetData = array('widget' => array(
+                $widgetData = ['widget' => [
                     'name' => $widgetConfig->getWidgetInstance()->getName(),
                     'type' => $widgetConfig->getWidgetInstance()->getWidget()->getName(),
                     'data' => $data,
@@ -242,15 +240,15 @@ class HomeImporter extends Importer implements ConfigurationInterface, RichTextI
                     'width' => $widgetDisplayConfig ? $widgetDisplayConfig->getWidth() : null,
                     'height' => $widgetDisplayConfig ? $widgetDisplayConfig->getHeight() : null,
                     'color' => $widgetDisplayConfig ? $widgetDisplayConfig->getColor() : null,
-                ));
+                ]];
 
                 $widgets[] = $widgetData;
             }
 
-            $tabs[] = array('tab' => array(
+            $tabs[] = ['tab' => [
                 'name' => $homeTab->getHomeTab()->getName(),
                 'widgets' => $widgets,
-            ));
+            ]];
         }
 
         return $tabs;

--- a/main/core/Library/Transfert/ConfigurationBuilders/Tools/ResourceManagerImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/Tools/ResourceManagerImporter.php
@@ -108,6 +108,8 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                 }
             }
         }
+
+        return $data['data'];
     }
 
     public function import(array $data, $workspace, $entityRoles, Directory $root, $fullImport = true)

--- a/main/core/Library/Transfert/ConfigurationBuilders/ToolsImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/ToolsImporter.php
@@ -133,7 +133,7 @@ class ToolsImporter extends Importer implements ConfigurationInterface
         $processor = new Processor();
         $processor->processConfiguration($this, $data);
 
-        foreach ($data['tools'] as $tool) {
+        foreach ($data['tools'] as $key => &$tool) {
             $importer = $this->getImporterByName($tool['tool']['type']);
 
             if (!$importer && isset($tool['tool']['data'])) {
@@ -142,9 +142,11 @@ class ToolsImporter extends Importer implements ConfigurationInterface
 
             if (isset($tool['tool']['data'])) {
                 $array['data'] = $tool['tool']['data'];
-                $importer->validate($array);
+                $tool['tool']['data'] = $importer->validate($array);
             }
         }
+
+        return $data;
     }
 
     public function import(array $tools, Workspace $workspace, array $entityRoles, Directory $root)

--- a/main/core/Manager/TransferManager.php
+++ b/main/core/Manager/TransferManager.php
@@ -74,19 +74,23 @@ class TransferManager
         if ($validateProperties) {
             if (isset($data['properties'])) {
                 $properties['properties'] = $data['properties'];
+                //get the validate return one day
                 $importer->validate($properties);
             }
         }
 
         if (isset($data['roles'])) {
             $roles['roles'] = $data['roles'];
+            //get the validate return one day
             $rolesImporter->validate($roles);
         }
 
         if (isset($data['tools'])) {
             $tools['tools'] = $data['tools'];
-            $toolsImporter->validate($tools);
+            $data['tools'] = $toolsImporter->validate($tools)['tools'];
         }
+
+        return $data;
     }
 
     /**
@@ -105,22 +109,14 @@ class TransferManager
      */
     public function populateWorkspace(
         Workspace $workspace,
+        $data,
         File $template,
         Directory $root,
         array $entityRoles,
-        $isValidated = false,
         $importRoles = true
     ) {
-        $data = $this->container->get('claroline.manager.workspace_manager')->getTemplateData($template);
         $this->om->startFlushSuite();
-        $data = $this->reorderData($data);
-        $this->setImporters($template, $workspace->getCreator());
         $this->setWorkspaceForImporter($workspace);
-
-        if (!$isValidated) {
-            $this->validate($data, false);
-        }
-
         if ($importRoles) {
             $importedRoles = $this->getImporterByName('roles')->import($data['roles'], $workspace);
             $this->om->forceFlush();
@@ -144,7 +140,6 @@ class TransferManager
         }
 
         $this->importRichText($workspace, $data);
-        $this->container->get('claroline.manager.workspace_manager')->removeTemplate($template);
     }
 
     /**
@@ -178,10 +173,11 @@ class TransferManager
         //just to be sure doctrine is ok before doing all the workspace
 
         $this->om->startFlushSuite();
-        $this->setImporters($template, $workspace->getCreator());
+        $data = $this->reorderData($data);
+        $this->setImporters($template, $workspace->getCreator(), $data);
 
         if (!$isValidated) {
-            $this->validate($data, false);
+            $data = $this->validate($data, false);
             $isValidated = true;
         }
 
@@ -241,7 +237,8 @@ class TransferManager
         );
 
         $this->log('Populating the workspace...');
-        $this->populateWorkspace($workspace, $template, $root, $entityRoles, true, false);
+        $this->populateWorkspace($workspace, $data, $template, $root, $entityRoles, false);
+        $this->container->get('claroline.manager.workspace_manager')->removeTemplate($template);
         $this->container->get('claroline.manager.workspace_manager')->createWorkspace($workspace);
         $this->om->endFlushSuite();
 
@@ -406,12 +403,11 @@ class TransferManager
      * @param File  $template
      * @param array $data
      */
-    private function setImporters(File $template, User $owner)
+    private function setImporters(File $template, User $owner, array $data)
     {
         foreach ($this->listImporters as $importer) {
             $importer->setRootPath($this->templateDirectory.DIRECTORY_SEPARATOR.$template->getBasename());
             $importer->setOwner($owner);
-            $data = $this->container->get('claroline.manager.workspace_manager')->getTemplateData($template);
             $importer->setConfiguration($data);
             $importer->setListImporters($this->listImporters);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

The current import mechanism didn't use the default value set in the configuration because we never returned the data after the processor fired the processConfiguration method.

It fixes my use case where I needed the default values for the home widgets. I didn't change the rest.

I also slightly simplified the import method in the TransferManager (removes some useless/duplicated code).
