### PR TITLE
[CoreBundle] Fixing workspace import 

### DIFF
--- a/main/core/Library/Transfert/ConfigurationBuilders/Tools/ResourceManagerImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/Tools/ResourceManagerImporter.php
@@ -108,6 +108,8 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                 }
             }
         }
+
+        return $data['data'];
     }
 
     public function import(array $data, $workspace, $entityRoles, Directory $root, $fullImport = true)

--- a/main/core/Library/Transfert/ConfigurationBuilders/ToolsImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/ToolsImporter.php
@@ -133,7 +133,7 @@ class ToolsImporter extends Importer implements ConfigurationInterface
         $processor = new Processor();
         $processor->processConfiguration($this, $data);
 
-        foreach ($data['tools'] as $tool) {
+        foreach ($data['tools'] as &$tool) {
             $importer = $this->getImporterByName($tool['tool']['type']);
 
             if (!$importer && isset($tool['tool']['data'])) {
@@ -142,9 +142,11 @@ class ToolsImporter extends Importer implements ConfigurationInterface
 
             if (isset($tool['tool']['data'])) {
                 $array['data'] = $tool['tool']['data'];
-                $importer->validate($array);
+                $tool['tool']['data'] = $importer->validate($array);
             }
         }
+
+        return $data;
     }
 
     public function import(array $tools, Workspace $workspace, array $entityRoles, Directory $root)

--- a/main/core/Manager/TransferManager.php
+++ b/main/core/Manager/TransferManager.php
@@ -85,8 +85,10 @@ class TransferManager
 
         if (isset($data['tools'])) {
             $tools['tools'] = $data['tools'];
-            $toolsImporter->validate($tools);
+            $data['tools'] = $toolsImporter->validate($tools);
         }
+
+        return $data;
     }
 
     /**
@@ -106,15 +108,13 @@ class TransferManager
     public function populateWorkspace(
         Workspace $workspace,
         File $template,
+        array $data,
         Directory $root,
         array $entityRoles,
         $isValidated = false,
         $importRoles = true
     ) {
-        $data = $this->container->get('claroline.manager.workspace_manager')->getTemplateData($template);
         $this->om->startFlushSuite();
-        $data = $this->reorderData($data);
-        $this->setImporters($template, $workspace->getCreator());
         $this->setWorkspaceForImporter($workspace);
 
         if (!$isValidated) {
@@ -166,6 +166,7 @@ class TransferManager
         $isValidated = false
     ) {
         $data = $this->container->get('claroline.manager.workspace_manager')->getTemplateData($template, true);
+        $data = $this->reorderData($data);
 
         if ($workspace->getCode() === null) {
             $workspace->setCode($data['parameters']['code']);
@@ -181,7 +182,7 @@ class TransferManager
         $this->setImporters($template, $workspace->getCreator());
 
         if (!$isValidated) {
-            $this->validate($data, false);
+            $data = $this->validate($data, false);
             $isValidated = true;
         }
 
@@ -241,7 +242,7 @@ class TransferManager
         );
 
         $this->log('Populating the workspace...');
-        $this->populateWorkspace($workspace, $template, $root, $entityRoles, true, false);
+        $this->populateWorkspace($workspace, $template, $data, $root, $entityRoles, true, false);
         $this->container->get('claroline.manager.workspace_manager')->createWorkspace($workspace);
         $this->om->endFlushSuite();
 

--- a/main/core/Manager/TransferManager.php
+++ b/main/core/Manager/TransferManager.php
@@ -87,7 +87,8 @@ class TransferManager
 
         if (isset($data['tools'])) {
             $tools['tools'] = $data['tools'];
-            $data['tools'] = $toolsImporter->validate($tools)['tools'];
+            $dataTools = $toolsImporter->validate($tools);
+            $data['tools'] = $dataTools['tools'];
         }
 
         return $data;

--- a/main/core/Manager/TransferManager.php
+++ b/main/core/Manager/TransferManager.php
@@ -74,18 +74,20 @@ class TransferManager
         if ($validateProperties) {
             if (isset($data['properties'])) {
                 $properties['properties'] = $data['properties'];
+                //get the validate return one day
                 $importer->validate($properties);
             }
         }
 
         if (isset($data['roles'])) {
             $roles['roles'] = $data['roles'];
+            //get the validate return one day
             $rolesImporter->validate($roles);
         }
 
         if (isset($data['tools'])) {
             $tools['tools'] = $data['tools'];
-            $data['tools'] = $toolsImporter->validate($tools);
+            $data['tools'] = $toolsImporter->validate($tools)['tools'];
         }
 
         return $data;
@@ -107,20 +109,14 @@ class TransferManager
      */
     public function populateWorkspace(
         Workspace $workspace,
-        File $template,
         array $data,
+        File $template,
         Directory $root,
         array $entityRoles,
-        $isValidated = false,
         $importRoles = true
     ) {
         $this->om->startFlushSuite();
         $this->setWorkspaceForImporter($workspace);
-
-        if (!$isValidated) {
-            $this->validate($data, false);
-        }
-
         if ($importRoles) {
             $importedRoles = $this->getImporterByName('roles')->import($data['roles'], $workspace);
             $this->om->forceFlush();
@@ -144,7 +140,6 @@ class TransferManager
         }
 
         $this->importRichText($workspace, $data);
-        $this->container->get('claroline.manager.workspace_manager')->removeTemplate($template);
     }
 
     /**
@@ -179,7 +174,8 @@ class TransferManager
         //just to be sure doctrine is ok before doing all the workspace
 
         $this->om->startFlushSuite();
-        $this->setImporters($template, $workspace->getCreator());
+        $data = $this->reorderData($data);
+        $this->setImporters($template, $workspace->getCreator(), $data);
 
         if (!$isValidated) {
             $data = $this->validate($data, false);
@@ -242,7 +238,8 @@ class TransferManager
         );
 
         $this->log('Populating the workspace...');
-        $this->populateWorkspace($workspace, $template, $data, $root, $entityRoles, true, false);
+        $this->populateWorkspace($workspace, $data, $template, $root, $entityRoles, false);
+        $this->container->get('claroline.manager.workspace_manager')->removeTemplate($template);
         $this->container->get('claroline.manager.workspace_manager')->createWorkspace($workspace);
         $this->om->endFlushSuite();
 
@@ -407,12 +404,11 @@ class TransferManager
      * @param File  $template
      * @param array $data
      */
-    private function setImporters(File $template, User $owner)
+    private function setImporters(File $template, User $owner, array $data)
     {
         foreach ($this->listImporters as $importer) {
             $importer->setRootPath($this->templateDirectory.DIRECTORY_SEPARATOR.$template->getBasename());
             $importer->setOwner($owner);
-            $data = $this->container->get('claroline.manager.workspace_manager')->getTemplateData($template);
             $importer->setConfiguration($data);
             $importer->setListImporters($this->listImporters);
 

--- a/main/core/Resources/translations/platform.de.yml
+++ b/main/core/Resources/translations/platform.de.yml
@@ -363,7 +363,7 @@ filter_actions: 'Filtrer les actions'
 filters: Filtres
 find_workspaces: 'Tous les espaces d''activités publics'
 firstName: Vorname
-first_name: vorname
+first_name: Vorname
 footer: 'Pied de page'
 for_period: 'sur la période du :'
 forgot_password: 'Mot de passe oublié ?'
@@ -593,7 +593,7 @@ my_public_documents: 'Mes documents publics'
 my_resources: 'Mes ressources'
 my_workspace: 'Espace personnel'
 my_workspaces: 'Mes espaces d''activités'
-name: 'Name'
+name: Name
 name_required: 'Nom requis'
 new: Nouveau
 new_folder_in_current_ws: 'Nouveau répertoire dans l''espace d''activité courant'
@@ -656,7 +656,7 @@ parameters_save_error: 'Une erreur est survenue pendant la sauvegarde des param�
 parameters_save_success: 'Paramètres sauvegardés avec succès.'
 passed: Réussi
 passing_score: 'Score pour réussir'
-password: 'Passwort'
+password: Passwort
 password_mismatch: 'Les mots de passe ne correspondent pas.'
 password_ok: 'Votre mot de passe a été modifié. Vous pouvez maintenant vous connecter.'
 paste: Coller


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

The current import mechanism didn't use the default value set in the configuration because we never returned the data after the processor fired the processConfiguration method.

It fixes my use case where I needed the default values for the home widgets. I didn't change the rest.

I also slightly simplified the import method in the TransferManager (removes some useless/duplicated code).


