### PR TITLE
[exo-v2] No server interaction in player + bug fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "reselect": "^2.5.3",
     "d3": "^4.4.0",
     "svg4everybody": "^2.1.2",
-    "whatwg-fetch": "^2.0.1"
+    "whatwg-fetch": "^2.0.1",
+    "uuid": "^3.0.1"
   },
   "files": [
     "package.json"

--- a/plugin/exo/Controller/Api/PaperController.php
+++ b/plugin/exo/Controller/Api/PaperController.php
@@ -86,7 +86,7 @@ class PaperController extends AbstractController
      * @EXT\Route("/{id}", name="exercise_export_paper")
      * @EXT\Method("GET")
      * @EXT\ParamConverter("paper", class="UJMExoBundle:Attempt\Paper", options={"mapping": {"id": "uuid"}})
-     * @EXT\ParamConverter("user", converter="current_user", options={"allowAnonymous"=true})
+     * @EXT\ParamConverter("user", converter="current_user")
      *
      * @param Exercise $exercise
      * @param Paper    $paper
@@ -94,11 +94,10 @@ class PaperController extends AbstractController
      *
      * @return JsonResponse
      */
-    public function getAction(Exercise $exercise, Paper $paper, User $user = null)
+    public function getAction(Exercise $exercise, Paper $paper, User $user)
     {
         $this->assertHasPermission('OPEN', $exercise);
 
-        // ATTENTION : As is, anonymous have access to all the other anonymous Papers !!!
         if (!$this->isAdmin($paper->getExercise()) && $paper->getUser() !== $user) {
             // Only administrator or the User attached can see a Paper
             throw new AccessDeniedException();

--- a/plugin/exo/Entity/Attempt/Answer.php
+++ b/plugin/exo/Entity/Attempt/Answer.php
@@ -45,7 +45,7 @@ class Answer
      *
      * @ORM\Column(name="nb_tries", type="integer")
      */
-    private $tries = 1;
+    private $tries = 0;
 
     /**
      * The answer data formatted in string for DB storage.

--- a/plugin/exo/Manager/AttemptManager.php
+++ b/plugin/exo/Manager/AttemptManager.php
@@ -184,7 +184,6 @@ class AttemptManager
                     $answer = $this->answerManager->create($answerData);
                 } else {
                     $answer = $this->answerManager->update($existingAnswer, $answerData);
-                    $answer->setTries($answer->getTries() + 1);
                 }
             } catch (ValidationException $e) {
                 throw new ValidationException('Submitted answers are invalid', $e->getErrors());
@@ -194,6 +193,7 @@ class AttemptManager
             $score = $this->questionManager->calculateScore($answer->getQuestion(), $answer);
             $answer->setScore($score);
             $answer->setIp($clientIp);
+            $answer->setTries($answer->getTries() + 1);
 
             $paper->addAnswer($answer);
             $submitted[] = $answer;

--- a/plugin/exo/Resources/modules/quiz/components/quiz.jsx
+++ b/plugin/exo/Resources/modules/quiz/components/quiz.jsx
@@ -58,7 +58,7 @@ function mapStateToProps(state) {
   return {
     id: select.id(state),
     title: select.title(state),
-    viewMode: state.viewMode,
+    viewMode: select.viewMode(state),
     editable: select.editable(state),
     empty: select.empty(state),
     published: select.published(state),
@@ -72,7 +72,7 @@ function mapDispatchToProps(dispatch) {
       dispatch(actions.updateViewMode(mode))
     },
     playQuiz(id) {
-      dispatch(playerActions.playQuiz(id))
+      dispatch(playerActions.play(id))
     },
     saveQuiz() {
       dispatch(editorActions.saveQuiz())

--- a/plugin/exo/Resources/modules/quiz/components/quiz.jsx
+++ b/plugin/exo/Resources/modules/quiz/components/quiz.jsx
@@ -34,7 +34,7 @@ let Quiz = props =>
 Quiz.propTypes = {
   quiz: T.shape({
     id: T.string.isRequired,
-    title: T.string.isRequired,
+    title: T.string.isRequired
   }).isRequired,
   steps: T.object.isRequired,
   editable: T.bool.isRequired,

--- a/plugin/exo/Resources/modules/quiz/components/quiz.jsx
+++ b/plugin/exo/Resources/modules/quiz/components/quiz.jsx
@@ -20,20 +20,27 @@ import {
 
 let Quiz = props =>
   <div>
-    <PageHeader title={props.title} />
+    <PageHeader title={props.quiz.title} />
     {props.editable &&
-      <TopBar {...props} />
+      <TopBar
+        {...props}
+        id={props.quiz.id}
+        testQuiz={() => props.testQuiz(props.quiz, props.steps)}
+      />
     }
     {viewComponent(props.viewMode)}
   </div>
 
 Quiz.propTypes = {
-  id: T.string.isRequired,
-  title: T.string.isRequired,
+  quiz: T.shape({
+    id: T.string.isRequired,
+    title: T.string.isRequired,
+  }).isRequired,
+  steps: T.object.isRequired,
   editable: T.bool.isRequired,
   viewMode: T.string.isRequired,
   updateViewMode: T.func.isRequired,
-  playQuiz: T.func.isRequired,
+  testQuiz: T.func.isRequired,
   saveQuiz: T.func.isRequired
 }
 
@@ -56,8 +63,8 @@ function viewComponent(view) {
 
 function mapStateToProps(state) {
   return {
-    id: select.id(state),
-    title: select.title(state),
+    quiz: select.quiz(state),
+    steps: select.steps(state),
     viewMode: select.viewMode(state),
     editable: select.editable(state),
     empty: select.empty(state),
@@ -71,8 +78,8 @@ function mapDispatchToProps(dispatch) {
     updateViewMode(mode) {
       dispatch(actions.updateViewMode(mode))
     },
-    playQuiz(id) {
-      dispatch(playerActions.play(id))
+    testQuiz(quiz, steps) {
+      dispatch(playerActions.play(quiz, steps, null, true))
     },
     saveQuiz() {
       dispatch(editorActions.saveQuiz())

--- a/plugin/exo/Resources/modules/quiz/components/top-bar.jsx
+++ b/plugin/exo/Resources/modules/quiz/components/top-bar.jsx
@@ -10,6 +10,7 @@ import {generateUrl} from './../../utils/routing'
 import {
   VIEW_OVERVIEW,
   VIEW_EDITOR,
+  VIEW_PLAYER,
   VIEW_PAPERS
 } from './../enums'
 
@@ -65,7 +66,7 @@ export const TopBar = props =>
         }
       </Nav>
       <Nav pullRight>
-        {!props.empty &&
+        {!props.empty && VIEW_PLAYER !== props.viewMode &&
           <NavItem eventKey={5} href="#" onClick={() => {
             props.playQuiz(props.id)
           }}>
@@ -100,12 +101,14 @@ export const TopBar = props =>
             </MenuItem>
           </NavDropdown>
         }
-        <NavItem eventKey={7} href="#" onClick={() => {
-          props.saveQuiz()
-        }}>
-          <span className="fa fa-fw fa-save"></span>
-          {t('save')}
-        </NavItem>
+        {VIEW_EDITOR === props.viewMode &&
+          <NavItem eventKey={7} href="#" onClick={() => {
+            props.saveQuiz()
+          }}>
+            <span className="fa fa-fw fa-save"></span>
+            {t('save')}
+          </NavItem>
+        }
       </Nav>
     </Navbar.Collapse>
   </Navbar>
@@ -115,6 +118,7 @@ TopBar.propTypes = {
   empty: T.bool.isRequired,
   published: T.bool.isRequired,
   hasPapers: T.bool.isRequired,
+  viewMode: T.string.isRequired,
   updateViewMode: T.func.isRequired,
   playQuiz: T.func.isRequired,
   saveQuiz: T.func.isRequired

--- a/plugin/exo/Resources/modules/quiz/components/top-bar.jsx
+++ b/plugin/exo/Resources/modules/quiz/components/top-bar.jsx
@@ -67,9 +67,7 @@ export const TopBar = props =>
       </Nav>
       <Nav pullRight>
         {!props.empty && VIEW_PLAYER !== props.viewMode &&
-          <NavItem eventKey={5} href="#" onClick={() => {
-            props.playQuiz(props.id)
-          }}>
+          <NavItem eventKey={5} href="#" onClick={props.testQuiz}>
             <span className="fa fa-fw fa-play"></span>
             {tex('exercise_try')}
           </NavItem>
@@ -120,6 +118,6 @@ TopBar.propTypes = {
   hasPapers: T.bool.isRequired,
   viewMode: T.string.isRequired,
   updateViewMode: T.func.isRequired,
-  playQuiz: T.func.isRequired,
+  testQuiz: T.func.isRequired,
   saveQuiz: T.func.isRequired
 }

--- a/plugin/exo/Resources/modules/quiz/components/top-bar.test.js
+++ b/plugin/exo/Resources/modules/quiz/components/top-bar.test.js
@@ -23,7 +23,7 @@ describe('<TopBar/>', () => {
         'viewMode',
         'updateViewMode',
         'saveQuiz',
-        'playQuiz',
+        'testQuiz',
         'hasPapers'
       ]
     )
@@ -38,12 +38,12 @@ describe('<TopBar/>', () => {
         viewMode={[]}
         updateViewMode={[]}
         saveQuiz={[]}
-        playQuiz={[]}
+        testQuiz={[]}
       />
     )
     ensure.invalidProps(
       'TopBar',
-      ['id', 'empty', 'published', 'viewMode', 'updateViewMode', 'saveQuiz', 'playQuiz']
+      ['id', 'empty', 'published', 'viewMode', 'updateViewMode', 'saveQuiz', 'testQuiz']
     )
   })
 
@@ -57,7 +57,7 @@ describe('<TopBar/>', () => {
         viewMode="editor"
         updateViewMode={() => {}}
         saveQuiz={() => {}}
-        playQuiz={() => {}}
+        testQuiz={() => {}}
       />
     )
     ensure.propTypesOk()

--- a/plugin/exo/Resources/modules/quiz/components/top-bar.test.js
+++ b/plugin/exo/Resources/modules/quiz/components/top-bar.test.js
@@ -20,6 +20,7 @@ describe('<TopBar/>', () => {
         'id',
         'empty',
         'published',
+        'viewMode',
         'updateViewMode',
         'saveQuiz',
         'playQuiz',
@@ -34,6 +35,7 @@ describe('<TopBar/>', () => {
         id={[]}
         empty={[]}
         published={{}}
+        viewMode={[]}
         updateViewMode={[]}
         saveQuiz={[]}
         playQuiz={[]}
@@ -41,7 +43,7 @@ describe('<TopBar/>', () => {
     )
     ensure.invalidProps(
       'TopBar',
-      ['id', 'empty', 'published', 'updateViewMode', 'saveQuiz', 'playQuiz']
+      ['id', 'empty', 'published', 'viewMode', 'updateViewMode', 'saveQuiz', 'playQuiz']
     )
   })
 
@@ -52,6 +54,7 @@ describe('<TopBar/>', () => {
         empty={true}
         published={false}
         hasPapers={false}
+        viewMode="editor"
         updateViewMode={() => {}}
         saveQuiz={() => {}}
         playQuiz={() => {}}

--- a/plugin/exo/Resources/modules/quiz/decorators.test.js
+++ b/plugin/exo/Resources/modules/quiz/decorators.test.js
@@ -76,7 +76,7 @@ describe('Decorator', () => {
           interruptible: false,
           showCorrectionAt: SHOW_CORRECTION_AT_VALIDATION,
           correctionDate: '',
-          anonymous: false,
+          anonymizeAttempts: false,
           showScoreAt: SHOW_SCORE_AT_CORRECTION,
           showStatistics: false,
           showFullCorrection: true
@@ -203,7 +203,7 @@ describe('Decorator', () => {
           interruptible: false,
           showCorrectionAt: SHOW_CORRECTION_AT_VALIDATION,
           correctionDate: '',
-          anonymous: false,
+          anonymizeAttempts: false,
           showScoreAt: SHOW_SCORE_AT_CORRECTION,
           showStatistics: false,
           showFullCorrection: true

--- a/plugin/exo/Resources/modules/quiz/defaults.js
+++ b/plugin/exo/Resources/modules/quiz/defaults.js
@@ -19,7 +19,7 @@ const quiz = {
     interruptible: false,
     showCorrectionAt: SHOW_CORRECTION_AT_VALIDATION,
     correctionDate: '',
-    anonymous: false,
+    anonymizeAttempts: false,
     showScoreAt: SHOW_SCORE_AT_CORRECTION,
     showStatistics: false,
     showFullCorrection: true
@@ -52,7 +52,7 @@ const hint = {
 }
 
 const answer = {
-  tries: 1,
+  tries: 0,
   usedHints: [],
   data: undefined
 }

--- a/plugin/exo/Resources/modules/quiz/editor/components/quiz-editor.jsx
+++ b/plugin/exo/Resources/modules/quiz/editor/components/quiz-editor.jsx
@@ -238,10 +238,10 @@ const Correction = props =>
       </select>
     </FormGroup>
     <CheckGroup
-      checkId="quiz-anonymous"
-      checked={props.parameters.anonymous}
+      checkId="quiz-anonymizeAttempts"
+      checked={props.parameters.anonymizeAttempts}
       label={t('anonymous')}
-      onChange={checked => props.onChange('parameters.anonymous', checked)}
+      onChange={checked => props.onChange('parameters.anonymizeAttempts', checked)}
     />
     <CheckGroup
       checkId="quiz-showFullCorrection"
@@ -263,7 +263,7 @@ Correction.propTypes = {
     showScoreAt: T.string.isRequired,
     showFullCorrection: T.bool.isRequired,
     showStatistics: T.bool.isRequired,
-    anonymous: T.bool.isRequired,
+    anonymizeAttempts: T.bool.isRequired,
     correctionDate: T.string
   }).isRequired,
   onChange: T.func.isRequired
@@ -335,7 +335,7 @@ QuizEditor.propTypes = {
       interruptible: T.bool.isRequired,
       showCorrectionAt: T.string.isRequired,
       correctionDate: T.string,
-      anonymous: T.bool.isRequired,
+      anonymizeAttempts: T.bool.isRequired,
       showScoreAt: T.string.isRequired,
       showStatistics: T.bool.isRequired,
       showFullCorrection: T.bool.isRequired

--- a/plugin/exo/Resources/modules/quiz/editor/components/quiz-editor.test.js
+++ b/plugin/exo/Resources/modules/quiz/editor/components/quiz-editor.test.js
@@ -69,10 +69,10 @@ describe('<QuizEditor/>', () => {
     ensure.equal(updatedPath, 'title')
     ensure.equal(updatedValue, 'FOO')
 
-    const anonymous = form.find('input#quiz-anonymous')
-    ensure.equal(anonymous.length, 1, 'has anonymous checkbox')
-    anonymous.simulate('change', {target: {checked: true}})
-    ensure.equal(updatedPath, 'parameters.anonymous')
+    const anonymizeAttempts = form.find('input#quiz-anonymizeAttempts')
+    ensure.equal(anonymizeAttempts.length, 1, 'has anonymizeAttempts checkbox')
+    anonymizeAttempts.simulate('change', {target: {checked: true}})
+    ensure.equal(updatedPath, 'parameters.anonymizeAttempts')
     ensure.equal(updatedValue, true)
   })
 })
@@ -92,7 +92,7 @@ function fixture() {
       interruptible: true,
       showCorrectionAt: 'never',
       correctionDate: null,
-      anonymous: false,
+      anonymizeAttempts: false,
       showScoreAt: 'never',
       showStatistics: true,
       showFullCorrection: false

--- a/plugin/exo/Resources/modules/quiz/index.js
+++ b/plugin/exo/Resources/modules/quiz/index.js
@@ -2,7 +2,7 @@ import {Quiz} from './quiz'
 
 const container = document.querySelector('.quiz-container')
 const rawQuizData = JSON.parse(container.dataset.quiz)
-const noServer = JSON.parse(container.dataset.noServer)
+const noServer = !!container.dataset.noServer
 const quiz = new Quiz(rawQuizData, noServer)
 
 quiz.render(container)

--- a/plugin/exo/Resources/modules/quiz/index.js
+++ b/plugin/exo/Resources/modules/quiz/index.js
@@ -2,6 +2,7 @@ import {Quiz} from './quiz'
 
 const container = document.querySelector('.quiz-container')
 const rawQuizData = JSON.parse(container.dataset.quiz)
-const quiz = new Quiz(rawQuizData)
+const noServer = JSON.parse(container.dataset.noServer)
+const quiz = new Quiz(rawQuizData, noServer)
 
 quiz.render(container)

--- a/plugin/exo/Resources/modules/quiz/overview/overview.jsx
+++ b/plugin/exo/Resources/modules/quiz/overview/overview.jsx
@@ -58,7 +58,7 @@ const Parameters = props =>
               {tex(props.parameters.randomPick ? 'no' : 'yes')}
             </Parameter>
             <Parameter name="anonymous">
-              {tex(props.parameters.anonymous ? 'yes' : 'no')}
+              {tex(props.parameters.anonymizeAttempts ? 'yes' : 'no')}
             </Parameter>
             <Parameter name="test_exit">
               {tex(props.parameters.interruptible ? 'yes' : 'no')}
@@ -95,7 +95,7 @@ Parameters.propTypes = {
     interruptible: T.bool.isRequired,
     showCorrectionAt: T.string.isRequired,
     correctionDate: T.string,
-    anonymous: T.bool.isRequired,
+    anonymizeAttempts: T.bool.isRequired,
     showScoreAt: T.string.isRequired
   }).isRequired,
   meta: T.shape({
@@ -201,7 +201,7 @@ Overview.propTypes = {
     interruptible: T.bool.isRequired,
     showCorrectionAt: T.string.isRequired,
     correctionDate: T.string,
-    anonymous: T.bool.isRequired,
+    anonymizeAttempts: T.bool.isRequired,
     showScoreAt: T.string.isRequired
   }).isRequired,
   meta: T.shape({

--- a/plugin/exo/Resources/modules/quiz/overview/overview.jsx
+++ b/plugin/exo/Resources/modules/quiz/overview/overview.jsx
@@ -9,6 +9,7 @@ import {
   quizTypes,
   SHOW_CORRECTION_AT_DATE
 } from './../enums'
+import {actions as playerActions} from './../player/actions'
 
 const Parameter = props =>
   <tr>
@@ -103,6 +104,16 @@ Parameters.propTypes = {
   })
 }
 
+const StartButton = props =>
+  <button type="button" className="btn btn-start btn-lg btn-primary btn-block" onClick={props.onClick}>
+    <span className="fa fa-fw fa-play"></span>
+    {tex('exercise_start')}
+  </button>
+
+StartButton.propTypes = {
+  onClick: T.func.isRequired
+}
+
 const Layout = props =>
   <div className="quiz-overview">
     <div className="panel-body">
@@ -145,7 +156,7 @@ const Layout = props =>
             </a>
           }
           {!props.empty &&
-            <button-start data-paper-link="true" />
+            <StartButton onClick={props.play} />
           }
         </div>
       </div>
@@ -162,7 +173,8 @@ Layout.propTypes = {
   }).isRequired,
   meta: T.shape({
     created: T.string.isRequired
-  })
+  }),
+  play: T.func.isRequired
 }
 
 class Overview extends Component {
@@ -176,11 +188,16 @@ class Overview extends Component {
   render() {
     return (
       <Layout
-        {...this.props}
+        empty={this.props.empty}
+        editable={this.props.editable}
+        description={this.props.quiz.description}
+        parameters={this.props.quiz.parameters}
+        meta={this.props.quiz.meta}
+        play={() => this.props.play(this.props.quiz, this.props.steps)}
         additionalInfo={this.state.additionalInfo}
         onAdditionalToggle={() => this.setState({
-          additionalInfo: !this.state.additionalInfo}
-        )}
+          additionalInfo: !this.state.additionalInfo
+        })}
       />
     )
   }
@@ -189,36 +206,48 @@ class Overview extends Component {
 Overview.propTypes = {
   empty: T.bool.isRequired,
   editable: T.bool.isRequired,
-  description: T.string.isRequired,
-  parameters: T.shape({
-    showMetadata: T.bool.isRequired,
-    type: T.string.isRequired,
-    randomOrder: T.string.isRequired,
-    randomPick: T.string.isRequired,
-    pick: T.number.isRequired,
-    duration: T.number.isRequired,
-    maxAttempts: T.number.isRequired,
-    interruptible: T.bool.isRequired,
-    showCorrectionAt: T.string.isRequired,
-    correctionDate: T.string,
-    anonymizeAttempts: T.bool.isRequired,
-    showScoreAt: T.string.isRequired
+  quiz: T.shape({
+    description: T.string.isRequired,
+    parameters: T.shape({
+      showMetadata: T.bool.isRequired,
+      type: T.string.isRequired,
+      randomOrder: T.string.isRequired,
+      randomPick: T.string.isRequired,
+      pick: T.number.isRequired,
+      duration: T.number.isRequired,
+      maxAttempts: T.number.isRequired,
+      interruptible: T.bool.isRequired,
+      showCorrectionAt: T.string.isRequired,
+      correctionDate: T.string,
+      anonymizeAttempts: T.bool.isRequired,
+      showScoreAt: T.string.isRequired
+    }).isRequired,
+    meta: T.shape({
+      created: T.string.isRequired
+    }).isRequired
   }).isRequired,
-  meta: T.shape({
-    created: T.string.isRequired
-  }).isRequired
+  steps: T.object.isRequired,
+  play: T.func.isRequired
 }
 
 function mapStateToProps(state) {
   return {
     empty: select.empty(state),
     editable: select.editable(state),
-    meta: select.meta(state),
-    description: select.description(state),
-    parameters: select.parameters(state)
+    quiz: select.quiz(state),
+    steps: select.steps(state)
   }
 }
 
-const ConnectedOverview = connect(mapStateToProps)(Overview)
+function mapDispatchToProps(dispatch) {
+  return {
+    play(quiz, steps) {
+      // TODO : optimisation - we may want to get a local paper if exists to avoid calling the server
+      dispatch(playerActions.play(quiz, steps))
+    }
+  }
+}
+
+const ConnectedOverview = connect(mapStateToProps, mapDispatchToProps)(Overview)
 
 export {ConnectedOverview as Overview}

--- a/plugin/exo/Resources/modules/quiz/overview/overview.jsx
+++ b/plugin/exo/Resources/modules/quiz/overview/overview.jsx
@@ -166,7 +166,7 @@ const Layout = props =>
 Layout.propTypes = {
   empty: T.bool.isRequired,
   editable: T.bool.isRequired,
-  description: T.string.isRequired,
+  description: T.string,
   onAdditionalToggle: T.func.isRequired,
   parameters: T.shape({
     showMetadata: T.bool.isRequired
@@ -175,6 +175,10 @@ Layout.propTypes = {
     created: T.string.isRequired
   }),
   play: T.func.isRequired
+}
+
+Layout.defaultProps = {
+  description: null
 }
 
 class Overview extends Component {
@@ -207,7 +211,7 @@ Overview.propTypes = {
   empty: T.bool.isRequired,
   editable: T.bool.isRequired,
   quiz: T.shape({
-    description: T.string.isRequired,
+    description: T.string,
     parameters: T.shape({
       showMetadata: T.bool.isRequired,
       type: T.string.isRequired,

--- a/plugin/exo/Resources/modules/quiz/overview/overview.jsx
+++ b/plugin/exo/Resources/modules/quiz/overview/overview.jsx
@@ -145,7 +145,7 @@ const Layout = props =>
             </a>
           }
           {!props.empty &&
-            <button-start data-paper-link="true"/>
+            <button-start data-paper-link="true" />
           }
         </div>
       </div>

--- a/plugin/exo/Resources/modules/quiz/overview/overview.test.js
+++ b/plugin/exo/Resources/modules/quiz/overview/overview.test.js
@@ -71,7 +71,7 @@ describe('<Overview/>', () => {
           interruptible: true,
           showCorrectionAt: SHOW_CORRECTION_AT_DATE,
           correctionDate: '2015/05/12',
-          anonymous: true,
+          anonymizeAttempts: true,
           showScoreAt: SHOW_SCORE_AT_CORRECTION
         },
         meta: {

--- a/plugin/exo/Resources/modules/quiz/overview/overview.test.js
+++ b/plugin/exo/Resources/modules/quiz/overview/overview.test.js
@@ -27,9 +27,8 @@ describe('<Overview/>', () => {
         /* can't tests these ones because selectors are hard-coded */
         // 'empty',
         // 'editable',
-        'meta',
-        'description',
-        'parameters'
+        'quiz',
+        'steps'
       ]
     )
   })
@@ -40,7 +39,8 @@ describe('<Overview/>', () => {
         description: 456,
         parameters: true,
         meta: true
-      }
+      },
+      steps: 123
     })
     shallow(<Overview store={store}/>)
     ensure.invalidProps(
@@ -49,9 +49,8 @@ describe('<Overview/>', () => {
         /* same than above */
         // 'empty',
         // 'editable',
-        'meta',
-        'description',
-        'parameters'
+        'quiz',
+        'steps'
       ]
     )
   })

--- a/plugin/exo/Resources/modules/quiz/overview/overview.test.js
+++ b/plugin/exo/Resources/modules/quiz/overview/overview.test.js
@@ -27,8 +27,8 @@ describe('<Overview/>', () => {
         /* can't tests these ones because selectors are hard-coded */
         // 'empty',
         // 'editable',
-        'quiz',
-        'steps'
+        'steps',
+        'quiz.parameters'
       ]
     )
   })
@@ -49,7 +49,7 @@ describe('<Overview/>', () => {
         /* same than above */
         // 'empty',
         // 'editable',
-        'quiz',
+        'quiz.description',
         'steps'
       ]
     )
@@ -77,7 +77,8 @@ describe('<Overview/>', () => {
           created: '2016-12-12',
           published: true
         }
-      }
+      },
+      steps: {}
     })
     const overview = mount(<Overview store={store}/>)
 

--- a/plugin/exo/Resources/modules/quiz/papers/generator.js
+++ b/plugin/exo/Resources/modules/quiz/papers/generator.js
@@ -1,4 +1,4 @@
-import collection from 'lodash/collection'
+import {shuffle, sampleSize} from 'lodash/collection'
 
 import {makeId} from './../../utils/utils'
 
@@ -47,7 +47,7 @@ function generateStructure(quiz, steps, previousPaper = null) {
   // Shuffles steps if needed
   if ( (!previousPaper && SHUFFLE_ONCE === parameters.randomOrder)
     || SHUFFLE_ALWAYS === parameters.randomOrder) {
-    pickedSteps = collection.shuffle(pickedSteps)
+    pickedSteps = shuffle(pickedSteps)
   }
 
   // Pick questions for each steps and generate structure
@@ -68,7 +68,7 @@ function generateStructure(quiz, steps, previousPaper = null) {
     // Shuffles items if needed
     if ( (!previousPaper && SHUFFLE_ONCE === step.parameters.randomOrder)
       || SHUFFLE_ALWAYS === step.parameters.randomOrder) {
-      pickedItems = collection.shuffle(pickedItems)
+      pickedItems = shuffle(pickedItems)
     }
 
     return {
@@ -91,7 +91,7 @@ function pick(originalSet, count = 0) {
   let picked
   if (0 !== count) {
     // Get a random subset of element
-    picked = collection.sampleSize(originalSet, count).sort((a, b) => {
+    picked = sampleSize(originalSet, count).sort((a, b) => {
       // We need to put the picked items in their original order
       if (originalSet.indexOf(a) < originalSet.indexOf(b)) {
         return -1

--- a/plugin/exo/Resources/modules/quiz/papers/generator.js
+++ b/plugin/exo/Resources/modules/quiz/papers/generator.js
@@ -1,6 +1,8 @@
 import collection from 'lodash/collection'
+
+import {makeId} from './../../utils/utils'
+
 import {
-  SHUFFLE_NEVER,
   SHUFFLE_ONCE,
   SHUFFLE_ALWAYS
 } from './../enums'
@@ -10,20 +12,20 @@ import {
  *
  * @param {object} quiz - the quiz definition
  * @param {object} steps - the list of quiz steps
- * @param {object} items - the list of quiz items
  * @param {object} previousPaper - the previous attempt of the user if any
  *
  * @returns {{number: number, anonymized: boolean, structure}}
  */
-export function generatePaper(quiz, steps, items, previousPaper = null) {
+export function generatePaper(quiz, steps, previousPaper = null) {
   return {
+    id: makeId(),
     number: previousPaper ? previousPaper.number + 1 : 1,
     anonymized: quiz.parameters.anonymizeAttempts,
-    structure: generateStructure(quiz, steps, items, previousPaper)
+    structure: generateStructure(quiz, steps, previousPaper)
   }
 }
 
-function generateStructure(quiz, steps, items, previousPaper = null) {
+function generateStructure(quiz, steps, previousPaper = null) {
   const parameters = quiz.parameters
 
   // The structure of the previous paper if any
@@ -45,7 +47,7 @@ function generateStructure(quiz, steps, items, previousPaper = null) {
   // Shuffles steps if needed
   if ( (!previousPaper && SHUFFLE_ONCE === parameters.randomOrder)
     || SHUFFLE_ALWAYS === parameters.randomOrder) {
-    pickedSteps = collection.shuffle(pickedSteps);
+    pickedSteps = collection.shuffle(pickedSteps)
   }
 
   // Pick questions for each steps and generate structure
@@ -56,7 +58,8 @@ function generateStructure(quiz, steps, items, previousPaper = null) {
     if (previousPaper && SHUFFLE_ONCE === step.parameters.randomPick) {
       // Get picked items from the last user paper
       // Retrieves the list of items of the current step
-      pickedItems = repickQuestions($pickedStep, $previousStructure);
+      const stepStructure = previousStructure.find((step) => step.id === stepId)
+      pickedItems = stepStructure.items.slice(0)
     } else {
       // Pick a new set of questions
       pickedItems = pick(step.items, step.parameters.pick)
@@ -65,13 +68,13 @@ function generateStructure(quiz, steps, items, previousPaper = null) {
     // Shuffles items if needed
     if ( (!previousPaper && SHUFFLE_ONCE === step.parameters.randomOrder)
       || SHUFFLE_ALWAYS === step.parameters.randomOrder) {
-      pickedItems = collection.shuffle(pickedItems);
+      pickedItems = collection.shuffle(pickedItems)
     }
 
     return {
       id: stepId,
       items: pickedItems
-    };
+    }
   })
 }
 
@@ -98,8 +101,8 @@ function pick(originalSet, count = 0) {
       return 0
     })
   } else {
-    picked = originalSet.splice(0);
+    picked = originalSet.slice(0)
   }
 
-  return picked;
+  return picked
 }

--- a/plugin/exo/Resources/modules/quiz/papers/generator.js
+++ b/plugin/exo/Resources/modules/quiz/papers/generator.js
@@ -1,0 +1,105 @@
+import collection from 'lodash/collection'
+import {
+  SHUFFLE_NEVER,
+  SHUFFLE_ONCE,
+  SHUFFLE_ALWAYS
+} from './../enums'
+
+/**
+ * Generate a new paper for a quiz.
+ *
+ * @param {object} quiz - the quiz definition
+ * @param {object} steps - the list of quiz steps
+ * @param {object} items - the list of quiz items
+ * @param {object} previousPaper - the previous attempt of the user if any
+ *
+ * @returns {{number: number, anonymized: boolean, structure}}
+ */
+export function generatePaper(quiz, steps, items, previousPaper = null) {
+  return {
+    number: previousPaper ? previousPaper.number + 1 : 1,
+    anonymized: quiz.parameters.anonymizeAttempts,
+    structure: generateStructure(quiz, steps, items, previousPaper)
+  }
+}
+
+function generateStructure(quiz, steps, items, previousPaper = null) {
+  const parameters = quiz.parameters
+
+  // The structure of the previous paper if any
+  let previousStructure = []
+  if (previousPaper) {
+    previousStructure = previousPaper.slice(0)
+  }
+
+  // Generate the list of step ids for the paper
+  let pickedSteps
+  if (previousPaper && SHUFFLE_ONCE === parameters.randomPick) {
+    // Get picked steps from the last user paper
+    pickedSteps = previousStructure.map((step) => step.id)
+  } else {
+    // Pick a new set of steps
+    pickedSteps = pick(quiz.steps, parameters.pick)
+  }
+
+  // Shuffles steps if needed
+  if ( (!previousPaper && SHUFFLE_ONCE === parameters.randomOrder)
+    || SHUFFLE_ALWAYS === parameters.randomOrder) {
+    pickedSteps = collection.shuffle(pickedSteps);
+  }
+
+  // Pick questions for each steps and generate structure
+  return pickedSteps.map((stepId) => {
+    let step = steps[stepId]
+
+    let pickedItems = []
+    if (previousPaper && SHUFFLE_ONCE === step.parameters.randomPick) {
+      // Get picked items from the last user paper
+      // Retrieves the list of items of the current step
+      pickedItems = repickQuestions($pickedStep, $previousStructure);
+    } else {
+      // Pick a new set of questions
+      pickedItems = pick(step.items, step.parameters.pick)
+    }
+
+    // Shuffles items if needed
+    if ( (!previousPaper && SHUFFLE_ONCE === step.parameters.randomOrder)
+      || SHUFFLE_ALWAYS === step.parameters.randomOrder) {
+      pickedItems = collection.shuffle(pickedItems);
+    }
+
+    return {
+      id: stepId,
+      items: pickedItems
+    };
+  })
+}
+
+/**
+ * Picks a random subset of elements in a collection.
+ * If count is 0, the whole collection is returned.
+ *
+ * @param {Array} originalSet
+ * @param {number} count
+ *
+ * @returns {array}
+ */
+function pick(originalSet, count = 0) {
+  let picked
+  if (0 !== count) {
+    // Get a random subset of element
+    picked = collection.sampleSize(originalSet, count).sort((a, b) => {
+      // We need to put the picked items in their original order
+      if (originalSet.indexOf(a) < originalSet.indexOf(b)) {
+        return -1
+      } else if (originalSet.indexOf(a) > originalSet.indexOf(b)) {
+        return 1
+      }
+      return 0
+    })
+  } else {
+    picked = originalSet.splice(0);
+  }
+
+  return picked;
+}

--- a/plugin/exo/Resources/modules/quiz/player/actions.js
+++ b/plugin/exo/Resources/modules/quiz/player/actions.js
@@ -1,78 +1,117 @@
-import {generateUrl} from './../../utils/routing'
 import {makeActionCreator} from './../../utils/actions'
 import {actions as quizActions} from './../actions'
-import {VIEW_PLAYER} from './../enums'
-import {normalize} from './normalizer'
+import {VIEW_PLAYER, VIEW_OVERVIEW} from './../enums'
+import {api} from './api'
+import {generatePaper} from './../papers/generator'
 
-export const ATTEMPT_START = 'ATTEMPT_START'
-export const STEP_OPEN     = 'STEP_OPEN'
-export const ANSWER_UPDATE = 'ANSWER_UPDATE'
+export const ATTEMPT_START  = 'ATTEMPT_START'
+export const ATTEMPT_FINISH = 'ATTEMPT_FINISH'
+export const STEP_OPEN      = 'STEP_OPEN'
+export const ANSWER_UPDATE  = 'ANSWER_UPDATE'
+export const ANSWERS_SUBMIT = 'ANSWERS_SUBMIT'
 
 export const actions = {}
 
-// TODO : display loader on ajax call
-// TODO : catch any error in the network call.
+function shouldCallServer(state) {
+  // TODO : use selector here
+  return !state.noServer && !state.testMode
+}
 
-actions.playQuiz = (quizId) => {
-  return function (dispatch) {
-    return fetch(generateUrl('exercise_attempt_start', {exerciseId: quizId}), {
-      credentials: 'include',
-      method: 'POST'
-    })
-    .then(response => response.json())
-    .then(json => {
-      const normalized = normalize(json)
+function initPlayer(paper, answers, testMode) {
+  return (dispatch) => {
+    dispatch(actions.startAttempt(paper, answers, testMode))
 
-      dispatch(actions.startAttempt(normalized.paper, normalized.answers))
+    const firstStep = paper.structure[0]
 
-      const firstStep = normalized.paper.structure[0]
-      dispatch(actions.openStep(firstStep.id, firstStep.items))
-      dispatch(quizActions.updateViewMode(VIEW_PLAYER))
-    })
+    dispatch(actions.openStep(firstStep))
+    dispatch(quizActions.updateViewMode(VIEW_PLAYER))
   }
 }
 
-actions.submitQuiz = (quizId, paperId, answers, nextActions) => {
-  return function (dispatch) {
-    const answerRequest = []
-    for (let answer in answers) {
-      if (answers.hasOwnProperty(answer) && answers[answer]._touched) {
-        // Answer has been modified => send it to the server
-        answerRequest.push(answers[answer])
-      }
-    }
-
-    if (0 !== answerRequest.length) {
-      return fetch(generateUrl('exercise_attempt_submit', {exerciseId: quizId, id: paperId}), {
-        credentials: 'include',
-        method: 'PUT',
-        body: JSON.stringify(answerRequest)
-      })
-      .then(() => {
-        if (nextActions) {
-          nextActions(dispatch)
-        }
-      })
-
-      // TODO : catch any error in the network call.
-    } else {
-      nextActions(dispatch)
-    }
-  }
-}
-
-actions.finishQuiz = (quizId, paperId, nextActions) => {
-  return function (dispatch) {
-    return fetch(generateUrl('exercise_attempt_finish', {exerciseId: quizId, id: paperId}), {
-      credentials: 'include',
-      method: 'PUT'
-    })
-    .then(() => {
-      nextActions(dispatch)
-    })
-  }
-}
-
-actions.startAttempt = makeActionCreator(ATTEMPT_START, 'paper', 'answers')
+actions.startAttempt = makeActionCreator(ATTEMPT_START, 'paper', 'answers', 'testMode')
+actions.finishAttempt = makeActionCreator(ATTEMPT_FINISH, 'paper')
+actions.openStep = makeActionCreator(STEP_OPEN, 'step')
 actions.updateAnswer = makeActionCreator(ANSWER_UPDATE, 'questionId', 'answerData')
-actions.openStep = makeActionCreator(STEP_OPEN, 'id', 'items')
+actions.submitAnswers = makeActionCreator(ANSWERS_SUBMIT, 'quizId', 'paperId', 'answers')
+
+actions.play = (quiz, testMode = false) => {
+  return (dispatch, getState) => {
+    if (shouldCallServer(getState())) {
+      // Request a paper from the API and open the player
+      return dispatch((dispatch) => {
+        api
+          .startAttempt(quiz.id)
+          .then((normalizedData) =>
+            dispatch(initPlayer(normalizedData.paper, normalizedData.answers, testMode)
+          )
+        )
+      })
+    } else {
+      // Create a new local paper and open the player
+      // For test mode we never reuse an old paper for generation to avoid obsolete data
+      const paper = generatePaper(quiz, steps, items, !testMode ? previousPaper : null)
+
+      return dispatch(initPlayer(paper, {}, testMode))
+    }
+  }
+}
+
+actions.submit = (quizId, paperId, answers = null) => {
+  return (dispatch, getState) => {
+    let answersPromise
+    if (answers && shouldCallServer(getState())) {
+      // Send answers to the API
+      answersPromise = api.submitAnswers(quizId, paperId, answers)
+    } else {
+      // Nothing to do
+      answersPromise = Promise.resolve()
+    }
+
+    return answersPromise.then(() =>
+      answers ? dispatch(actions.submitAnswers(quizId, paperId, answers)) : null
+    )
+  }
+}
+
+actions.finish = (quizId, paper, pendingAnswers = null) => {
+  return (dispatch, getState) => {
+    // First, submit answers for the current step
+    dispatch(actions.submit(quizId, paper.id, pendingAnswers)).then(() => {
+      let paperPromise
+      if (shouldCallServer(getState())) {
+        // Send finish request to API
+        paperPromise = api.finishAttempt(quizId, paper.id)
+      } else {
+        // Just resolve the current paper (the next actions will mark it as finished)
+        paperPromise = Promise.resolve({paper: paper})
+      }
+
+      return paperPromise.then((normalizedData) =>
+        // Finish the attempt and use quiz config to know what to do next
+        dispatch(actions.handleAttemptEnd(normalizedData.paper))
+      )
+    })
+  }
+}
+
+actions.navigateTo = (quizId, paperId, nextStep, pendingAnswers = null) => {
+  return (dispatch) => {
+    // Submit answers for the current step
+    dispatch(actions.submit(quizId, paperId, pendingAnswers)).then(() =>
+      // Open the requested step
+      dispatch(actions.openStep(nextStep))
+    )
+  }
+}
+
+actions.handleAttemptEnd = (paper) => {
+  return (dispatch) => {
+    // Finish the current attempt
+    dispatch(actions.finishAttempt(paper))
+
+    // We will decide here if we show the correction now or not and where we redirect the user
+
+    // Redirect to the quiz overview
+    dispatch(quizActions.updateViewMode(VIEW_OVERVIEW))
+  }
+}

--- a/plugin/exo/Resources/modules/quiz/player/api.js
+++ b/plugin/exo/Resources/modules/quiz/player/api.js
@@ -1,0 +1,45 @@
+import {generateUrl} from './../../utils/routing'
+import {normalize} from './normalizer'
+
+// TODO : display loader on ajax call
+// TODO : catch any error in the network call.
+
+export const api = {}
+
+api.startAttempt = (quizId) => {
+  return fetch(generateUrl('exercise_attempt_start', {exerciseId: quizId}), {
+    credentials: 'include',
+    method: 'POST'
+  })
+  .then(response => response.json())
+  .then(json => normalize(json))
+}
+
+api.submitAnswers = (quizId, paperId, answers) => {
+  const answerRequest = []
+  for (let answer in answers) {
+    if (answers.hasOwnProperty(answer) && answers[answer]._touched) {
+      // Answer has been modified => send it to the server
+      answerRequest.push(answers[answer])
+    }
+  }
+
+  if (0 !== answerRequest.length) {
+    return fetch(generateUrl('exercise_attempt_submit', {exerciseId: quizId, id: paperId}), {
+      credentials: 'include',
+      method: 'PUT',
+      body: JSON.stringify(answerRequest)
+    })
+  } else {
+    return Promise.resolve()
+  }
+}
+
+api.finishAttempt = (quizId, paperId) => {
+  return fetch(generateUrl('exercise_attempt_finish', {exerciseId: quizId, id: paperId}), {
+    credentials: 'include',
+    method: 'PUT'
+  })
+  .then(response => response.json())
+  .then(json => normalize(json))
+}

--- a/plugin/exo/Resources/modules/quiz/player/components/nav-bar.jsx
+++ b/plugin/exo/Resources/modules/quiz/player/components/nav-bar.jsx
@@ -33,7 +33,7 @@ SubmitButton.propTypes = {
 }
 
 const FinishButton = props =>
-  <button className="btn btn-primary" onClick={props.onClick}>
+  <button className="btn btn-finish btn-primary" onClick={props.onClick}>
     <span className="fa fa-fw fa-sign-out"></span>
     Finish
   </button>
@@ -69,7 +69,7 @@ PlayerNav.propTypes = {
   }),
   navigateTo: T.func.isRequired,
   finish: T.func.isRequired,
-  submit: T.func
+  submit: T.func.isRequired
 }
 
 PlayerNav.defaultProps = {

--- a/plugin/exo/Resources/modules/quiz/player/components/nav-bar.jsx
+++ b/plugin/exo/Resources/modules/quiz/player/components/nav-bar.jsx
@@ -46,7 +46,7 @@ const PlayerNav = props =>
   <nav className="player-nav">
     <div className="backward">
       {props.previous &&
-      <PreviousButton onClick={() => props.navigateTo(props.previous)} />
+        <PreviousButton onClick={() => props.navigateTo(props.previous)} />
       }
     </div>
 
@@ -61,11 +61,11 @@ const PlayerNav = props =>
 PlayerNav.propTypes = {
   next: T.shape({
     id: T.string.isRequired,
-    items: T.arrayOf.arrayOf
+    items: T.arrayOf(T.string).isRequired
   }),
   previous: T.shape({
     id: T.string.isRequired,
-    items: T.arrayOf.arrayOf
+    items: T.arrayOf(T.string).isRequired
   }),
   navigateTo: T.func.isRequired,
   finish: T.func.isRequired,

--- a/plugin/exo/Resources/modules/quiz/player/components/nav-bar.test.js
+++ b/plugin/exo/Resources/modules/quiz/player/components/nav-bar.test.js
@@ -49,8 +49,6 @@ describe('<PlayerNav/>', () => {
   it('renders a navbar', () => {
     const navbar = mount(
       <PlayerNav
-        next={null}
-        previous={null}
         navigateTo={() => true}
         finish={() => true}
         submit={() => true}
@@ -59,22 +57,51 @@ describe('<PlayerNav/>', () => {
     ensure.propTypesOk()
     ensure.equal(navbar.find('.player-nav').length, 1)
 
+    // There is no previous step, so no previous btn
     ensure.equal(navbar.find('.btn-previous').length, 0)
+
+    // There is no next step, so no next btn
     ensure.equal(navbar.find('.btn-next').length, 0)
-    ensure.equal(navbar.find('.btn-next').length, 0)
+
+    // On the last step there is a finish btn
+    ensure.equal(navbar.find('.btn-finish').length, 1)
   })
 
   it('renders a previous btn if there is a previous step', () => {
+    const previousStep = {
+      id: '123',
+      items: []
+    }
+
     const navbar = mount(
       <PlayerNav
-          next={null}
-          previous={null}
-          navigateTo={() => true}
-          finish={() => true}
-          submit={() => true}
-        />
+        previous={previousStep}
+        navigateTo={() => true}
+        finish={() => true}
+        submit={() => true}
+      />
     )
     ensure.propTypesOk()
-    ensure.equal(navbar.find('btn-previous').length, 1)
+    ensure.equal(navbar.find('.btn-previous').length, 1)
+  })
+
+  it('renders a next btn if there is a next step', () => {
+    const nextStep = {
+      id: '123',
+      items: []
+    }
+
+    const navbar = mount(
+      <PlayerNav
+        next={nextStep}
+        navigateTo={() => true}
+        finish={() => true}
+        submit={() => true}
+      />
+    )
+    ensure.propTypesOk()
+    ensure.equal(navbar.find('.btn-next').length, 1)
+    // Finish btn is only shown if there is no next step
+    ensure.equal(navbar.find('.btn-finish').length, 0)
   })
 })

--- a/plugin/exo/Resources/modules/quiz/player/components/nav-bar.test.js
+++ b/plugin/exo/Resources/modules/quiz/player/components/nav-bar.test.js
@@ -1,0 +1,80 @@
+import React from 'react'
+import {shallow, mount} from 'enzyme'
+import {spyConsole, renew, ensure, mockTranslator, mockRouting} from './../../../utils/test'
+import {PlayerNav} from './nav-bar.jsx'
+
+describe('<PlayerNav/>', () => {
+  beforeEach(() => {
+    spyConsole.watch()
+    renew(PlayerNav, 'PlayerNav')
+    mockTranslator()
+    mockRouting()
+  })
+  afterEach(spyConsole.restore)
+
+  it('has required props', () => {
+    shallow(<PlayerNav/>)
+    ensure.missingProps(
+      'PlayerNav',
+      [
+        'navigateTo',
+        'finish',
+        'submit'
+      ]
+    )
+  })
+
+  it('has typed props', () => {
+    shallow(
+      <PlayerNav
+        next={[]}
+        previous={[]}
+        navigateTo={{}}
+        finish={[]}
+        submit={[]}
+      />
+    )
+    ensure.invalidProps(
+      'PlayerNav',
+      [
+        'next',
+        'previous',
+        'navigateTo',
+        'finish',
+        'submit'
+      ]
+    )
+  })
+
+  it('renders a navbar', () => {
+    const navbar = mount(
+      <PlayerNav
+        next={null}
+        previous={null}
+        navigateTo={() => true}
+        finish={() => true}
+        submit={() => true}
+      />
+    )
+    ensure.propTypesOk()
+    ensure.equal(navbar.find('.player-nav').length, 1)
+
+    ensure.equal(navbar.find('.btn-previous').length, 0)
+    ensure.equal(navbar.find('.btn-next').length, 0)
+    ensure.equal(navbar.find('.btn-next').length, 0)
+  })
+
+  it('renders a previous btn if there is a previous step', () => {
+    const navbar = mount(
+      <PlayerNav
+          next={null}
+          previous={null}
+          navigateTo={() => true}
+          finish={() => true}
+          submit={() => true}
+        />
+    )
+    ensure.propTypesOk()
+    ensure.equal(navbar.find('btn-previous').length, 1)
+  })
+})

--- a/plugin/exo/Resources/modules/quiz/player/components/player.jsx
+++ b/plugin/exo/Resources/modules/quiz/player/components/player.jsx
@@ -8,8 +8,6 @@ import selectQuiz from './../../selectors'
 import {select} from './../selectors'
 
 import {actions as playerActions} from './../actions'
-import {actions as quizActions} from './../../actions'
-import {VIEW_OVERVIEW} from './../../enums'
 
 import {Player as ItemPlayer} from './../../../items/components/player.jsx'
 import {PlayerNav} from './nav-bar.jsx'
@@ -55,8 +53,8 @@ class Player extends Component {
           previous={this.props.previous}
           next={this.props.next}
           navigateTo={(step) => this.props.navigateTo(this.props.quizId, this.props.paper.id, step, this.props.answers)}
-          finish={() => this.props.finish(this.props.quizId, this.props.paper.id, this.props.answers)}
           submit={() => this.props.submit(this.props.quizId, this.props.paper.id, this.props.answers)}
+          finish={() => this.props.finish(this.props.quizId, this.props.paper, this.props.answers)}
         />
       </div>
     )
@@ -108,32 +106,4 @@ function mapStateToProps(state) {
   }
 }
 
-function mapDispatchToProps(dispatch) {
-  return {
-    updateAnswer(questionId, answerData) {
-      dispatch(playerActions.updateAnswer(questionId, answerData))
-    },
-    navigateTo(quizId, paperId, step, currentStepAnswers) {
-      // Submit answers
-      dispatch(playerActions.submitQuiz(quizId, paperId, currentStepAnswers, (dispatch) => {
-        // Go to the requested step
-        dispatch(playerActions.openStep(step.id, step.items))
-      }))
-    },
-    submit(quizId, paperId, answers) {
-      dispatch(playerActions.submitQuiz(quizId, paperId, answers))
-    },
-    finish(quizId, paperId, currentStepAnswers) {
-      // Submit answers
-      dispatch(playerActions.submitQuiz(quizId, paperId, currentStepAnswers, (dispatch) => {
-        // Mark paper as finished
-        dispatch(playerActions.finishQuiz(quizId, paperId, (dispatch) => {
-          // Close player
-          dispatch(quizActions.updateViewMode(VIEW_OVERVIEW))
-        }))
-      }))
-    }
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(Player)
+export default connect(mapStateToProps, playerActions)(Player)

--- a/plugin/exo/Resources/modules/quiz/player/reducers.js
+++ b/plugin/exo/Resources/modules/quiz/player/reducers.js
@@ -4,12 +4,17 @@ import {decorateAnswer} from './decorators'
 import * as moment from 'moment'
 
 import {
+  TEST_MODE_SET,
   ATTEMPT_START,
   ATTEMPT_FINISH,
   STEP_OPEN,
   ANSWER_UPDATE,
   ANSWERS_SUBMIT
 } from './actions'
+
+function setTestMode(state, action) {
+  return action.testMode
+}
 
 function initPaper(state, action) {
   return action.paper
@@ -26,10 +31,6 @@ function finishPaper(state, action) {
 
 function initAnswers(state, action) {
   return action.answers
-}
-
-function setTestMode(state, action) {
-  return action.testMode
 }
 
 function updateAnswer(state, action) {
@@ -69,6 +70,12 @@ function setCurrentStep(state, action) {
 }
 
 export const reducers = {
+  testMode: makeReducer(false, {
+    [TEST_MODE_SET]: setTestMode
+  }),
+  currentStep: makeReducer(null, {
+    [STEP_OPEN]: setCurrentStep
+  }),
   paper: makeReducer({}, {
     [ATTEMPT_START]: initPaper,
     [ATTEMPT_FINISH]: finishPaper
@@ -78,11 +85,5 @@ export const reducers = {
     [STEP_OPEN]: initCurrentStepAnswers,
     [ANSWER_UPDATE]: updateAnswer,
     [ANSWERS_SUBMIT]: submitAnswers
-  }),
-  currentStep: makeReducer(null, {
-    [STEP_OPEN]: setCurrentStep
-  }),
-  testMode: makeReducer(false, {
-    [ATTEMPT_START]: setTestMode
   })
 }

--- a/plugin/exo/Resources/modules/quiz/player/reducers.js
+++ b/plugin/exo/Resources/modules/quiz/player/reducers.js
@@ -1,7 +1,7 @@
 import {update} from './../../utils/utils'
 import {makeReducer} from './../../utils/reducers'
 import {decorateAnswer} from './decorators'
-import * as moment from 'moment'
+import moment from 'moment'
 
 import {
   TEST_MODE_SET,

--- a/plugin/exo/Resources/modules/quiz/quiz.js
+++ b/plugin/exo/Resources/modules/quiz/quiz.js
@@ -12,9 +12,9 @@ import {registerDefaultItemTypes, getDecorators} from './../items/item-types'
 import './editor/style.css'
 
 export class Quiz {
-  constructor(rawQuizData) {
+  constructor(rawQuizData, noServer = false) {
     registerDefaultItemTypes()
-    this.store = createStore(decorate(normalize(rawQuizData), getDecorators()))
+    this.store = createStore(decorate(normalize(rawQuizData), getDecorators()), noServer)
     this.dndQuiz = DragDropContext(HTML5Backend)(QuizComponent)
   }
 

--- a/plugin/exo/Resources/modules/quiz/quiz.js
+++ b/plugin/exo/Resources/modules/quiz/quiz.js
@@ -14,7 +14,10 @@ import './editor/style.css'
 export class Quiz {
   constructor(rawQuizData, noServer = false) {
     registerDefaultItemTypes()
-    this.store = createStore(decorate(normalize(rawQuizData), getDecorators()), noServer)
+
+    const quizData = decorate(normalize(rawQuizData), getDecorators())
+
+    this.store = createStore(Object.assign({noServer: noServer}, quizData))
     this.dndQuiz = DragDropContext(HTML5Backend)(QuizComponent)
   }
 

--- a/plugin/exo/Resources/modules/quiz/selectors.js
+++ b/plugin/exo/Resources/modules/quiz/selectors.js
@@ -1,6 +1,9 @@
 // TODO : use reselect
+// TODO : there is possible code refactoring with editor/selectors.js
 
 const empty = state => state.quiz.steps.length === 0
+const quiz = state => state.quiz
+const steps = state => state.steps
 const id = state => state.quiz.id
 const description = state => state.quiz.description
 const parameters = state => state.quiz.parameters
@@ -15,6 +18,8 @@ const hasPapers = () => true
 
 export default {
   id,
+  quiz,
+  steps,
   empty,
   editable,
   hasPapers,

--- a/plugin/exo/Resources/modules/quiz/selectors.js
+++ b/plugin/exo/Resources/modules/quiz/selectors.js
@@ -1,3 +1,5 @@
+// TODO : use reselect
+
 const empty = state => state.quiz.steps.length === 0
 const id = state => state.quiz.id
 const description = state => state.quiz.description
@@ -5,6 +7,7 @@ const parameters = state => state.quiz.parameters
 const title = state => state.quiz.title
 const meta = state => state.quiz.meta
 const published = state => state.quiz.meta.published
+const viewMode = state => state.viewMode
 
 // TODO: update when data is available
 const editable = () => true
@@ -19,5 +22,6 @@ export default {
   meta,
   parameters,
   title,
-  published
+  published,
+  viewMode
 }

--- a/plugin/exo/Resources/modules/quiz/store.js
+++ b/plugin/exo/Resources/modules/quiz/store.js
@@ -44,17 +44,17 @@ if (process.env.NODE_ENV !== 'production') {
   middleware.push(freeze)
 }
 
-const self = (state = null) => state
+const returnSelf = (state = null) => state
 
 export function makeReducer(editable) {
   return combineReducers({
-    noServer: self,
+    noServer: returnSelf,
     viewMode: quizReducers.viewMode,
-    quiz: editable ? editorReducers.quiz : self,
-    steps: editable ? editorReducers.steps : self,
-    items: editable ? editorReducers.items : self,
-    modal: editable ? editorReducers.modal : self,
-    editor: editable ? editorReducers.editor : self,
+    quiz: editable ? editorReducers.quiz : returnSelf,
+    steps: editable ? editorReducers.steps : returnSelf,
+    items: editable ? editorReducers.items : returnSelf,
+    modal: editable ? editorReducers.modal : returnSelf,
+    editor: editable ? editorReducers.editor : returnSelf,
     testMode: playerReducers.testMode,
     currentStep: playerReducers.currentStep,
     paper: playerReducers.paper,

--- a/plugin/exo/Resources/modules/quiz/store.js
+++ b/plugin/exo/Resources/modules/quiz/store.js
@@ -7,7 +7,7 @@ import {
   createStore as baseCreate
 } from 'redux'
 import thunk from 'redux-thunk'
-import identity from 'lodash/identity'
+
 import {reducers as quizReducers} from './reducers'
 import {reducers as editorReducers} from './editor/reducers'
 import {reducers as playerReducers} from './player/reducers'
@@ -44,21 +44,25 @@ if (process.env.NODE_ENV !== 'production') {
   middleware.push(freeze)
 }
 
+const self = (state = null) => state
+
 export function makeReducer(editable) {
   return combineReducers({
+    noServer: self,
     viewMode: quizReducers.viewMode,
-    quiz: editable ? editorReducers.quiz : identity,
-    steps: editable ? editorReducers.steps : identity,
-    items: editable ? editorReducers.items : identity,
-    modal: editable ? editorReducers.modal : identity,
-    editor: editable ? editorReducers.editor : identity,
+    quiz: editable ? editorReducers.quiz : self,
+    steps: editable ? editorReducers.steps : self,
+    items: editable ? editorReducers.items : self,
+    modal: editable ? editorReducers.modal : self,
+    editor: editable ? editorReducers.editor : self,
+    testMode: playerReducers.testMode,
     currentStep: playerReducers.currentStep,
     paper: playerReducers.paper,
     answers: playerReducers.answers
   })
 }
 
-export function createStore(initialState, noServer = false, editable = true) {
+export function createStore(initialState, editable = true) {
   return baseCreate(makeReducer(editable), initialState, compose(
     applyMiddleware(...middleware),
     window.devToolsExtension ? window.devToolsExtension() : f => f

--- a/plugin/exo/Resources/modules/quiz/store.js
+++ b/plugin/exo/Resources/modules/quiz/store.js
@@ -58,7 +58,7 @@ export function makeReducer(editable) {
   })
 }
 
-export function createStore(initialState, editable = true) {
+export function createStore(initialState, noServer = false, editable = true) {
   return baseCreate(makeReducer(editable), initialState, compose(
     applyMiddleware(...middleware),
     window.devToolsExtension ? window.devToolsExtension() : f => f

--- a/plugin/exo/Resources/modules/quiz/store.test.js
+++ b/plugin/exo/Resources/modules/quiz/store.test.js
@@ -4,12 +4,15 @@ import {createStore} from './store'
 describe('createStore', () => {
   it('initializes the store with initial data and calls reducer', () => {
     const state = {
+      noServer: false,
       quiz: {id: '1'},
       steps: {},
       items: {}
     }
     const store = createStore(state)
     assertEqual(store.getState(), {
+      noServer: false,
+      testMode: false,
       quiz: {id: '1'},
       steps: {},
       items: {},

--- a/plugin/exo/Resources/modules/utils/utils.js
+++ b/plugin/exo/Resources/modules/utils/utils.js
@@ -49,7 +49,7 @@ export function lastIds(count) {
 
   const ids = []
 
-  for (let i = lastGeneratedIds.length - count + 1; i <= lastGeneratedIds.length; ++i) {
+  for (let i = lastGeneratedIds.length - count; i < lastGeneratedIds.length; ++i) {
     ids.push(lastGeneratedIds[i])
   }
 

--- a/plugin/exo/Resources/modules/utils/utils.js
+++ b/plugin/exo/Resources/modules/utils/utils.js
@@ -1,6 +1,7 @@
 import update from 'immutability-helper'
 import invariant from 'invariant'
 import React from 'react'
+import uuid from 'uuid'
 
 // re-export immutability-helper with a custom delete command
 update.extend('$delete', (property, object) => {
@@ -24,33 +25,18 @@ export function makeActionCreator(type, ...argNames) {
 }
 
 // counter for id generation
-let idCount = 0
+let lastGeneratedId = null
 
 // generate a temporary id string
 export function makeId() {
-  return `generated-id-${++idCount}`
+  lastGeneratedId = uuid()
+
+  return lastGeneratedId
 }
 
 // return the last generated id (mainly for test purposes)
 export function lastId() {
-  return `generated-id-${idCount}`
-}
-
-// test purpose only
-export function lastIds(count) {
-  if (count > idCount) {
-    throw new Error(
-      `Cannot access last ${count} ids, only ${idCount} were generated`
-    )
-  }
-
-  const ids = []
-
-  for (let i = idCount - count + 1; i <= idCount; ++i) {
-    ids.push(`generated-id-${i}`)
-  }
-
-  return ids
+  return lastGeneratedId
 }
 
 export function makeItemPanelKey(itemType, itemId) {

--- a/plugin/exo/Resources/modules/utils/utils.js
+++ b/plugin/exo/Resources/modules/utils/utils.js
@@ -25,18 +25,35 @@ export function makeActionCreator(type, ...argNames) {
 }
 
 // counter for id generation
-let lastGeneratedId = null
+let lastGeneratedIds = []
 
 // generate a temporary id string
 export function makeId() {
-  lastGeneratedId = uuid()
+  lastGeneratedIds.push(uuid())
 
-  return lastGeneratedId
+  return lastGeneratedIds[lastGeneratedIds.length - 1]
 }
 
 // return the last generated id (mainly for test purposes)
 export function lastId() {
-  return lastGeneratedId
+  return lastGeneratedIds[lastGeneratedIds.length - 1]
+}
+
+// test purpose only
+export function lastIds(count) {
+  if (count > lastGeneratedIds.length) {
+    throw new Error(
+      `Cannot access last ${count} ids, only ${lastGeneratedIds.length} were generated`
+    )
+  }
+
+  const ids = []
+
+  for (let i = lastGeneratedIds.length - count + 1; i <= lastGeneratedIds.length; ++i) {
+    ids.push(lastGeneratedIds[i])
+  }
+
+  return ids
 }
 
 export function makeItemPanelKey(itemType, itemId) {

--- a/plugin/exo/Resources/translations/ujm_exo.en.yml
+++ b/plugin/exo/Resources/translations/ujm_exo.en.yml
@@ -128,7 +128,7 @@ exercise_finished_attempts: "[0, 1] You have finished %count% attempt|]1,Inf[  Y
 exercise_restart: Restart the quiz
 exercise_start: Start the quiz
 exercise_tries: "[0, 1] You have %count% try|]1,Inf[ You have %count% tries"
-exercise_try: Try the quiz
+exercise_try: Try
 exit: Exit
 exo_empty_user_can_edit: This quiz is empty. Please edit and publish it to fill it.
 exo_empty_user_read_only: This quiz is empty and has not been configured by its designer. Please come back later.

--- a/plugin/exo/Resources/translations/ujm_exo.fr.yml
+++ b/plugin/exo/Resources/translations/ujm_exo.fr.yml
@@ -126,7 +126,7 @@ exercise_finished_attempts: "[0, 1] %count% réalisée à ce stade|]1,Inf[ %coun
 exercise_restart: Recommencer le questionnaire
 exercise_start: Commencer le questionnaire
 exercise_tries: "[0, 1] Vous avez droit à %count% essai|]1,Inf[ Vous avez droit à %count% essais"
-exercise_try: Tester le questionnaire
+exercise_try: Tester
 exit: Quitter
 exo_empty_user_can_edit: Ce questionnaire est vide. Editez et publiez-le afin de le remplir.
 exo_empty_user_read_only: Ce questionnaire est vide et n'a pas encore été configuré par son concepteur. Veuillez revenir plus tard.

--- a/plugin/exo/Resources/views/Exercise/open.html.twig
+++ b/plugin/exo/Resources/views/Exercise/open.html.twig
@@ -21,6 +21,7 @@
       class="quiz-container"
       data-quiz="{{ exercise | json_encode | raw | escape }}"
       data-editable="{{ editEnabled }}"
+      data-no-server="false"
     >
     </div>
 {% endblock %}

--- a/plugin/exo/Resources/views/Exercise/open.html.twig
+++ b/plugin/exo/Resources/views/Exercise/open.html.twig
@@ -21,7 +21,6 @@
       class="quiz-container"
       data-quiz="{{ exercise | json_encode | raw | escape }}"
       data-editable="{{ editEnabled }}"
-      data-no-server="false"
     >
     </div>
 {% endblock %}

--- a/plugin/exo/Serializer/Attempt/AnswerSerializer.php
+++ b/plugin/exo/Serializer/Attempt/AnswerSerializer.php
@@ -107,6 +107,7 @@ class AnswerSerializer extends AbstractSerializer
         }
 
         $this->mapObjectToEntity([
+            'tries' => 'tries',
             'data' => function (Answer $answer, \stdClass $data) {
                 if (!empty($data->data)) {
                     $answer->setData(json_encode($data->data));

--- a/plugin/exo/Tests/Controller/Api/PaperControllerTest.php
+++ b/plugin/exo/Tests/Controller/Api/PaperControllerTest.php
@@ -173,14 +173,7 @@ class PaperControllerTest extends TransactionalTestCase
 
         // Request the created paper
         $this->request('GET', "/api/exercises/{$this->exercise->getUuid()}/papers/{$paper->getUuid()}");
-        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
-
-        // Validate the received content
-        $this->assertIsValidPaperDetail($paper, json_decode($this->client->getResponse()->getContent()));
-
-        $this->markTestIncomplete(
-            'As is, anonymous have access to all the other anonymous Papers.'
-        );
+        $this->assertEquals(403, $this->client->getResponse()->getStatusCode());
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no

- Remove access to the `getPaper` API endpoint to anonymous. This is a security breach and this was only needed because the old player was not able to display the correction whithout calling the server.
- Display the "Save" button only in the editor
- Do not display the "Test" button in the player
- Fix a mismatch in naming between the client and API (quiz parameter anonymous/anonymiseAttempts)
- Clean player actions structure
- Quiz can now be played without api interactions
- Restore the play button for regular users


