### PR TITLE
[PathBundle] Fixed path import issue due to manualProgressionAllowed option missing from PathImporter

### DIFF
--- a/plugin/path/Transfer/PathImporter.php
+++ b/plugin/path/Transfer/PathImporter.php
@@ -59,6 +59,7 @@ class PathImporter extends Importer implements ConfigurationInterface, RichTextI
                         ->booleanNode('breadcrumbs')->end()
                         ->booleanNode('summaryDisplayed')->end()
                         ->booleanNode('completeBlockingCondition')->end()
+                        ->booleanNode('manualProgressionAllowed')->end()
                         ->booleanNode('modified')->end()
                         ->booleanNode('published')->end()
                     ->end()
@@ -122,14 +123,6 @@ class PathImporter extends Importer implements ConfigurationInterface, RichTextI
                     $text = $this->container->get('claroline.importer.rich_text_formatter')->format($text);
 
                     // Decode JSON to be able to replace IDs in structure
-
-                    // TODO update IDs in step structure
-                    /*$json = json_decode($text);
-                    if (!empty($json) && !empty($json->steps)) {
-                        foreach ($json->steps as $step) {
-                            $this->formatStep($step);
-                        }
-                    }*/
 
                     $entity->setStructure($text);
                     $this->container->get('doctrine.orm.entity_manager')->persist($entity);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | 

'manualProgressionAllowed' was missing from PathImporter. As a result any attempt to import a path was resulting to an error "option not found in data.path".



