### PR TITLE
[WebSite] changes assetic destination folder

### DIFF
--- a/plugin/website/Resources/views/Website/Macros/edit_macros.html.twig
+++ b/plugin/website/Resources/views/Website/Macros/edit_macros.html.twig
@@ -1,12 +1,12 @@
 {% macro getStylesheets() %}
-    {% stylesheets debug=false filter='less, cssmin' output='bundles/icapwebsite/css/edit-style.css'
-    '@FrontEndBundle/Resources/public/angular-ui-tree/dist/angular-ui-tree.min.css'
-    '@IcapWebsiteBundle/Resources/public/css/angular/angular-motion.min.css'
-    '@IcapWebsiteBundle/Resources/views/less/edit.less'
-    '@IcapWebsiteBundle/Resources/public/css/angular/pushmenu.css'
-    '@IcapWebsiteBundle/Resources/views/less/flexnav.less'
+    {% stylesheets debug=false filter='less, cssmin' output='css/icapwebsite/edit-style.css'
+        '@FrontEndBundle/Resources/public/angular-ui-tree/dist/angular-ui-tree.min.css'
+        '@IcapWebsiteBundle/Resources/public/css/angular/angular-motion.min.css'
+        '@IcapWebsiteBundle/Resources/views/less/edit.less'
+        '@IcapWebsiteBundle/Resources/public/css/angular/pushmenu.css'
+        '@IcapWebsiteBundle/Resources/views/less/flexnav.less'
     %}
-    <link rel="stylesheet" href="{{ asset_url }}" screen="media" />
+    <link rel="stylesheet" href="{{ asset_url }}" media="screen" />
     {% endstylesheets %}
     <link rel="stylesheet" href="{{ asset('bundles/frontend/mjolnic-bootstrap-colorpicker/dist/css/bootstrap-colorpicker.min.css') }}"/>
 {% endmacro %}

--- a/plugin/website/Resources/views/Website/Macros/view_macros.html.twig
+++ b/plugin/website/Resources/views/Website/Macros/view_macros.html.twig
@@ -1,17 +1,17 @@
 {% macro getStylesheets(orientation) %}
     {% if orientation == 'horizontal' %}
-        {% stylesheets debug=false filter='less, cssmin' output='bundles/icapwebsite/css/view-style-horizontal.css'
-        "@IcapWebsiteBundle/Resources/views/less/flexnav.less"
-        "@IcapWebsiteBundle/Resources/views/less/view.less"
+        {% stylesheets debug=false filter='less, cssmin' output='css/icapwebsite/view-style-horizontal.css'
+            "@IcapWebsiteBundle/Resources/views/less/flexnav.less"
+            "@IcapWebsiteBundle/Resources/views/less/view.less"
         %}
-        <link rel="stylesheet" href="{{ asset_url }}" screen="media" />
+        <link rel="stylesheet" href="{{ asset_url }}" media="screen" />
         {% endstylesheets %}
     {% else %}
-        {% stylesheets debug=false filter='less, cssmin' output='bundles/icapwebsite/css/view-style-vertical.css'
-        "@IcapWebsiteBundle/Resources/public/css/angular/pushmenu.css"
-        "@IcapWebsiteBundle/Resources/views/less/view.less"
+        {% stylesheets debug=false filter='less, cssmin' output='css/icapwebsite/view-style-vertical.css'
+            "@IcapWebsiteBundle/Resources/public/css/angular/pushmenu.css"
+            "@IcapWebsiteBundle/Resources/views/less/view.less"
         %}
-        <link rel="stylesheet" href="{{ asset_url }}" screen="media" />
+        <link rel="stylesheet" href="{{ asset_url }}" media="screen" />
         {% endstylesheets %}
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Styles managed by assetic for website are dumped in the same folder used by `asset:installs`.
This produces strange results on my dev install (dumped files also appears in the vendor source directory, website/Resources/public/css, and so in git changes). 

I think it's due to the symlinks (possibly a problem with how windows manages it).

I've just moved the dest folder to another one in the `web` dir.

ping @ptsavdar.


