### PR TITLE
[exo-v2] fixes start quiz in Firefox

### DIFF
--- a/plugin/exo/Resources/modules/api/middleware.js
+++ b/plugin/exo/Resources/modules/api/middleware.js
@@ -82,15 +82,13 @@ function handleResponseError(error, failure) {
 function getResponseData(response) {
   let data = null
 
-  if (response.body) {
-    const contentType = response.headers.get('content-type')
-    if (contentType && contentType.indexOf('application/json') !== -1) {
-      // Decode JSON
-      data = response.json()
-    } else {
-      // Return raw data (maybe someday we will need to also manage files)
-      data = response.text()
-    }
+  const contentType = response.headers.get('content-type')
+  if (contentType && contentType.indexOf('application/json') !== -1) {
+    // Decode JSON
+    data = response.json()
+  } else {
+    // Return raw data (maybe someday we will need to also manage files)
+    data = response.text()
   }
 
   return data // this is a promise


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

It seems `response.body` does not exist in FF. In fact the whole condition was uneeded as empty body is handled by `.json() / .text()`.

