### PR TITLE
[exo-v2] items html data validation

### DIFF
--- a/plugin/exo/Resources/modules/utils/utils.js
+++ b/plugin/exo/Resources/modules/utils/utils.js
@@ -90,7 +90,14 @@ export function extractTextFromHtml(html) {
   const wrapper = document.createElement('div')
   wrapper.innerHTML = html
 
-  return wrapper.textContent
+  return wrapper.textContent || isAllowedHtmlTag(wrapper.innerHTML)
+}
+
+export function isAllowedHtmlTag(html) {
+  const allowedTags = ['img', 'audio', 'iframe', 'video']
+  return allowedTags.some((tag) => {
+    return html.indexOf(tag) >= 0
+  })
 }
 
 export function makeInputPropType(valueType) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes

<!-- please add a description here if needed -->

When any html element without text (img / video ...) is set as item data the validation is in error
