### PR TITLE
[exo-v2] UI fixes

### DIFF
--- a/plugin/exo/Resources/less/items/choice.less
+++ b/plugin/exo/Resources/less/items/choice.less
@@ -76,8 +76,13 @@
     padding: @table-cell-padding;
   }
 
+  .item:first-of-type {
+    .border-top-radius(@border-radius-base - 1);
+  }
+
   .item:last-of-type {
     border: none;
+    .border-bottom-radius(@border-radius-base - 1);
   }
 
   .control-label {

--- a/plugin/exo/Resources/less/items/common.less
+++ b/plugin/exo/Resources/less/items/common.less
@@ -16,3 +16,7 @@
         font-style: italic;
     }
 }
+
+.item-hints {
+    margin-top: @line-height-computed;
+}

--- a/plugin/exo/Resources/less/items/common.less
+++ b/plugin/exo/Resources/less/items/common.less
@@ -1,0 +1,18 @@
+.item-title {
+    font-weight: bold;
+    font-size: 16px;
+    margin-top: 0;
+    padding: 0;
+    margin-bottom: @line-height-computed; // normalize margin as item title can be a h
+}
+
+.item-metadata {
+    .item-content,
+    .item-description {
+        margin-bottom: 12px;
+    }
+
+    .item-description {
+        font-style: italic;
+    }
+}

--- a/plugin/exo/Resources/less/main.less
+++ b/plugin/exo/Resources/less/main.less
@@ -16,6 +16,7 @@
 
 // Exo styles
 @import "quiz/index";
+@import "items/common";
 @import "items/icons";
 @import "items/choice";
 @import "items/words";

--- a/plugin/exo/Resources/less/quiz/index.less
+++ b/plugin/exo/Resources/less/quiz/index.less
@@ -1,3 +1,4 @@
+@import "./step";
 @import "./player";
 @import "./editor";
 @import "./add-item-modal";

--- a/plugin/exo/Resources/less/quiz/papers.less
+++ b/plugin/exo/Resources/less/quiz/papers.less
@@ -17,4 +17,18 @@
   .nav-tabs {
     margin-bottom: @panel-body-padding;
   }
+
+  .paper-title {
+    font-size: @font-size-h3;
+    // same margins as a regular bootstrap H
+    margin-top: (@line-height-computed / 2);
+    margin-bottom: (@line-height-computed / 2);
+    padding: 0 0 5px;
+    border-bottom: 1px solid @panel-default-border;
+  }
+
+  .no-answer {
+    font-style: italic;
+    color: @text-muted;
+  }
 }

--- a/plugin/exo/Resources/less/quiz/papers.less
+++ b/plugin/exo/Resources/less/quiz/papers.less
@@ -13,4 +13,8 @@
   max-width: @quiz-container-width;
   margin: 0 auto;
   padding: @panel-body-padding;
+
+  .nav-tabs {
+    margin-bottom: @panel-body-padding;
+  }
 }

--- a/plugin/exo/Resources/less/quiz/player.less
+++ b/plugin/exo/Resources/less/quiz/player.less
@@ -18,17 +18,6 @@
   }
 }
 
-.item-player .item-content,
-.item-player .item-title,
-.item-player .item-description,
-.item-paper .item-content {
-  margin-bottom: 12px;
-}
-
-.item-title {
-  font-size: 16px;
-}
-
 
 
 .tooltiped-button {

--- a/plugin/exo/Resources/less/quiz/player.less
+++ b/plugin/exo/Resources/less/quiz/player.less
@@ -3,12 +3,9 @@
   padding: @panel-body-padding;
   max-width: @quiz-container-width;
   margin: 0 auto;
-  .step-title {
-    word-break: break-all;
-  }
 
   .step-description {
-    margin-bottom:  @line-height-computed;
+    margin-bottom: @line-height-computed;
     word-break: break-all;
   }
 

--- a/plugin/exo/Resources/less/quiz/step.less
+++ b/plugin/exo/Resources/less/quiz/step.less
@@ -1,0 +1,7 @@
+.step-title {
+    // Same style as an H4 for now
+    font-size: @font-size-h4;
+    margin-top: (@line-height-computed / 2);
+    margin-bottom: (@line-height-computed / 2);
+    word-break: break-all;
+}

--- a/plugin/exo/Resources/modules/items/choice/paper.jsx
+++ b/plugin/exo/Resources/modules/items/choice/paper.jsx
@@ -9,10 +9,9 @@ import {PaperTabs} from '../components/paper-tabs.jsx'
 export const ChoicePaper = props => {
   return (
     <PaperTabs
-      item={props.item}
-      answer={props.answer}
+      id={props.item.id}
       yours={
-        <div className="container choice-paper">
+        <div className="choice-paper">
           {props.item.solutions.map(solution =>
             <div
               key={utils.answerId(solution.id)}
@@ -46,7 +45,7 @@ export const ChoicePaper = props => {
         </div>
       }
       expected={
-        <div className="container choice-paper">
+        <div className="choice-paper">
           {props.item.solutions.map(solution =>
             <div
               key={utils.expectedId(solution.id)}

--- a/plugin/exo/Resources/modules/items/components/metadata.jsx
+++ b/plugin/exo/Resources/modules/items/components/metadata.jsx
@@ -2,18 +2,22 @@ import React, {PropTypes as T} from 'react'
 
 export const Metadata = props => {
   return(
-      <div className="question-metadata">
-        {props.title !== '' &&
-          <h4>{props.title} </h4>
+      <div className="item-metadata">
+        {props.item.content &&
+          <div className="item-content" dangerouslySetInnerHTML={{__html: props.item.content}}></div>
         }
-        {props.description !== '' &&
-          <i>{props.description} </i>
+
+        {props.item.description &&
+          <div className="item-description" dangerouslySetInnerHTML={{__html: props.item.description}}></div>
         }
       </div>
   )
 }
 
 Metadata.propTypes = {
-  title: T.string,
-  description: T.string
+  item: T.shape({
+    title: T.string,
+    content: T.string.isRequired,
+    description: T.string
+  }).isRequired
 }

--- a/plugin/exo/Resources/modules/items/components/paper-tabs.jsx
+++ b/plugin/exo/Resources/modules/items/components/paper-tabs.jsx
@@ -1,12 +1,9 @@
 
 import React, {Component, PropTypes as T} from 'react'
 import Tab from 'react-bootstrap/lib/Tab'
-import Row from 'react-bootstrap/lib/Row'
-import Col from 'react-bootstrap/lib/Col'
 import Nav from 'react-bootstrap/lib/Nav'
 import NavItem from 'react-bootstrap/lib/NavItem'
-import {tex} from './../../utils/translate'
-import {Metadata} from './metadata.jsx'
+import {tex} from '../../utils/translate'
 
 export class PaperTabs extends Component
 {
@@ -23,52 +20,33 @@ export class PaperTabs extends Component
 
   render() {
     return (
-      <div>
-        <Metadata title={this.props.item.title} description={this.props.item.description} />
-        <Tab.Container id={`${this.props.item.id}-paper`} defaultActiveKey="first">
-          <Row className="clearfix">
-            <Col sm={12}>
-              <Nav bsStyle="tabs">
-                <NavItem eventKey="first" onSelect={() => this.handleSelect('first')}>
-                  <span className="fa fa-user"></span> {tex('your_answer')}
-                </NavItem>
-                <NavItem eventKey="second" onSelect={() => this.handleSelect('second')}>
-                  <span className="fa fa-check"></span> {tex('expected_answer')}
-                </NavItem>
-              </Nav>
-            </Col>
-            <Col sm={12}>
-              <Tab.Content animation>
-                <Tab.Pane eventKey="first">
-                  <div className="panel panel-body">
-                    {this.props.yours}
-                  </div>
-                </Tab.Pane>
-                <Tab.Pane eventKey="second">
-                  <div className="panel panel-body">
-                    {this.props.expected}
-                  </div>
-                </Tab.Pane>
-              </Tab.Content>
-            </Col>
-          </Row>
-        </Tab.Container>
-      </div>
+      <Tab.Container id={`${this.props.id}-paper`} defaultActiveKey="first">
+        <div>
+          <Nav bsStyle="tabs">
+            <NavItem eventKey="first" onSelect={() => this.handleSelect('first')}>
+              <span className="fa fa-user"></span> {tex('your_answer')}
+            </NavItem>
+            <NavItem eventKey="second" onSelect={() => this.handleSelect('second')}>
+              <span className="fa fa-check"></span> {tex('expected_answer')}
+            </NavItem>
+          </Nav>
+
+          <Tab.Content animation>
+            <Tab.Pane eventKey="first">
+              {this.props.yours}
+            </Tab.Pane>
+            <Tab.Pane eventKey="second">
+              {this.props.expected}
+            </Tab.Pane>
+          </Tab.Content>
+        </div>
+      </Tab.Container>
     )
   }
 }
 
 PaperTabs.propTypes = {
-  item: T.shape({
-    id: T.string.isRequired,
-    title: T.string.isRequired,
-    description: T.string.isRequired,
-    solutions: T.oneOfType([
-      T.arrayOf(T.object),
-      T.object
-    ]).isRequired
-  }),
-  answer: T.any.isRequired,
+  id: T.string.isRequired,
   yours: T.object.isRequired,
   expected: T.object.isRequired,
   onTabChange: T.func

--- a/plugin/exo/Resources/modules/items/match/paper.jsx
+++ b/plugin/exo/Resources/modules/items/match/paper.jsx
@@ -10,7 +10,6 @@ import NavItem from 'react-bootstrap/lib/NavItem'
 import {Feedback} from '../components/feedback-btn.jsx'
 import {SolutionScore} from '../components/score.jsx'
 import {utils} from './utils/utils'
-import {Metadata} from '../components/metadata.jsx'
 
 /* global jsPlumb */
 
@@ -55,20 +54,20 @@ function initJsPlumb(jsPlumbInstance) {
 }
 
 export const MatchLinkPopover = props =>
-      <Popover
-        id={`popover-${props.solution.firstId}-${props.solution.secondId}`}
-        positionTop={props.top}
-        placement="bottom"
-        >
-          <div className={classes(
-            'fa',
-            {'fa-check text-success' : props.solution.score > 0},
-            {'fa-times text-danger' : props.solution.score <= 0 }
-          )}>
-          </div>
-          &nbsp;<label className="label popover-label" dangerouslySetInnerHTML={{__html: props.solution.feedback}}/>
-        &nbsp;<label className="label popover-label">{props.solution.score}</label>
-      </Popover>
+  <Popover
+    id={`popover-${props.solution.firstId}-${props.solution.secondId}`}
+    positionTop={props.top}
+    placement="bottom"
+    >
+      <div className={classes(
+        'fa',
+        {'fa-check text-success' : props.solution.score > 0},
+        {'fa-times text-danger' : props.solution.score <= 0 }
+      )}>
+      </div>
+      &nbsp;<label className="label popover-label" dangerouslySetInnerHTML={{__html: props.solution.feedback}}/>
+    &nbsp;<label className="label popover-label">{props.solution.score}</label>
+  </Popover>
 
 
 MatchLinkPopover.propTypes = {
@@ -217,7 +216,6 @@ export class MatchPaper extends Component
             <div ref={(el) => { this.container = el }} id={`jsplumb-container-${this.props.item.id}`} className="jsplumb-container" style={{position:'relative'}}>
               <Tab.Content animation>
                 <Tab.Pane eventKey="first">
-                  <Metadata title={this.props.item.title} description={this.props.item.description}/>
                   <div id={`match-question-paper-${this.props.item.id}-first`} className="match-question-paper">
                     <div className="jsplumb-row">
                       <div className="item-col">
@@ -258,7 +256,6 @@ export class MatchPaper extends Component
                   </div>
                 </Tab.Pane>
                 <Tab.Pane eventKey="second">
-                  <Metadata title={this.props.item.title} description={this.props.item.description}/>
                   <div id={`match-question-paper-${this.props.item.id}-second`} className="match-question-paper">
                     <div className="jsplumb-row">
                       <div className="item-col">

--- a/plugin/exo/Resources/modules/items/words/paper.jsx
+++ b/plugin/exo/Resources/modules/items/words/paper.jsx
@@ -1,4 +1,6 @@
 import React, {PropTypes as T} from 'react'
+
+import {tex} from '../../utils/translate'
 import {Highlight} from './utils/highlight.jsx'
 import {Feedback} from '../components/feedback-btn.jsx'
 import {SolutionScore} from '../components/score.jsx'
@@ -39,19 +41,21 @@ AnswerTable.propTypes = {
 
 export const WordsPaper = (props) => {
   const solutions = props.item.solutions.slice(0)
-  var halfLength = Math.ceil(solutions.length / 2)
-  var leftSide = solutions.splice(0, halfLength)
-  var rightSide = solutions
+  const halfLength = Math.ceil(solutions.length / 2)
+  const leftSide = solutions.splice(0, halfLength)
+  const rightSide = solutions
 
   return (
     <PaperTabs
       id={props.item.id}
       yours={
-        <Highlight
-          text={props.answer}
-          solutions={props.item.solutions}
-          showScore={true}
-        />
+        props.answer && 0 !== props.answer.length ?
+          <Highlight
+            text={props.answer}
+            solutions={props.item.solutions}
+            showScore={true}
+          /> :
+          <div className="no-answer">{tex('no_answer')}</div>
       }
       expected={
         <div className="row">

--- a/plugin/exo/Resources/modules/items/words/paper.jsx
+++ b/plugin/exo/Resources/modules/items/words/paper.jsx
@@ -45,8 +45,7 @@ export const WordsPaper = (props) => {
 
   return (
     <PaperTabs
-      item={props.item}
-      answer={props.answer}
+      id={props.item.id}
       yours={
         <Highlight
           text={props.answer}
@@ -55,7 +54,7 @@ export const WordsPaper = (props) => {
         />
       }
       expected={
-        <div>
+        <div className="row">
           <div className="col-md-6">
             <AnswerTable solutions={leftSide}/>
           </div>

--- a/plugin/exo/Resources/modules/quiz/papers/components/paper.jsx
+++ b/plugin/exo/Resources/modules/quiz/papers/components/paper.jsx
@@ -8,13 +8,15 @@ import {Metadata as ItemMetadata} from './../../../items/components/metadata.jsx
 
 let Paper = props =>
   <div className="paper">
-    <h2>
+    <h2 className="paper-title">
       {tex('correction')}&nbsp;{props.paper.number}
     </h2>
-    <hr/>
+
     {props.steps.map((step, idx) =>
       <div key={idx} className="item-paper">
-        <h3 className="step-title">{tex('step')}&nbsp;{idx + 1}</h3>
+        <h3 className="step-title">
+          {step.title ? step.title : tex('step') + ' ' + (idx + 1)}
+        </h3>
 
         {step.items.map(item =>
           <Panel key={item.id}>

--- a/plugin/exo/Resources/modules/quiz/papers/components/paper.jsx
+++ b/plugin/exo/Resources/modules/quiz/papers/components/paper.jsx
@@ -4,21 +4,26 @@ import Panel from 'react-bootstrap/lib/Panel'
 import {tex} from './../../../utils/translate'
 import {getDefinition} from './../../../items/item-types'
 import {selectors} from './../selectors'
+import {Metadata as ItemMetadata} from './../../../items/components/metadata.jsx'
 
 let Paper = props =>
   <div className="paper">
-    <h3>
+    <h2>
       {tex('correction')}&nbsp;{props.paper.number}
-    </h3>
+    </h2>
     <hr/>
     {props.steps.map((step, idx) =>
       <div key={idx} className="item-paper">
-        <h4>{tex('step')}&nbsp;{idx + 1}</h4>
+        <h3 className="step-title">{tex('step')}&nbsp;{idx + 1}</h3>
+
         {step.items.map(item =>
           <Panel key={item.id}>
-            <header className="item-content">
-              <strong dangerouslySetInnerHTML={{__html: item.content}}/>
-            </header>
+            {item.title &&
+              <h4 className="item-title">{item.title}</h4>
+            }
+
+            <ItemMetadata item={item} />
+
             {React.createElement(
               getDefinition(item.type).paper,
               {item, answer: getAnswer(item.id, props.paper.answers)}

--- a/plugin/exo/Resources/modules/quiz/player/components/item-player.jsx
+++ b/plugin/exo/Resources/modules/quiz/player/components/item-player.jsx
@@ -1,5 +1,7 @@
 import React, {PropTypes as T} from 'react'
 
+import {Metadata as ItemMetadata} from './../../../items/components/metadata.jsx'
+
 import {tex, transChoice} from './../../../utils/translate'
 
 const UsedHint = props =>
@@ -81,18 +83,12 @@ Hints.propTypes = {
 const ItemPlayer = props =>
   <div className="item-player">
     {props.item.title &&
-      <h3 className="h4 item-title">
-        {props.item.title}
-      </h3>
+      <h3 className="item-title">{props.item.title}</h3>
     }
-    {props.item.description &&
-      <div className="item-description" dangerouslySetInnerHTML={{__html: props.item.description}}></div>
-    }
-    <div className="item-content"  dangerouslySetInnerHTML={{__html: props.item.content}}></div>
 
-    <hr/>
+    <ItemMetadata item={props.item} />
+
     {props.children}
-    <hr/>
 
     {props.item.hints && 0 !== props.item.hints.length &&
       <Hints
@@ -106,7 +102,7 @@ const ItemPlayer = props =>
 ItemPlayer.propTypes = {
   item: T.shape({
     id: T.string.isRequired,
-    title: T.string.isRequired,
+    title: T.string,
     description: T.string.isRequired,
     content: T.string.isRequired,
     hints: T.array

--- a/plugin/exo/Resources/modules/quiz/player/components/player.jsx
+++ b/plugin/exo/Resources/modules/quiz/player/components/player.jsx
@@ -15,12 +15,8 @@ import {PlayerNav} from './nav-bar.jsx'
 const Player = props => {
   return(
     <div className="quiz-player">
-      <h2 className="h4 step-title">
-        {props.step.title ?
-          <span dangerouslySetInnerHTML={{ __html: props.step.title }}></span>
-          :
-          <span>{tex('step')}&nbsp; {props.number}</span>
-        }
+      <h2 className="step-title">
+        {props.step.title ? props.step.title : tex('step') + ' ' + props.number}
       </h2>
 
       {props.step.description &&

--- a/plugin/exo/Resources/translations/ujm_exo.en.yml
+++ b/plugin/exo/Resources/translations/ujm_exo.en.yml
@@ -291,7 +291,7 @@ never: Never
 new_name: New name of the document
 next: Next
 no: No
-no_answer: No answer
+no_answer: No answer.
 no_answer_zone: There is no answer zone
 no_finish: Not finished
 no_pic_found: No document found

--- a/plugin/exo/Resources/translations/ujm_exo.fr.yml
+++ b/plugin/exo/Resources/translations/ujm_exo.fr.yml
@@ -290,7 +290,7 @@ never: Jamais
 new_name: Nouveau nom du document
 next: Suivant
 no: Non
-no_answer: Pas de réponse
+no_answer: Pas de réponse.
 no_answer_zone: Vous n'avez mis aucune zone de réponse
 no_pic_found: Pas de document trouvé
 no_finish: Non terminé


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

- Removes extra HTML elements.
- Fixes H* elements order.
- Fixes small bug in choices border radius.
- Displays step title in papers if available.
- Uses same styles for item meta in player and paper.
- Fixes item meta (title, content, description) order in papers.
- Fixes display of HTML contents in papers.
- Adds a generic "No answer" message in words paper.
- Removes unused props from `PaperTabs` component.


