### PR TITLE
[exo-v2] fixes exported rows in pair questions

### DIFF
--- a/plugin/exo/Serializer/Question/Type/PairQuestionSerializer.php
+++ b/plugin/exo/Serializer/Question/Type/PairQuestionSerializer.php
@@ -49,7 +49,11 @@ class PairQuestionSerializer implements SerializerInterface
 
         $questionData->random = $pairQuestion->getShuffle();
         $questionData->penalty = $pairQuestion->getPenalty();
-        $questionData->rows = $pairQuestion->getRows()->count();
+
+        // The grid only contains expected answers
+        $questionData->rows = $pairQuestion->getRows()->filter(function (GridRow $row) {
+            return 0 < $row->getScore();
+        })->count();
 
         $items = $this->serializeItems($pairQuestion, $options);
         if (in_array(Transfer::SHUFFLE_ANSWERS, $options)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes

The player must only display rows for expected answers in the player (not all combinations defined by the creator).


