### PR TITLE
[InnovaRecorder] Administration configuration doesn't work

### DIFF
--- a/plugin/audio-recorder/Form/Type/AudioRecorderConfigurationType.php
+++ b/plugin/audio-recorder/Form/Type/AudioRecorderConfigurationType.php
@@ -23,8 +23,8 @@ class AudioRecorderConfigurationType extends AbstractType
                         'min' => 0,
                       ],
                     ])
-                ->add('', 'submit', [
-                  'label' => 'submit_config_label',
+                ->add('validate', 'submit', [
+                  'label' => 'validate',
                   'translation_domain' => 'innova_audio_recorder',
                   'attr' => [
                       'class' => 'btn btn-primary pull-right',

--- a/plugin/audio-recorder/Resources/translations/innova_audio_recorder.en.yml
+++ b/plugin/audio-recorder/Resources/translations/innova_audio_recorder.en.yml
@@ -39,3 +39,6 @@ resource_creation_error_download: Please use the download button to save your au
 start_recording: Start
 stop_recording: Stop
 submit_config_label: Save configuration
+
+#
+validate: Validate

--- a/plugin/audio-recorder/Resources/translations/innova_audio_recorder.fr.yml
+++ b/plugin/audio-recorder/Resources/translations/innova_audio_recorder.fr.yml
@@ -40,3 +40,6 @@ resource_creation_error_download: Utilisez le bouton de téléchargement pour sa
 start_recording: Démarrer
 stop_recording: Stop
 submit_config_label: Sauvegarder la configuration
+
+#v
+validate: Valider

--- a/plugin/video-recorder/Form/Type/VideoRecorderConfigurationType.php
+++ b/plugin/video-recorder/Form/Type/VideoRecorderConfigurationType.php
@@ -11,7 +11,7 @@ class VideoRecorderConfigurationType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder->add('max_recording_time', 'integer', ['required' => true, 'attr' => ['min' => 0]])
-            ->add('', 'submit', ['label' => 'submit_config_label', 'translation_domain' => 'innova_video_recorder', 'attr' => ['class' => 'btn btn-primary pull-right']]);
+            ->add('validate', 'submit', ['label' => 'validate', 'translation_domain' => 'innova_video_recorder', 'attr' => ['class' => 'btn btn-primary pull-right']]);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/plugin/video-recorder/Resources/translations/innova_video_recorder.en.yml
+++ b/plugin/video-recorder/Resources/translations/innova_video_recorder.en.yml
@@ -32,6 +32,7 @@ start: 'Start'
 stop: 'Stop'
 
 # v
+validate: Validate
 video_recorder_configuration_max_recording_time: Maximum recording time (Secondes, 0 = infinite)
 
 # w

--- a/plugin/video-recorder/Resources/translations/innova_video_recorder.fr.yml
+++ b/plugin/video-recorder/Resources/translations/innova_video_recorder.fr.yml
@@ -31,5 +31,8 @@ start: 'Démarrer'
 stop_recording: 'Arrêter l''enregistrement'
 stop: 'Stop'
 
+# v
+validate: Valider
+
 # w
 warning_message_record_end: 'L''enregistrement est terminé.<br/>Cliquez sur "Valider" s''il convient ou sur "Recommencer".<br/>(Recommencer effacera l''enregistrement actuel.)'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

The configuration form for innova recorders throws a 500 error because the button name is required.