### PR TITLE
[CoreBundle] Increasing workspace import speed

### DIFF
--- a/main/core/Library/Transfert/ConfigurationBuilders/GroupsImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/GroupsImporter.php
@@ -11,13 +11,12 @@
 
 namespace Claroline\CoreBundle\Library\Transfert\ConfigurationBuilders;
 
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Claroline\CoreBundle\Library\Transfert\Importer;
-use Symfony\Component\Config\Definition\Processor;
-use JMS\DiExtraBundle\Annotation as DI;
 use Claroline\CoreBundle\Persistence\ObjectManager;
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
 
 /**
  * @DI\Service("claroline.importer.groups_importer")
@@ -51,7 +50,7 @@ class GroupsImporter extends Importer implements ConfigurationInterface
     {
         $configuration = $this->getConfiguration();
         $names = $this->om->getRepository('Claroline\CoreBundle\Entity\Group')->findNames();
-        $availableUsernames = array();
+        $availableUsernames = [];
 
         foreach ($this->om->getRepository('Claroline\CoreBundle\Entity\User')->findUsernames() as $username) {
             $availableUsernames[] = $username['username'];
@@ -69,7 +68,7 @@ class GroupsImporter extends Importer implements ConfigurationInterface
             $availableUsernames[] = $configuration['members']['owner']['username'];
         }
 
-        $availableRoleName = array();
+        $availableRoleName = [];
 
         if (isset($configuration['roles'])) {
             foreach ($configuration['roles'] as $role) {
@@ -88,7 +87,7 @@ class GroupsImporter extends Importer implements ConfigurationInterface
                                         function ($v) use ($names) {
                                             return call_user_func_array(
                                                 __CLASS__.'::nameAlreadyExistsInDatabase',
-                                                array($v, $names)
+                                                [$v, $names]
                                             );
                                         }
                                     )
@@ -99,7 +98,7 @@ class GroupsImporter extends Importer implements ConfigurationInterface
                                         function ($v) use ($names) {
                                             return call_user_func_array(
                                                 __CLASS__.'::nameAlreadyExistsInConfig',
-                                                array($v, $names)
+                                                [$v, $names]
                                             );
                                         }
                                     )
@@ -115,7 +114,7 @@ class GroupsImporter extends Importer implements ConfigurationInterface
                                                     function ($v) use ($availableUsernames) {
                                                         return call_user_func_array(
                                                             __CLASS__.'::usernameExists',
-                                                            array($v, $availableUsernames)
+                                                            [$v, $availableUsernames]
                                                         );
                                                     }
                                                 )
@@ -134,7 +133,7 @@ class GroupsImporter extends Importer implements ConfigurationInterface
                                                 function ($v) use ($availableRoleName) {
                                                     return call_user_func_array(
                                                         __CLASS__.'::roleNameExists',
-                                                        array($v, $availableRoleName)
+                                                        [$v, $availableRoleName]
                                                     );
                                                 }
                                             )
@@ -195,9 +194,9 @@ class GroupsImporter extends Importer implements ConfigurationInterface
         return false;
     }
 
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
-        return array();
+        return [];
     }
 
     public function import(array $data)

--- a/main/core/Library/Transfert/ConfigurationBuilders/RolesImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/RolesImporter.php
@@ -160,7 +160,7 @@ class RolesImporter extends Importer implements ConfigurationInterface
         return $entityRoles;
     }
 
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
         $data = [];
 

--- a/main/core/Library/Transfert/ConfigurationBuilders/Tools/HomeImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/Tools/HomeImporter.php
@@ -204,7 +204,7 @@ class HomeImporter extends Importer implements ConfigurationInterface, RichTextI
         }
     }
 
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
         $homeTabs = $this->container->get('claroline.manager.home_tab_manager')
             ->getWorkspaceHomeTabConfigsByWorkspace($workspace);

--- a/main/core/Library/Transfert/ConfigurationBuilders/Tools/ResourceManagerImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/Tools/ResourceManagerImporter.php
@@ -744,8 +744,6 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
             $this->getCreationRightsArray($role['role']['rights']['create']) :
             [];
 
-        //is it in the identity map ?
-        $this->log('get creation rights');
         $createdRights = $this->rightManager->getRightsFromIdentityMapOrScheduledForInsert(
             $role['role']['name'],
             $resourceEntity->getResourceNode()
@@ -759,7 +757,6 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
 
         //There is no ResourceRight in the IdentityMap so we must create it
         if ($createdRights === null) {
-            $this->log('create resource rights');
             $this->rightManager->create(
                 $role['role']['rights'],
                 $entityRole,
@@ -769,7 +766,6 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
             );
             //We use the ResourceRight from the IdentityMap
         } else {
-            $this->log('set mask');
             $createdRights->setMask($this->maskManager->encodeMask(
                     $role['role']['rights'],
                     $createdRights->getResourceNode()->getResourceType())

--- a/main/core/Library/Transfert/ConfigurationBuilders/Tools/ResourceManagerImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/Tools/ResourceManagerImporter.php
@@ -326,7 +326,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
         }
     }
 
-    public function export(Workspace $workspace, array &$_files, $object)
+    public function export($workspace, array &$_files, $object)
     {
         $_data = [];
         //first we get the root

--- a/main/core/Library/Transfert/ConfigurationBuilders/Tools/Resources/ActivityImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/Tools/Resources/ActivityImporter.php
@@ -14,7 +14,6 @@ use Claroline\CoreBundle\Entity\Activity\ActivityParameters;
 use Claroline\CoreBundle\Entity\Resource\Activity;
 use Claroline\CoreBundle\Entity\Resource\File;
 use Claroline\CoreBundle\Entity\Resource\ResourceNode;
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Library\Transfert\Importer;
 use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
 use JMS\DiExtraBundle\Annotation as DI;
@@ -139,7 +138,7 @@ class ActivityImporter extends Importer implements ConfigurationInterface, RichT
         }
     }
 
-    public function export(Workspace $workspace, array &$_files, $object)
+    public function export($workspace, array &$_files, $object)
     {
         // we need to add things that aren't here first...
         $_data = &$this->getExtendedData();

--- a/main/core/Library/Transfert/ConfigurationBuilders/Tools/Resources/FileImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/Tools/Resources/FileImporter.php
@@ -11,7 +11,6 @@
 namespace Claroline\CoreBundle\Library\Transfert\ConfigurationBuilders\Tools\Resources;
 
 use Claroline\CoreBundle\Entity\Resource\File;
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Library\Transfert\Importer;
 use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
 use JMS\DiExtraBundle\Annotation as DI;
@@ -111,7 +110,7 @@ class FileImporter extends Importer implements ConfigurationInterface, RichTextI
         );
     }
 
-    public function export(Workspace $workspace, array &$_files, $object)
+    public function export($workspace, array &$_files, $object)
     {
         $hash = $object->getHashName();
         $uid = uniqid().'.'.pathinfo($hash, PATHINFO_EXTENSION);

--- a/main/core/Library/Transfert/ConfigurationBuilders/Tools/Resources/TextImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/Tools/Resources/TextImporter.php
@@ -11,7 +11,6 @@
 
 namespace Claroline\CoreBundle\Library\Transfert\ConfigurationBuilders\Tools\Resources;
 
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Library\Transfert\Importer;
 use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
 use JMS\DiExtraBundle\Annotation as DI;
@@ -110,7 +109,7 @@ class TextImporter extends Importer implements ConfigurationInterface, RichTextI
         return !file_exists($rootpath.$ds.$v);
     }
 
-    public function export(Workspace $workspace, array &$_files, $object)
+    public function export($workspace, array &$_files, $object)
     {
         $content = $this->om->getRepository('Claroline\CoreBundle\Entity\Resource\Revision')
             ->getLastRevision($object)->getContent();

--- a/main/core/Library/Transfert/ConfigurationBuilders/Tools/Widgets/TextImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/Tools/Widgets/TextImporter.php
@@ -13,7 +13,6 @@ namespace Claroline\CoreBundle\Library\Transfert\ConfigurationBuilders\Tools\Wid
 
 use Claroline\CoreBundle\Entity\Widget\SimpleTextConfig;
 use Claroline\CoreBundle\Entity\Widget\WidgetInstance;
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Library\Transfert\Importer;
 use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
 use Claroline\CoreBundle\Persistence\ObjectManager;
@@ -93,7 +92,7 @@ class TextImporter extends Importer implements ConfigurationInterface, RichTextI
             ->end();
     }
 
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
         $txtConfig = $this->container->get('claroline.manager.simple_text_manager')->getTextConfig($object);
         $tmpPath = $this->container->get('claroline.config.platform_config_handler')->getParameter('tmp_dir').DIRECTORY_SEPARATOR.uniqid().'.txt';

--- a/main/core/Library/Transfert/ConfigurationBuilders/ToolsImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/ToolsImporter.php
@@ -200,7 +200,7 @@ class ToolsImporter extends Importer implements ConfigurationInterface
         return 'tools';
     }
 
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
         $data = [];
         $workspaceTools = $workspace->getOrderedTools();

--- a/main/core/Library/Transfert/ConfigurationBuilders/UsersImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/UsersImporter.php
@@ -11,13 +11,13 @@
 
 namespace Claroline\CoreBundle\Library\Transfert\ConfigurationBuilders;
 
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-use Claroline\CoreBundle\Library\Transfert\Importer;
-use Symfony\Component\Config\Definition\Processor;
-use JMS\DiExtraBundle\Annotation as DI;
-use Claroline\CoreBundle\Persistence\ObjectManager;
 use Claroline\CoreBundle\Entity\Workspace\Workspace;
+use Claroline\CoreBundle\Library\Transfert\Importer;
+use Claroline\CoreBundle\Persistence\ObjectManager;
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
 
 /**
  * @DI\Service("claroline.importer.users_importer")
@@ -53,14 +53,14 @@ class UsersImporter extends Importer implements ConfigurationInterface
 
     public function addUsersSection($rootNode)
     {
-        $usernames = array();
+        $usernames = [];
 
         foreach ($this->om->getRepository('Claroline\CoreBundle\Entity\User')->findUsernames() as $username) {
             $usernames[] = $username['username'];
         }
 
         $configuration = $this->getConfiguration();
-        $availableRoleName = array();
+        $availableRoleName = [];
 
         if (isset($configuration['roles'])) {
             foreach ($configuration['roles'] as $role) {
@@ -91,7 +91,7 @@ class UsersImporter extends Importer implements ConfigurationInterface
                                         function ($v) use ($usernames) {
                                             return call_user_func_array(
                                                 __CLASS__.'::usernameMissingInDatabase',
-                                                array($v, $usernames)
+                                                [$v, $usernames]
                                             );
                                         }
                                     )
@@ -107,7 +107,7 @@ class UsersImporter extends Importer implements ConfigurationInterface
                                                 function ($v) use ($availableRoleName) {
                                                     return call_user_func_array(
                                                         __CLASS__.'::roleNameExists',
-                                                        array($v, $availableRoleName)
+                                                        [$v, $availableRoleName]
                                                     );
                                                 }
                                             )
@@ -138,7 +138,7 @@ class UsersImporter extends Importer implements ConfigurationInterface
     {
         $processor = new Processor();
         self::setData($data);
-        $configuration = $processor->processConfiguration($this, $data);
+        $processor->processConfiguration($this, $data);
     }
 
     public function import(array $data, array $entityRoles)
@@ -147,7 +147,7 @@ class UsersImporter extends Importer implements ConfigurationInterface
 
         foreach ($data as $user) {
             $userEntities = $this->om->getRepository('ClarolineCoreBundle:User')
-                ->findBy(array('username' => $user['user']['username']));
+                ->findBy(['username' => $user['user']['username']]);
 
             if (isset($user['user']['roles']) && count($userEntities) === 1) {
                 foreach ($user['user']['roles'] as $role) {
@@ -180,8 +180,8 @@ class UsersImporter extends Importer implements ConfigurationInterface
         return $owner === $v ? true : false;
     }
 
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
-        return array();
+        return [];
     }
 }

--- a/main/core/Library/Transfert/ConfigurationBuilders/WorkspacePropertiesImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/WorkspacePropertiesImporter.php
@@ -11,13 +11,13 @@
 
 namespace Claroline\CoreBundle\Library\Transfert\ConfigurationBuilders;
 
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Library\Transfert\Importer;
-use Symfony\Component\Config\Definition\Processor;
 use Claroline\CoreBundle\Persistence\ObjectManager;
 use JMS\DiExtraBundle\Annotation as DI;
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
 
 /**
  * @DI\Service("claroline.importer.properties_importer")
@@ -82,7 +82,7 @@ class WorkspacePropertiesImporter extends Importer implements ConfigurationInter
     {
         $ws = $this->om->getRepository('ClarolineCoreBundle:Workspace\AbstractWorkspace')->findByCode($code);
 
-        if ($ws !== array()) {
+        if ($ws !== []) {
             throw new \Exception('The code '.$code.' already exists');
         }
     }
@@ -108,8 +108,8 @@ class WorkspacePropertiesImporter extends Importer implements ConfigurationInter
         return true;
     }
 
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
-        return array();
+        return [];
     }
 }

--- a/main/core/Library/Transfert/Importer.php
+++ b/main/core/Library/Transfert/Importer.php
@@ -163,5 +163,5 @@ abstract class Importer
       * @param mixed $object
       * @param mixed $data
       */
-     abstract public function export(Workspace $workspace, array &$files, $object);
+     abstract public function export($workspace, array &$files, $object);
 }

--- a/main/core/Manager/TransferManager.php
+++ b/main/core/Manager/TransferManager.php
@@ -164,12 +164,16 @@ class TransferManager
         $data = $this->container->get('claroline.manager.workspace_manager')->getTemplateData($template, true);
         $data = $this->reorderData($data);
 
-        if ($workspace->getCode() === null) {
+        if ($workspace->getCode() === null && isset($data['parameters'])) {
             $workspace->setCode($data['parameters']['code']);
+        } else {
+            $workspace->setCode(uniqid());
         }
 
-        if ($workspace->getName() === null) {
+        if ($workspace->getName() === null && isset($data['parameters'])) {
             $workspace->setName($data['parameters']['name']);
+        } else {
+            $workspace->setName(uniqid());
         }
 
         //just to be sure doctrine is ok before doing all the workspace
@@ -408,7 +412,7 @@ class TransferManager
     private function setImporters(File $template, User $owner, array $data)
     {
         foreach ($this->listImporters as $importer) {
-            $importer->setRootPath($this->templateDirectory.DIRECTORY_SEPARATOR.$template->getBasename());
+            $importer->setRootPath($this->templateDirectory.$template->getBasename('.zip'));
             $importer->setOwner($owner);
             $importer->setConfiguration($data);
             $importer->setListImporters($this->listImporters);

--- a/main/core/Manager/TransferManager.php
+++ b/main/core/Manager/TransferManager.php
@@ -287,7 +287,7 @@ class TransferManager
     /**
      * Full workspace export.
      */
-    public function export(Workspace $workspace)
+    public function export($workspace)
     {
         $this->log("Exporting {$workspace->getCode()}...");
 

--- a/main/core/Manager/WorkspaceManager.php
+++ b/main/core/Manager/WorkspaceManager.php
@@ -1192,11 +1192,12 @@ class WorkspaceManager
 
         $archive = new \ZipArchive();
         $fileName = $file->getBasename('.zip');
-        $extractPath = $this->templateDirectory.DIRECTORY_SEPARATOR.$fileName;
+        $extractPath = $this->templateDirectory.$fileName;
 
         if ($archive->open($file->getPathname())) {
             $fs = new FileSystem();
             $fs->mkdir($extractPath);
+            $this->log("Extracting workspace to {$extractPath}...");
 
             if (!$archive->extractTo($extractPath)) {
                 throw new \Exception("The workspace archive couldn't be extracted");

--- a/plugin/announcement/Transfer/AnnouncementImporter.php
+++ b/plugin/announcement/Transfer/AnnouncementImporter.php
@@ -13,7 +13,6 @@ namespace Claroline\AnnouncementBundle\Transfer;
 
 use Claroline\AnnouncementBundle\Entity\Announcement;
 use Claroline\AnnouncementBundle\Entity\AnnouncementAggregate;
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Library\Transfert\Importer;
 use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
 use JMS\DiExtraBundle\Annotation as DI;
@@ -157,7 +156,7 @@ class AnnouncementImporter extends Importer implements ConfigurationInterface, R
         return $announcementAggregate;
     }
 
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
         $data = [];
         $announcements = $object->getAnnouncements();

--- a/plugin/blog/Transfer/BlogImporter.php
+++ b/plugin/blog/Transfer/BlogImporter.php
@@ -45,7 +45,7 @@ class BlogImporter extends Importer implements ConfigurationInterface
                 ->arrayNode('options')
                     ->children()
                         ->booleanNode('authorize_comment')->defaultFalse()->end()
-                        ->booleanNode('authorize_anonymous_comment')->defaultFalse()->end()
+                        ->booleanNode('a$configurationuthorize_anonymous_comment')->defaultFalse()->end()
                         ->integerNode('post_per_page')->defaultValue(10)->end()
                         ->booleanNode('auto_publish_post')->defaultFalse()->end()
                         ->booleanNode('auto_publish_comment')->defaultFalse()->end()
@@ -109,7 +109,7 @@ class BlogImporter extends Importer implements ConfigurationInterface
     public function validate(array $data)
     {
         $processor = new Processor();
-        $result = $processor->processConfiguration($this, $data);
+        $processor->processConfiguration($this, $data);
     }
 
     /**
@@ -130,7 +130,7 @@ class BlogImporter extends Importer implements ConfigurationInterface
      *
      * @return array
      */
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
         return $this->blogManager->exportBlog($workspace, $files, $object);
     }

--- a/plugin/collecticiel/Manager/CollecticielManager.php
+++ b/plugin/collecticiel/Manager/CollecticielManager.php
@@ -66,7 +66,7 @@ class CollecticielManager
      *
      * @return array
      */
-    public function export(Workspace $workspace, array &$files, Dropzone $dropzone)
+    public function export($workspace, array &$files, Dropzone $dropzone)
     {
         $data = [];
 

--- a/plugin/collecticiel/Transfer/CollecticielImporter.php
+++ b/plugin/collecticiel/Transfer/CollecticielImporter.php
@@ -2,12 +2,11 @@
 
 namespace Innova\CollecticielBundle\Transfer;
 
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
-use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-use Symfony\Component\Config\Definition\Processor;
 use Claroline\CoreBundle\Library\Transfert\Importer;
+use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class CollecticielImporter extends Importer implements ConfigurationInterface, RichTextInterface
@@ -80,7 +79,7 @@ class CollecticielImporter extends Importer implements ConfigurationInterface, R
         return $this->container->get('innova.manager.collecticiel_manager')->import($data, $created, $this->getRootPath());
     }
 
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
         return $this->container->get('innova.manager.collecticiel_manager')->export($workspace, $files, $object);
     }

--- a/plugin/exo/Transfer/ExerciseImporter.php
+++ b/plugin/exo/Transfer/ExerciseImporter.php
@@ -2,7 +2,6 @@
 
 namespace UJM\ExoBundle\Transfer;
 
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Library\Configuration\PlatformConfigurationHandler;
 use Claroline\CoreBundle\Library\Transfert\Importer;
 use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
@@ -124,7 +123,7 @@ class ExerciseImporter extends Importer implements RichTextInterface
         $this->om->persist($exercise);
     }
 
-    public function export(Workspace $workspace, array &$files, $exercise)
+    public function export($workspace, array &$files, $exercise)
     {
         $exerciseData = $this->serializer->serialize($exercise, [Transfer::INCLUDE_SOLUTIONS]);
 

--- a/plugin/forum/Transfert/ForumImporter.php
+++ b/plugin/forum/Transfert/ForumImporter.php
@@ -11,7 +11,6 @@
 
 namespace Claroline\ForumBundle\Transfert;
 
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Library\Transfert\Importer;
 use Claroline\ForumBundle\Entity\Category;
 use Claroline\ForumBundle\Entity\Forum;
@@ -170,7 +169,7 @@ class ForumImporter extends Importer implements ConfigurationInterface
         return $forum;
     }
 
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
         $categories = $object->getCategories();
         $data = [];

--- a/plugin/lesson/Transfert/LessonImporter.php
+++ b/plugin/lesson/Transfert/LessonImporter.php
@@ -5,7 +5,7 @@
  * (c) Claroline Consortium <consortium@claroline.net>
  *
  * Author: Panagiotis TSAVDARIS
- * 
+ *
  * Date: 3/10/15
  */
 
@@ -13,13 +13,13 @@ namespace Icap\LessonBundle\Transfert;
 
 use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Library\Transfert\Importer;
-use Icap\LessonBundle\Manager\LessonManager;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use JMS\DiExtraBundle\Annotation as DI;
 use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
 use Claroline\CoreBundle\Persistence\ObjectManager;
+use Icap\LessonBundle\Manager\LessonManager;
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -66,7 +66,6 @@ class LessonImporter extends Importer implements ConfigurationInterface, RichTex
 
     public function addLessonDescription($rootNode)
     {
-        $rootPath = $this->getRootPath();
         $rootNode
             ->children()
                 ->arrayNode('chapters')
@@ -102,7 +101,7 @@ class LessonImporter extends Importer implements ConfigurationInterface, RichTex
      *
      * @return array $data
      */
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
         return $this->lessonManager->exportLesson($workspace, $files, $object);
     }

--- a/plugin/path/Manager/PathManager.php
+++ b/plugin/path/Manager/PathManager.php
@@ -282,7 +282,7 @@ class PathManager
         return $this;
     }
 
-    public function export(Workspace $workspace, array &$files, Path $path)
+    public function export($workspace, array &$files, Path $path)
     {
         $data = [];
 

--- a/plugin/path/Transfer/PathImporter.php
+++ b/plugin/path/Transfer/PathImporter.php
@@ -2,7 +2,6 @@
 
 namespace Innova\PathBundle\Transfer;
 
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Library\Transfert\Importer;
 use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -160,7 +159,7 @@ class PathImporter extends Importer implements ConfigurationInterface, RichTextI
         return $this->container->get('innova_path.manager.path')->import($structure, $data, $created);
     }
 
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
         return $this->container->get('innova_path.manager.path')->export($workspace, $files, $object);
     }

--- a/plugin/scorm/Transfert/ScormImporter.php
+++ b/plugin/scorm/Transfert/ScormImporter.php
@@ -12,12 +12,12 @@
 namespace Claroline\ScormBundle\Transfert;
 
 use Claroline\CoreBundle\Library\Transfert\Importer;
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Claroline\ScormBundle\Entity\Scorm12Resource;
 use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
 
 class ScormImporter extends Importer implements ConfigurationInterface
 {
@@ -57,7 +57,7 @@ class ScormImporter extends Importer implements ConfigurationInterface
                                         function ($v) use ($rootPath) {
                                             return call_user_func_array(
                                                 __CLASS__.'::fileNotExists',
-                                                array($v, $rootPath)
+                                                [$v, $rootPath]
                                             );
                                         }
                                     )
@@ -74,7 +74,7 @@ class ScormImporter extends Importer implements ConfigurationInterface
 
     public function supports($type)
     {
-        return $type == 'yml' ? true : false;
+        return $type === 'yml' ? true : false;
     }
 
     public function validate(array $data)
@@ -83,20 +83,20 @@ class ScormImporter extends Importer implements ConfigurationInterface
         $processor->processConfiguration($this, $data);
     }
 
-    public function export(Workspace $workspace, array &$_files, $object)
+    public function export($workspace, array &$_files, $object)
     {
         $hash = $object->getHashName();
         $uid = uniqid().'.'.pathinfo($hash, PATHINFO_EXTENSION);
         $_files[$uid] = $this->container
             ->getParameter('claroline.param.files_directory').DIRECTORY_SEPARATOR.$hash;
-        $data = array();
-        $version = $object instanceof \Claroline\ScormBundle\Entity\Scorm12Resource ? '1.2' : '2004';
+        $data = [];
+        $version = $object instanceof Scorm12Resource ? '1.2' : '2004';
 
         if (file_exists($_files[$uid])) {
-            $data = array(array('scorm' => array(
+            $data = [['scorm' => [
                 'path' => $uid,
                 'version' => $version,
-            )));
+            ]]];
         }
 
         return $data;

--- a/plugin/web-resource/Transfer/WebResourceImporter.php
+++ b/plugin/web-resource/Transfer/WebResourceImporter.php
@@ -10,15 +10,14 @@
 
 namespace Claroline\WebResourceBundle\Transfer;
 
+use Claroline\CoreBundle\Entity\Resource\File;
 use Claroline\CoreBundle\Library\Transfert\Importer;
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\HttpFoundation\File\File as SfFile;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Claroline\CoreBundle\Entity\Resource\File;
-use Claroline\CoreBundle\Entity\Workspace\Workspace;
 
 /**
  * @DI\Service("claroline.tool.resources.web_resource")
@@ -62,7 +61,7 @@ class WebResourceImporter extends Importer implements ConfigurationInterface
                                             function ($v) use ($rootPath) {
                                                 return call_user_func_array(
                                                     __CLASS__.'::fileNotExists',
-                                                    array($v, $rootPath)
+                                                    [$v, $rootPath]
                                                 );
                                             }
                                         )
@@ -78,7 +77,7 @@ class WebResourceImporter extends Importer implements ConfigurationInterface
 
     public function supports($type)
     {
-        return $type == 'yml' ? true : false;
+        return $type === 'yml' ? true : false;
     }
 
     public function validate(array $data)
@@ -102,18 +101,18 @@ class WebResourceImporter extends Importer implements ConfigurationInterface
         );
     }
 
-    public function export(Workspace $workspace, array &$_files, $object)
+    public function export($workspace, array &$_files, $object)
     {
         $hash = $object->getHashName();
         $uid = uniqid().'.'.pathinfo($hash, PATHINFO_EXTENSION);
         $_files[$uid] = $this->container
             ->getParameter('claroline.param.files_directory').DIRECTORY_SEPARATOR.$hash;
-        $data = array();
+        $data = [];
 
         if (file_exists($_files[$uid])) {
-            $data = array(array('file' => array(
+            $data = [['file' => [
                 'path' => $uid,
-            )));
+            ]]];
         }
 
         return $data;

--- a/plugin/website/Transfert/WebsiteImporter.php
+++ b/plugin/website/Transfert/WebsiteImporter.php
@@ -5,7 +5,7 @@
  * (c) Claroline Consortium <consortium@claroline.net>
  *
  * Author: Panagiotis TSAVDARIS
- * 
+ *
  * Date: 3/12/15
  */
 
@@ -14,10 +14,10 @@ namespace Icap\WebsiteBundle\Transfert;
 use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Library\Transfert\Importer;
 use Icap\WebsiteBundle\Manager\WebsiteManager;
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-use Symfony\Component\Config\Definition\Processor;
 use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
 
 /**
  * @DI\Service("claroline.importer.icap_website_importer")
@@ -144,7 +144,7 @@ class WebsiteImporter extends Importer implements ConfigurationInterface
      *
      * @return array $data
      */
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
         return $this->websiteManager->exportWebsite($workspace, $files, $object);
     }

--- a/plugin/wiki/Transfert/WikiImporter.php
+++ b/plugin/wiki/Transfert/WikiImporter.php
@@ -13,14 +13,14 @@ namespace Icap\WikiBundle\Transfert;
 
 use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Library\Transfert\Importer;
-use Icap\WikiBundle\Manager\WikiManager;
-use Symfony\Component\Config\Definition\Builder\TreeBuilder;
-use Symfony\Component\Config\Definition\Processor;
-use Symfony\Component\Config\Definition\ConfigurationInterface;
-use JMS\DiExtraBundle\Annotation as DI;
 use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Claroline\CoreBundle\Persistence\ObjectManager;
+use Icap\WikiBundle\Manager\WikiManager;
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Processor;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @DI\Service("claroline.importer.icap_wiki_importer")
@@ -68,7 +68,6 @@ class WikiImporter extends Importer implements ConfigurationInterface, RichTextI
 
     public function addWikiDescription($rootNode)
     {
-        $rootPath = $this->getRootPath();
         $rootNode
             ->children()
                 ->arrayNode('options')
@@ -112,7 +111,7 @@ class WikiImporter extends Importer implements ConfigurationInterface, RichTextI
     public function validate(array $data)
     {
         $processor = new Processor();
-        $result = $processor->processConfiguration($this, $data);
+        $processor->processConfiguration($this, $data);
     }
 
     public function import(array $data)
@@ -130,7 +129,7 @@ class WikiImporter extends Importer implements ConfigurationInterface, RichTextI
      *
      * @return array
      */
-    public function export(Workspace $workspace, array &$files, $object)
+    public function export($workspace, array &$files, $object)
     {
         return $this->wikiManager->exportWiki($workspace, $files, $object);
     }

--- a/plugin/wiki/Transfert/WikiImporter.php
+++ b/plugin/wiki/Transfert/WikiImporter.php
@@ -138,13 +138,13 @@ class WikiImporter extends Importer implements ConfigurationInterface, RichTextI
     {
         if (isset($data['sections'])) {
             foreach ($data['sections'] as $section) {
-                if (isset($data['contributions'])) {
+                if (isset($section['contributions'])) {
                     foreach ($section['contributions'] as $contribution) {
                         //look for the text with the exact same content (it's really bad I know but at least it works
-                         $text = file_get_contents($this->getRootPath().DIRECTORY_SEPARATOR.$contribution['contribution']['path']);
+                        $text = file_get_contents($this->getRootPath().DIRECTORY_SEPARATOR.$contribution['contribution']['path']);
                         $entities = $this->om->getRepository('Icap\WikiBundle\Entity\Contribution')->findByText($text);
                          //avoid circulary dependency
-                         $text = $this->container->get('claroline.importer.rich_text_formatter')->format($text);
+                        $text = $this->container->get('claroline.importer.rich_text_formatter')->format($text);
 
                         foreach ($entities as $entity) {
                             $entity->setText($text);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

This condition allow the import to work even if the manifest is overloaded with roles.
Roles with no permissions are skipped for performance issues because since they have no perm, they have no effect other than slowing down everything else.

Also fixes some path issues.
