### PR TITLE
[WikiBundle] Fix for anonymous wiki access and display

### DIFF
--- a/plugin/wiki/Repository/SectionRepository.php
+++ b/plugin/wiki/Repository/SectionRepository.php
@@ -30,7 +30,7 @@ class SectionRepository extends NestedTreeRepository
                 $queryBuilder->expr()->isNull('section.deleted')
             )
         )->setParameter('deleted', false);
-        if ($isAdmin === false) {
+        if ($isAdmin === false && $user !== null) {
             $queryBuilder
                 ->andWhere(
                     $queryBuilder->expr()->orX(
@@ -38,6 +38,11 @@ class SectionRepository extends NestedTreeRepository
                         'section.author = :userId'
                     )
                 )->setParameter('visible', true)->setParameter('userId', $user->getId());
+        }
+        if ($isAdmin === false && $user === null) {
+            $queryBuilder
+                ->andWhere('section.visible = :visible')
+                ->setParameter('visible', true);
         }
         $options = ['decorate' => false];
         $tree = $this->buildTree($queryBuilder->getQuery()->getArrayResult(), $options);

--- a/plugin/wiki/Resources/modules/wiki/wiki.controller.js
+++ b/plugin/wiki/Resources/modules/wiki/wiki.controller.js
@@ -243,12 +243,13 @@ export default class WikiController {
 
   _saveSectionWithNewContribution(section, newContrib, updatedSection) {
     this.wiki.editSection(section, newContrib, updatedSection).then(
-      () => {
+      success => {
         if (newContrib.id === 0) {
           this._setMessage('success', 'icap_wiki_section_add_success')
         } else {
           this._setMessage('success', 'icap_wiki_section_update_success')
         }
+        _$location.get(this).hash(`sect-${success.section.id}`)
       },
       () => {
         if (newContrib.id === 0) {
@@ -256,6 +257,7 @@ export default class WikiController {
         } else {
           this._setMessage('danger', 'icap_wiki_section_update_error')
         }
+        _$location.get(this).hash('top')
       }
     ).finally(
       () => {
@@ -263,6 +265,8 @@ export default class WikiController {
         this.currentSections = []
         this.disableFormButtons = false
         this.isFormOpen = false
+
+        _$anchorScroll.get(this)()
       }
     )
   }
@@ -280,6 +284,9 @@ export default class WikiController {
     ).finally(() => {
       this.disableFormButtons = false
       this.isFormOpen = false
+
+      _$location.get(this).hash(`sect-${section.id}`)
+      _$anchorScroll.get(this)()
     })
   }
 

--- a/plugin/wiki/Resources/public/css/style.css
+++ b/plugin/wiki/Resources/public/css/style.css
@@ -77,7 +77,7 @@ ul#wiki-contents-list li.invisible-wiki-content a,
 ol#wiki-contents-list li.invisible-wiki-content a { color:#999; }
 ol#wiki-contents-list, ol#wiki-contents-list ol { list-style-type:none; counter-reset: item; }
 ol#wiki-contents-list li { counter-increment: item; }
-ol#wiki-contents-list li a:before { content: counters(item, "."); }
+ol#wiki-contents-list li a:before { content: counters(item, ".") " - "; }
 
 
 /*Wiki sections*/
@@ -112,7 +112,7 @@ div.wiki-sections ol#wiki-sections-list ol.wiki-sections-list-elem>li.with-numbe
 div.wiki-sections ol#wiki-sections-list ol.wiki-sections-list-elem>li.with-numbers h4::before,
 div.wiki-sections ol#wiki-sections-list ol.wiki-sections-list-elem>li.with-numbers h5::before,
 div.wiki-sections ol#wiki-sections-list ol.wiki-sections-list-elem>li.with-numbers h6::before
-{ content: counters(section, "."); }
+{ content: counters(section, ".") " - "; }
 
 /*Delete section form*/
 .icap-wiki-delete-section-message {margin: 10px 0 20px 0; font-size: 16px;}

--- a/plugin/wiki/Resources/views/Wiki/view.html.twig
+++ b/plugin/wiki/Resources/views/Wiki/view.html.twig
@@ -32,7 +32,7 @@
 
     <script type="text/javascript">
         angular.module('WikiModule').value('wiki', {
-            activeUserId: {{ user is not empty ? user.id : "'null'" }},
+            activeUserId: {{ user is not empty ? user.id : 'null' }},
             id: {{ _resource.id }},
             title: "{{ _resource.resourceNode.name }}",
             mode: {{ _resource.mode }},
@@ -42,7 +42,9 @@
             isPDFExportActive: {{ config.getParameter('is_pdf_export_active') == true ? 'true' : 'false' }},
             sections: {{ tree|json_encode(constant('JSON_PRETTY_PRINT'))|raw }},
             deletedSections: {{ deletedSections|json_encode(constant('JSON_PRETTY_PRINT'))|raw }},
+            {% if user is not empty %}
             notificationButton: `{% render controller('IcapNotificationBundle:FollowerResource:renderForm', {'resourceId': _resource.resourceNode.id, 'resourceClass': _resource.resourceNode.class}) %}`
+            {% endif %}
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | 

Anonymous user can access wiki again.
Section title and section number are separated by hyphen.
Display scrolls to top of newly created or modified section after save.


