### PR TITLE
[CoreBundle] Fixing WorkspaceAccessExtension

### DIFF
--- a/main/core/Twig/WorkspaceAccessExtension.php
+++ b/main/core/Twig/WorkspaceAccessExtension.php
@@ -69,8 +69,12 @@ class WorkspaceAccessExtension extends \Twig_Extension
         ];
     }
 
-    public function isDateAccessValid(Workspace $workspace)
+    public function isDateAccessValid($workspace)
     {
+        if (!$workspace) {
+            return true;
+        }
+
         $isEndValid = $workspace->getEndDate() ? $workspace->getEndDate() > new \DateTime() : true;
         $isStartValid = $workspace->getStartDate() ? $workspace->getStartDate() < new \DateTime() : true;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

If a resource has no workspace (it's currently allowed because users don't always have one), this function crashes.


