### PR TITLE
[ExoBundle] adds option to disable overview for users

### DIFF
--- a/plugin/exo/Entity/Exercise.php
+++ b/plugin/exo/Entity/Exercise.php
@@ -70,6 +70,15 @@ class Exercise extends AbstractResource
     private $interruptible = false;
 
     /**
+     * Show overview to users or directly start the quiz.
+     *
+     * @ORM\Column(name="show_overview", type="boolean")
+     *
+     * @var bool
+     */
+    private $showOverview = true;
+
+    /**
      * Show the Exercise meta in the overview of the Exercise.
      *
      * @var bool
@@ -291,6 +300,26 @@ class Exercise extends AbstractResource
     public function isInterruptible()
     {
         return $this->interruptible;
+    }
+
+    /**
+     * Set show overview.
+     *
+     * @param bool $showOverview
+     */
+    public function setShowOverview($showOverview)
+    {
+        $this->showOverview = $showOverview;
+    }
+
+    /**
+     * Is overview shown ?
+     *
+     * @return bool
+     */
+    public function getShowOverview()
+    {
+        return $this->showOverview;
     }
 
     /**

--- a/plugin/exo/Migrations/pdo_mysql/Version20170213070637.php
+++ b/plugin/exo/Migrations/pdo_mysql/Version20170213070637.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace UJM\ExoBundle\Migrations\pdo_mysql;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution.
+ *
+ * Generation date: 2017/02/13 07:06:40
+ */
+class Version20170213070637 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql('
+            ALTER TABLE ujm_exercise 
+            ADD show_overview TINYINT(1) NOT NULL
+        ');
+        $this->addSql('
+            UPDATE ujm_exercise SET show_overview = true
+        ');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql('
+            ALTER TABLE ujm_exercise 
+            DROP show_overview
+        ');
+    }
+}

--- a/plugin/exo/Resources/modules/quiz/actions.js
+++ b/plugin/exo/Resources/modules/quiz/actions.js
@@ -3,6 +3,7 @@ import {makeActionCreator} from './../utils/utils'
 import {navigate} from './router'
 import select from './selectors'
 import {VIEW_OVERVIEW} from './enums'
+import {actions as playerActions} from './player/actions'
 
 export const VIEW_MODE_UPDATE = 'VIEW_MODE_UPDATE'
 export const OPEN_FIRST_STEP = 'OPEN_FIRST_STEP'
@@ -22,8 +23,16 @@ const updateViewMode = (mode, hasFragment = true) => {
       !select.editorOpened(state) &&
       select.noItems(state)
     ) {
+      // Redirects to editor for admins if the quiz is empty
       navigate('editor', false)
       dispatch(openFirstStep(select.firstStepId(state)))
+    } else if (mode === VIEW_OVERVIEW &&
+      !select.editable(state) &&
+      !select.hasOverview(state)
+    ) {
+      // Redirects to player for users if overview is disabled
+      navigate('player', false)
+      dispatch(playerActions.play(null, false))
     } else {
       dispatch({
         type: VIEW_MODE_UPDATE,

--- a/plugin/exo/Resources/modules/quiz/editor/components/quiz-editor.jsx
+++ b/plugin/exo/Resources/modules/quiz/editor/components/quiz-editor.jsx
@@ -61,12 +61,21 @@ const Properties = props =>
       />
     </FormGroup>
     <CheckGroup
-      checkId="quiz-show-metadata"
-      checked={props.parameters.showMetadata}
-      label={tex('metadata_visible')}
-      help={tex('metadata_visible_help')}
-      onChange={checked => props.onChange('parameters.showMetadata', checked)}
+      checkId="quiz-show-overview"
+      checked={props.parameters.showOverview}
+      label={tex('show_overview')}
+      onChange={checked => props.onChange('parameters.showOverview', checked)}
     />
+
+    {props.parameters.showOverview &&
+      <CheckGroup
+        checkId="quiz-show-metadata"
+        checked={props.parameters.showMetadata}
+        label={tex('metadata_visible')}
+        help={tex('metadata_visible_help')}
+        onChange={checked => props.onChange('parameters.showMetadata', checked)}
+      />
+    }
   </fieldset>
 
 Properties.propTypes = {
@@ -74,6 +83,7 @@ Properties.propTypes = {
   description: T.string.isRequired,
   parameters: T.shape({
     type: T.string.isRequired,
+    showOverview: T.bool.isRequired,
     showMetadata: T.bool.isRequired
   }).isRequired,
   validating: T.bool.isRequired,
@@ -369,6 +379,7 @@ QuizEditor.propTypes = {
     description: T.string.isRequired,
     parameters: T.shape({
       type: T.string.isRequired,
+      showOverview: T.bool.isRequired,
       showMetadata: T.bool.isRequired,
       randomOrder: T.string.isRequired,
       randomPick: T.string.isRequired,

--- a/plugin/exo/Resources/modules/quiz/overview/overview.jsx
+++ b/plugin/exo/Resources/modules/quiz/overview/overview.jsx
@@ -131,7 +131,7 @@ const Layout = props =>
     }
 
     {props.empty && props.editable &&
-      <a href="#/steps" role="button" className="btn btn-block btn-primary btn-lg">
+      <a href="#/editor" role="button" className="btn btn-block btn-primary btn-lg">
         <span className="fa fa-pencil"></span>
         {tex('edit')}
       </a>

--- a/plugin/exo/Resources/modules/quiz/selectors.js
+++ b/plugin/exo/Resources/modules/quiz/selectors.js
@@ -22,6 +22,7 @@ const editorOpened = state => state.editor.opened
 const noItems = state =>
   Object.keys(state.quiz.steps).length === 1 && Object.keys(state.items).length === 0
 const firstStepId = state => state.quiz.steps[0]
+const hasOverview = state => state.quiz.parameters.showOverview
 
 export default {
   id,
@@ -43,5 +44,6 @@ export default {
   modal,
   editorOpened,
   noItems,
-  firstStepId
+  firstStepId,
+  hasOverview
 }

--- a/plugin/exo/Resources/translations/ujm_exo.en.json
+++ b/plugin/exo/Resources/translations/ujm_exo.en.json
@@ -481,6 +481,7 @@
     "show_instructions": "Show instructions",
     "show_interact_fields": "Hints and global feedback",
     "show_metadata_fields": "Title and other fields",
+    "show_overview": "Display quiz overview to users",
     "signing": "Signing",
     "size": "Size",
     "solution_score": "{0} %score% point|{1} %score% point|[2,Inf] %score% points",

--- a/plugin/exo/Resources/translations/ujm_exo.fr.json
+++ b/plugin/exo/Resources/translations/ujm_exo.fr.json
@@ -496,6 +496,7 @@
     "show_instructions": "Montrer les consignes",
     "show_interact_fields": "Indices et commentaire final",
     "show_metadata_fields": "Titre et autres champs",
+    "show_overview": "Afficher l'accueil du questionnaire aux utilisateurs",
     "signing": "Passation",
     "size": "Taille",
     "solution_score": "{-1, 0, 1} %score% point|[2,+Inf[ %score% points|]-Inf, -2] %score% points",

--- a/plugin/exo/Serializer/ExerciseSerializer.php
+++ b/plugin/exo/Serializer/ExerciseSerializer.php
@@ -166,6 +166,7 @@ class ExerciseSerializer implements SerializerInterface
         $parameters->interruptible = $exercise->isInterruptible();
 
         // Visibility parameters
+        $parameters->showOverview = $exercise->getShowOverview();
         $parameters->showMetadata = $exercise->isMetadataVisible();
         $parameters->showStatistics = $exercise->hasStatistics();
         $parameters->showFullCorrection = !$exercise->isMinimalCorrection();
@@ -246,6 +247,10 @@ class ExerciseSerializer implements SerializerInterface
 
         if (isset($parameters->interruptible)) {
             $exercise->setInterruptible($parameters->interruptible);
+        }
+
+        if (isset($parameters->showOverview)) {
+            $exercise->setShowOverview($parameters->showOverview);
         }
 
         if (isset($parameters->showMetadata)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes

This option only affects users who can not edit the quiz.

**Known issue**
For now, the overview is still displayed during the initialization (aka AJAX call) of the player.


