### PR TITLE
[9.x] Fixes links in agenda event widget that redirect to first tab

### DIFF
--- a/plugin/agenda/Resources/views/Widget/event_widget.html.twig
+++ b/plugin/agenda/Resources/views/Widget/event_widget.html.twig
@@ -39,8 +39,7 @@
             {{ event.getStartInDateTime()|date('d/m/Y') }},
         {% endif %}
 
-        <a href="#"
-           class="{{ event.isTask ? 'info-of-task' : 'info-of-event' }}"
+        <a class="{{ event.isTask ? 'info-of-task' : 'info-of-event' }}"
            tabindex="0"
            role="button"
            data-placement="top"


### PR DESCRIPTION
… #1986

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #1986 


