### PR TITLE
[ExoBundle] fixes quiz migration

### DIFF
--- a/plugin/exo/Installation/AdditionalInstaller.php
+++ b/plugin/exo/Installation/AdditionalInstaller.php
@@ -8,6 +8,7 @@ use UJM\ExoBundle\Installation\Updater\Updater060001;
 use UJM\ExoBundle\Installation\Updater\Updater060200;
 use UJM\ExoBundle\Installation\Updater\Updater070000;
 use UJM\ExoBundle\Installation\Updater\Updater090000;
+use UJM\ExoBundle\Installation\Updater\Updater090002;
 
 class AdditionalInstaller extends BaseInstaller
 {
@@ -59,6 +60,14 @@ class AdditionalInstaller extends BaseInstaller
                 $this->container->get('ujm_exo.serializer.exercise'),
                 $this->container->get('ujm_exo.serializer.step'),
                 $this->container->get('ujm_exo.serializer.question')
+            );
+            $updater->setLogger($this->logger);
+            $updater->postUpdate();
+        }
+
+        if (version_compare($currentVersion, '9.0.2', '<')) {
+            $updater = new Updater090002(
+                $this->container->get('doctrine.dbal.default_connection')
             );
             $updater->setLogger($this->logger);
             $updater->postUpdate();

--- a/plugin/exo/Installation/Updater/Updater090002.php
+++ b/plugin/exo/Installation/Updater/Updater090002.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace UJM\ExoBundle\Installation\Updater;
+
+use Claroline\BundleRecorder\Log\LoggableTrait;
+use Doctrine\DBAL\Connection;
+
+class Updater090002
+{
+    use LoggableTrait;
+
+    /**
+     * @var Connection
+     */
+    private $connection;
+
+    /**
+     * Updater090002 constructor.
+     *
+     * @param Connection $connection
+     */
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
+    public function postUpdate()
+    {
+        $this->fixQuizTypes();
+    }
+
+    private function fixQuizTypes()
+    {
+        $this->connection
+            ->prepare('
+                UPDATE ujm_exercise SET `type` = "summative" WHERE `type` = "1";
+            ')
+            ->execute();
+
+        $this->connection
+            ->prepare('
+                UPDATE ujm_exercise SET `type` = "summative" WHERE `type` = "sommatif";
+            ')
+            ->execute();
+
+        $this->connection
+            ->prepare('
+                UPDATE ujm_exercise SET `type` = "evaluative" WHERE `type` = "2";
+            ')
+            ->execute();
+
+        $this->connection
+            ->prepare('
+                UPDATE ujm_exercise SET `type` = "formative" WHERE `type` = "3";
+            ')
+            ->execute();
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #1994 

- Adds a new updater to fix migration of quiz types.
- Fixes answer data migration.

**Note about answer migration :**
I've directly fixes the original updater file because the fix is only here to filter incomplete answer data. 
In the old version when a user didn't answered a question, sometimes incomplete data were stored in the DB.

So if someone has already updated to 9.x and do not hit a bug, he doesn't need this fix.

ping @ptsavdar : this should solve your problems.


