### PR TITLE
[UrlBundle] Spoof user-agent header when validating URLs

### DIFF
--- a/plugin/url/Validator/Constraints/ReachableUrlValidator.php
+++ b/plugin/url/Validator/Constraints/ReachableUrlValidator.php
@@ -2,13 +2,13 @@
 
 namespace HeVinci\UrlBundle\Validator\Constraints;
 
+use Guzzle\Http\Client;
 use Guzzle\Http\Exception\ClientErrorResponseException;
 use Guzzle\Http\Exception\CurlException;
 use Guzzle\Http\Exception\ServerErrorResponseException;
+use JMS\DiExtraBundle\Annotation as DI;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\UrlValidator;
-use Guzzle\Http\Client;
-use JMS\DiExtraBundle\Annotation as DI;
 
 /**
  * @DI\Validator("url_validator")
@@ -29,40 +29,45 @@ class ReachableUrlValidator extends UrlValidator
         }
 
         $client = new Client();
+
         try {
-            $request = $client->head($value);
+            $request = $client->head(
+                $value,
+                // make request with a fake user-agent header to avoid possible restrictions on curl requests
+                ['User-Agent' => 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/55.0.2883.87 Chrome/55.0.2883.87 Safari/537.36']
+            );
             $response = $request->send();
 
             if (!$response->isSuccessful()) {
-                $this->context->addViolation($constraint->clientError, array(
+                $this->context->addViolation($constraint->clientError, [
                     '%errorCode%' => $response->getStatusCode(),
-                ));
+                ]);
             }
         } catch (CurlException $e) {
-            $this->context->addViolation($constraint->websiteDoesntExist, array(
+            $this->context->addViolation($constraint->websiteDoesntExist, [
                 '%url' => $value,
-            ));
+            ]);
         } catch (ClientErrorResponseException $e) {
             $errorCode = $e->getResponse()->getStatusCode();
 
-            if ($errorCode == 403) {
+            if ($errorCode === 403) {
                 $this->context->addViolation($constraint->accessDenied);
-            } elseif ($errorCode == 404) {
+            } elseif ($errorCode === 404) {
                 $this->context->addViolation($constraint->resNotFound);
-            } elseif ($errorCode == 405) {
+            } elseif ($errorCode === 405) {
                 $allow = $e->getResponse()->getHeaders()['allow'];
                 if (!preg_match('#GET#', $allow)) {
                     $this->context->addViolation($constraint->methodNotAllowed);
                 }
             } else {
-                $this->context->addViolation($constraint->clientError, array(
+                $this->context->addViolation($constraint->clientError, [
                     '%errorCode%' => $errorCode,
-                ));
+                ]);
             }
         } catch (ServerErrorResponseException $e) {
-            $this->context->addViolation($constraint->serverError, array(
+            $this->context->addViolation($constraint->serverError, [
                 '%errorCode%' => $e->getResponse()->getStatusCode(),
-            ));
+            ]);
         }
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

URLs are currently validated using curl requests but some websites reject them with a 406-like error code if they see the default curl user-agent header. This PR simply adds a real browser u-a header to prevent that behaviour.


