### PR TITLE
[CoreBundle] fixes polyfills import

### DIFF
--- a/main/core/Resources/views/Layout/javascripts.html.twig
+++ b/main/core/Resources/views/Layout/javascripts.html.twig
@@ -6,6 +6,10 @@
     }
 </script>
 
+{# Polyfills #}
+<script src="{{ hotAsset('dist/claroline-distribution-main-core-core-js.js') }}"></script>
+<script src="{{ hotAsset('dist/claroline-distribution-main-core-whatwg-fetch.js') }}"></script>
+
 {# SVG external reference polyfill for IE<13 #}
 {% javascripts debug=false filter='jsmin' output='vendor/svg4everybody/svg4everybody.js'
     '../node_modules/svg4everybody/dist/svg4everybody.js'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

This PR ensures that polyfills are always available in the base layout.
This fixes quizzes on Safari and IE11.


