### PR TITLE
Fixes call to getDetails() function when workspace options is null

### DIFF
--- a/main/core/Controller/ResourceController.php
+++ b/main/core/Controller/ResourceController.php
@@ -254,7 +254,11 @@ class ResourceController
         // Fetch workspace details, otherwise it won't store them in session.
         // I know it's not pretty but it's the only way
         // I could think of to load them before the node gets stored is session
-        $node->getWorkspace()->getOptions()->getDetails();
+        $options = $node->getWorkspace()->getOptions();
+
+        if ($options) {
+            $options->getDetails();
+        }
         $this->request->getSession()->set('current_resource_node', $node);
         $isIframe = (bool) $this->request->query->get('iframe');
         //double check... first the resource, then the target


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

