### PR TITLE
[CoreBundle] fixes javascripts load order

### DIFF
--- a/main/core/Resources/views/Layout/javascripts.html.twig
+++ b/main/core/Resources/views/Layout/javascripts.html.twig
@@ -1,5 +1,10 @@
 <script src="{{ hotAsset('dist/es6_dll.js') }}"></script>
 <script src="{{ hotAsset('dist/angular_dll.js') }}"></script>
+
+{% if app.environment == 'prod' %}
+    <script src="{{ hotAsset('dist/commons.js') }}"></script>
+{% endif %}
+
 <script>
     if (window.sessionStorage.getItem('hide_brower_warning')) {
         $('.outdated-browser-warning').hide();
@@ -163,10 +168,6 @@
 
 <script src="{{ asset('bundles/stfalcontinymce/vendor/tinymce/tinymce.jquery.min.js') }}"></script>
 <script src="{{ asset('bundles/stfalcontinymce/vendor/tinymce/jquery.tinymce.min.js') }}"></script><!-- this is not duplicated file -->
-
-{% if app.environment == 'prod' %}
-    <script src="{{ hotAsset('dist/commons.js') }}"></script>
-{% endif %}
 
 <script src="{{ hotAsset('dist/claroline-distribution-main-core-tinymce.js') }}"></script>
 <script src="{{ asset('bundles/clarolinecore/js/tinymce/resource_picker_button.js') }}"></script>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

Polyfills require to be loaded after webpack `commons` in prod environment. 
They are broken without it.


