### PR TITLE
[ExoBundle] allow decimal score in cloze keyword

### DIFF
--- a/plugin/exo/Resources/modules/items/cloze/editor.jsx
+++ b/plugin/exo/Resources/modules/items/cloze/editor.jsx
@@ -68,7 +68,7 @@ class ChoiceItem extends Component {
                   'score',
                   this.props.answer.text,
                   this.props.answer.caseSensitive,
-                  parseInt(e.target.value)
+                  Number(e.target.value)
                 )
               )}
             />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| Fixed tickets | https://github.com/claroline/Distribution/issues/2120

<!-- please add a description here if needed -->
resolve #2120

