### PR TITLE
Update i18n parameter in PlatformDefaults.php

### DIFF
--- a/main/core/Library/Configuration/PlatformDefaults.php
+++ b/main/core/Library/Configuration/PlatformDefaults.php
@@ -92,7 +92,7 @@ class PlatformDefaults implements ParameterProviderInterface
             'help_url' => 'http://doc.claroline.com',
             'register_button_at_login' => false,
             'send_mail_at_workspace_registration' => true,
-            'locales' => ['fr', 'en', 'es'],
+            'locales' => ['fr', 'en'],
             'domain_name' => null,
             'platform_url' => null,
             'mailer_from' => null,


### PR DESCRIPTION
When Claroline is installed only french and english are activate by defaut, ES translation is not completed


