### PR TITLE
[ExoBundle] Update icon file and refs

### DIFF
--- a/plugin/exo/Resources/modules/items/components/icon.jsx
+++ b/plugin/exo/Resources/modules/items/components/icon.jsx
@@ -6,7 +6,7 @@ const T = React.PropTypes
 
 const Icon = props =>
   <svg className={`item-icon item-icon-${props.size}`}>
-    <use xlinkHref={`${asset('bundles/ujmexo/images/item-icons.svg')}#icon-${props.name}`} />
+    <use xlinkHref={`${asset('bundles/ujmexo/images/item-icons.svg')}#icon-quiz-${props.name}`} />
   </svg>
 
 Icon.propTypes = {

--- a/plugin/exo/Resources/public/images/item-icons.svg
+++ b/plugin/exo/Resources/public/images/item-icons.svg
@@ -1,105 +1,162 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-
 <svg xmlns="http://www.w3.org/2000/svg">
     <defs>
-        <symbol id="icon-choice" viewBox="0 0 16 16">
-            <g transform="translate(0 -16)" fill="none">
-                <path d="M16 19H6M16 24H6M16 29H6" stroke-width="2"/>
-                <path d="M1.738 18.292l1.175 1.175 2.35-2.35" stroke-width="1.174"/>
-                <ellipse cy="23.901" cx="3" ry="1.599" rx="1.611" stroke-width=".785"/><ellipse cy="28.901" cx="3" ry="1.599" rx="1.611" stroke-width=".785"/>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-boolean">
+            <g fill="none" stroke-width="3">
+                <path d="m1.1025697 16.975847 4.5756969 3.845638 8.3023154-9.840434"/>
+                <path d="m30.941433 10.976493-11.00406 10.960758"/>
+                <path d="m19.941433 10.976493 11 11"/>
             </g>
         </symbol>
-
-        <symbol id="icon-open" viewBox="0 0 16 16">
-            <g fill="none" stroke-width="2">
-                <path d="M0 3h10M0 8h8M0 13h6"/>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-caption">
+            <g>
+                <path d="m31.496087 31.5v-8.5l-6.456251-6.5-10.429331 10.5-4.469713-4.5-8.939426 9z" fill-rule="evenodd"/>
+                <path d="m1 1v12h14.779432l7.238504-1.781554-.017932-8.4268357-7.177271-1.7916103z" fill="none" stroke-width="2"/>
+                <ellipse cx="17" cy="7" fill="none" rx="2.4000006" ry="2.3999999" stroke-linecap="square" stroke-width="1.20000005"/>
             </g>
-            <path d="M12.066 4.604l-3.163 7.772.176 2.39 1.757-1.494L14 5.5z" fill-rule="evenodd" stroke-width="1.159"/>
-            <path d="M12.866 2.695l.288-.707 1.905.883-.29.708z" stroke-linecap="square" stroke-width="1.241"/>
         </symbol>
-
-        <symbol id="icon-cloze" viewBox="0 0 16 16">
-            <g transform="translate(0,-16)">
-                <g fill="none">
-                    <path d="m0 19h16" stroke-width="2"/>
-                    <path d="m0 24h16" stroke-width="2"/>
-                    <path d="m0 29h16" stroke-width="2"/>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-choice">
+            <g>
+                <g stroke-linecap="square">
+                    <rect height="2" stroke-width="2" width="18" x="13" y="7"/>
+                    <rect height="2" stroke-width="2" width="18" x="13" y="17"/>
+                    <rect height="2" stroke-width="2" width="18" x="13" y="27"/>
+                    <circle cx="6" cy="18" fill="none" r="3.25" stroke-width="1.5"/>
+                    <circle cx="6" cy="28" fill="none" r="3.25" stroke-width="1.5"/>
                 </g>
-                <rect rx=".17419" ry=".055548" height="3" width="7" y="17.5" x="2" fill="#fff"/>
-                <rect rx=".17419" ry=".055548" height="3" width="7" y="27.5" x="6" fill="#fff"/>
+                <path d="m1.7002834 6.9655451 2.9899036 2.6325719 6.500659-7.1837134" fill="none" stroke-width="2.7"/>
             </g>
         </symbol>
-
-        <symbol id="icon-graphic" viewBox="0 0 32 32">
-            <g transform="translate(-16 -16) scale(1.0012)" stroke-linecap="square" fill="none">
-                <circle stroke-width="1.924" cy="24.038" cx="24" r="7.038"/>
-                <rect rx=".095" ry=".049" height=".723" width="6.698" y="23.639" x="20.651" stroke-width="1.302"/>
-                <rect rx=".159" ry=".012" height="6.891" width=".891" y="20.554" x="23.554" stroke-width="1.109"/>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-cloze">
+            <g stroke-linecap="square">
+                <rect height="3" width="3" x=".5" y="4.5"/>
+                <rect height="3" width="13" x="18.5" y="4.5"/>
+                <rect height="3" width="3" x="28.5" y="24.5"/>
+                <rect height="3" width="13" x=".5" y="24.5"/>
+                <rect height="3" width="31" x=".5" y="14.5"/>
+                <rect fill="none" height="6" ry="1" stroke-width="2" width="12" x="5" y="3"/>
+                <rect fill="none" height="6" rx="1" stroke-width="2" width="12" x="15" y="23"/>
             </g>
-            <path d="M1.04 31.502L10 23l4 4 9-10 8.507 6.72v7.78z" fill-rule="evenodd" stroke-width=".994"/>
         </symbol>
-
-        <symbol id="icon-match" viewBox="0 0 32 32">
-            <g fill="none">
-                <circle cx="4" cy="4" r="3.214" stroke-width="1.573"/>
-                <ellipse rx="3.207" ry="3.207" cy="4" cx="28" stroke-width="1.586"/>
-                <path d="M7 4h18" stroke-width="3.976"/>
-                <g fill-opacity="0">
-                    <ellipse rx="3.17" ry="3.22" cy="28" cx="4.05" stroke-width="1.561"/>
-                    <ellipse rx="3.214" ry="3.214" cy="16" cx="28" stroke-width="1.573"/>
-                    <ellipse rx="3.258" ry="3.209" cy="16" cx="4" stroke-width="1.583"/>
-                    <ellipse rx="3.175" ry="3.218" cy="28" cx="27.957" stroke-width="1.564"/>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-graphic">
+            <g>
+                <path d="m31.498534 31.5v-8.5l-6.456252-6.5-10.42933 10.5-4.469713-4.5-8.9394258 9z" fill-rule="evenodd"/>
+                <g stroke-linecap="square" stroke-width="2">
+                    <rect height=".025" transform="scale(1 -1)" width="6" x="6" y="-9"/>
+                    <rect height=".025" transform="matrix(0 1 1 0 0 0)" width="6" x="6" y="9"/>
+                    <ellipse cx="9" cy="9" fill="none" rx="8" ry="8"/>
                 </g>
-                <path d="M6.813 26.294L25.22 17.63" stroke-width="3.789"/>
             </g>
         </symbol>
-
-        <symbol id="icon-pair" viewBox="0 0 16 16">
-            <defs>
-                <marker id="a" orient="auto" overflow="visible">
-                    <path d="M1.154 0l-1.73 1v-2l1.73 1z" fill-rule="evenodd" stroke="#000" stroke-width=".4pt"/>
-                </marker>
-            </defs>
-            <g transform="translate(0 -16)" fill="none" stroke-width="1">
-                <rect stroke-dasharray="1,1" stroke-dashoffset=".5" rx="3" ry="0" height="8" width="6" y="22.5" x=".5"/>
-                <rect stroke-dashoffset=".5" rx="0" ry="3" height="8" width="6" y="22.5" x="9.5"/>
-                <path marker-end="url(#a)" d="M2.16 19.55s5.5-3.5 11 0" stroke-linecap="round"/>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-grid">
+            <path d="m3.2390284 2.000005c-1.7947108 0-3.2390234 1.0356-3.2390234 2.3219506v23.3560894c0 1.286352 1.4443128 2.32195 3.2390234 2.32195h25.6390156c1.794709 0 3.239022-1.035598 3.239022-2.32195v-23.3560894c0-1.2863506-1.444313-2.3219506-3.239022-2.3219506h-25.6390156zm.7258533 4.109267h4.1014621c1.1008246 0 1.9863412.8605031 1.9863412 1.9317068v2.1541462c0 1.071203-.8855166 1.935609-1.9863412 1.935609h-4.1014621c-1.1008238 0-1.9863407-.864406-1.9863407-1.935609v-2.1541462c0-1.0712037.8855169-1.9317068 1.9863407-1.9317068zm20.0234073.011709h4.101461c1.100825 0 1.986342.8644054 1.986342 1.9356092v2.1541458c0 1.071203-.885517 1.931706-1.986342 1.931706h-4.101461c-1.100825 0-1.986342-.860503-1.986342-1.931706v-2.1541458c0-1.0712038.885517-1.9356092 1.986342-1.9356092zm-9.974629.042926h4.101461c1.100825 0 1.986341.860503 1.986341 1.9317068v2.1541452c0 1.071204-.885516 1.935609-1.986341 1.935609h-4.101461c-1.100825 0-1.986342-.864405-1.986342-1.935609v-2.1541452c0-1.0712038.885517-1.9317068 1.986342-1.9317068zm-9.8692661 7.79707h4.1014625c1.1008226 0 1.9863396.860503 1.9863396 1.931707v2.158048c0 1.071203-.885517 1.931707-1.9863396 1.931707h-4.1014625c-1.100824 0-1.9863411-.860504-1.9863407-1.931707v-2.158048c0-1.071204.8855167-1.931707 1.9863407-1.931707zm20.0234071.01171h4.105364c1.100824 0 1.986341.864405 1.986341 1.935609v2.154145c0 1.071204-.885517 1.93561-1.986341 1.93561h-4.105364c-1.100824 0-1.986341-.864406-1.986341-1.93561v-2.154145c0-1.071204.885517-1.935609 1.986341-1.935609zm-9.974631.04293h4.101464c1.100822 0 1.990241.860503 1.990241 1.931707v2.158047c0 1.071204-.889419 1.931705-1.990241 1.931705h-4.101464c-1.100822 0-1.986339-.860501-1.986339-1.931705v-2.158047c0-1.071204.885517-1.931707 1.986339-1.931707zm-10.0995077 7.976582h4.1014617c1.1008246 0 1.986341.864405 1.986341 1.935609v2.154145c0 1.071204-.8855164 1.931707-1.986341 1.931707h-4.1014617c-1.1008244 0-1.9902433-.860503-1.9902433-1.931707v-2.154145c0-1.071204.8894193-1.935609 1.9902433-1.935609zm20.0234067.01558h4.101463c1.100823 0 1.98634.860504 1.98634 1.931707v2.154146c0 1.071204-.885517 1.935609-1.98634 1.935609h-4.101463c-1.100825 0-1.986342-.864405-1.986342-1.935609v-2.154146c0-1.071203.885517-1.931707 1.986342-1.931707zm-9.974629.03902h4.101461c1.100825 0 1.986341.864406 1.986341 1.935609v2.154146c0 1.071204-.885516 1.931707-1.986341 1.931707h-4.101461c-1.100825 0-1.986342-.860503-1.986342-1.931707v-2.154146c0-1.071203.885517-1.935609 1.986342-1.935609z"/>
+        </symbol>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-insertion">
+            <path d="m-.027533 10.499639h22.88997" fill="none"/>
+            <g stroke-linecap="square">
+                <rect height="2" stroke-width="2" width="21.999998" x=".99999994" y="3"/>
+                <rect height="2" stroke-width="1.99999988" width="18" x="1" y="11"/>
+                <rect height="2" stroke-width="1.99999988" width="14" x="1" y="19"/>
+                <rect height="1" width="5" x="22.5" y="10.5"/>
+                <rect height="1" width="5" x="22.5" y="28.5"/>
+                <rect height="14.999999" width="1" x="24.5" y="12.500001"/>
             </g>
         </symbol>
-
-        <symbol id="icon-set" viewBox="0 0 16 16">
-            <defs>
-                <marker id="b" orient="auto" overflow="visible">
-                    <path d="M1.154 0l-1.73 1v-2l1.73 1z" fill-rule="evenodd" stroke="#000" stroke-width=".4pt"/>
-                </marker>
-            </defs>
-            <g stroke-width="1">
-                <path fill="none" d="M8.5 6.5h4v5h-4z"/>
-                <path fill="#fff" d="M10.5 9.5h4v5h-4z"/>
-                <path stroke-dashoffset=".5" stroke-dasharray="1, 1" fill="none" d="M1.5 1.5h4v6h-4z"/>
-                <path marker-end="url(#b)" d="M7.473 17.317s3.888-.472 4.08 3.182" stroke-linecap="round" stroke-width=".537" fill="none" transform="translate(0 -16)"/>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-match">
+            <g stroke-linecap="square">
+                <g fill="none" stroke-width="1.50000036">
+                    <circle cx="4" cy="4" r="3.25"/>
+                    <circle cx="4" cy="16" r="3.25"/>
+                    <circle cx="4" cy="28" r="3.25"/>
+                    <circle cx="28" cy="4" r="3.25"/>
+                    <circle cx="28" cy="16" r="3.25"/>
+                    <circle cx="28" cy="28" r="3.25"/>
+                </g>
+                <rect height="2" stroke-width="2" width="16" x="8" y="3"/>
+                <rect height="2" stroke-width="2.00005698" transform="matrix(.9036224 -.42832996 .4186162 .90816324 0 0)" width="18.932318" x="-4.2520313" y="25.642975"/>
             </g>
         </symbol>
-
-        <symbol id="icon-words" viewBox="0 0 16 16">
-            <g fill="none" stroke-width="2">
-                <path d="M0 3h10M0 8h8M0 13h6"/>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-open">
+            <g stroke-linecap="square" stroke-width="2">
+                <rect height="2" width="10" x="1" y="25"/>
+                <rect height="2" width="14" x="1" y="15"/>
+                <rect height="2" width="18" x="1" y="5"/>
             </g>
-            <path stroke-width="0" d="M12.098 3.803a3.25 3.25 0 0 0-3.25 3.25A3.25 3.25 0 0 0 9.5 9l-2.316 3.576.332 1.406 1.43-.19-.37-.995 1.094-.004-.4-.998 1.058-.012.957-1.586a3.25 3.25 0 0 0 .813.106 3.25 3.25 0 0 0 3.25-3.25 3.25 3.25 0 0 0-3.25-3.25zm.75 1a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1z"/>
+            <g transform="matrix(.38319446 -.92366769 .92366769 .38319446 -10.538078 22.089682)">
+                <rect height="4.502048" stroke-linecap="square" stroke-width="1.99999988" transform="matrix(.9999992 .0012663 -.00085628157 .99999963 0 0)" width="1.9626539" x="29.101677" y="26.497034"/>
+                <path d="m25.853553 31.521242v-5.441942l-17.0662908.0221-5.9887379 2.676774 5.5909903 2.720971z" fill-rule="evenodd"/>
+            </g>
         </symbol>
-
-        <symbol id="icon-grid" viewBox="0 0 16 16">
-          <path d="M1.584.977c-.898 0-1.621.518-1.621 1.162v11.69c0 .643.723 1.161 1.621 1.161h12.832c.898 0 1.621-.518 1.621-1.162V2.138c0-.643-.723-1.161-1.621-1.161H1.584zm.363 2.056H4c.55 0 .994.43.994.967v1.078A.98.98 0 0 1 4 6.047H1.947a.98.98 0 0 1-.994-.969V4c0-.536.443-.967.994-.967zm10.022.006h2.052a.98.98 0 0 1 .995.969v1.078a.978.978 0 0 1-.995.967H11.97a.978.978 0 0 1-.994-.967V4.008a.98.98 0 0 1 .994-.969zm-4.992.022h2.052c.551 0 .994.43.994.966v1.078a.98.98 0 0 1-.994.97H6.977a.98.98 0 0 1-.995-.97V4.027c0-.536.444-.966.995-.966zm-4.94 3.902H4.09c.55 0 .994.43.994.967v1.08a.978.978 0 0 1-.994.967H2.037a.978.978 0 0 1-.994-.967V7.93c0-.536.443-.967.994-.967zm10.022.006h2.054a.98.98 0 0 1 .994.968v1.079a.98.98 0 0 1-.994.968H12.06a.98.98 0 0 1-.995-.968V7.937a.98.98 0 0 1 .995-.968zm-4.993.021H9.12c.551 0 .996.43.996.967v1.08c0 .536-.445.967-.996.967H7.066a.978.978 0 0 1-.994-.967v-1.08c0-.536.443-.967.994-.967zm-5.054 3.992h2.052a.98.98 0 0 1 .995.97v1.077a.978.978 0 0 1-.995.967H2.012c-.551 0-.996-.43-.996-.967v-1.078c0-.536.445-.969.996-.969zm10.021.008h2.053c.55 0 .994.43.994.967v1.078a.98.98 0 0 1-.994.969h-2.053a.98.98 0 0 1-.994-.969v-1.078c0-.536.443-.967.994-.967zm-4.992.02h2.053a.98.98 0 0 1 .994.969v1.078a.978.978 0 0 1-.994.966H7.04a.978.978 0 0 1-.994-.966v-1.078a.98.98 0 0 1 .994-.97z" id="rect4166" stroke="#0ff" stroke-width="0" stroke-linecap="square" stroke-dashoffset=".5"/>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-ordering">
+            <g>
+                <g stroke-linecap="square">
+                    <rect height="2" stroke-width="1.99999988" width="16" x="15" y="27"/>
+                    <rect height="2.0013549" ry="0" stroke-width="2" width="12" x="15" y="19"/>
+                    <rect height="1.9580517" stroke-width="2" width="8.0175915" x="14.982409" y="11.041948"/>
+                    <rect height="18" stroke-width="2" width="2" x="5" y="3"/>
+                    <rect height="2" stroke-width="2" width="4" x="15" y="3"/>
+                </g>
+                <path d="m5.9999999 29.065972-4.0968836-6.565972h8.1937677z" fill-rule="evenodd" stroke-width=".99999994"/>
+            </g>
         </symbol>
-
-        <symbol id="icon-ordering" viewBox="0 0 16 16">
-          <path d="M3.05 1.004v11" id="path4139" fill="none" stroke-width="2"/>
-          <path id="path4143" d="M-10 11l-1.775-.475-1.774-.476 1.299-1.299 1.299-1.299.476 1.774z" transform="matrix(.72189 .64102 -.71923 .6434 18.227 13.61)" stroke-width=".835" stroke-linecap="square" stroke-dashoffset=".5"/>
-          <path d="M6.96 2.023h3" id="path4145" fill="none" fill-rule="evenodd" stroke-width="2"/>
-          <path d="M6.982 6.006h5.046" id="path4147" fill="none" fill-rule="evenodd" stroke-width="2"/>
-          <path d="M7.01 10.015h7.026" id="path4149" fill="none" fill-rule="evenodd" stroke-width="2"/>
-          <path d="M6.965 14.035H16" id="path4149-2" fill="none" fill-rule="evenodd" stroke-width="2"/>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-pair">
+            <g>
+                <g stroke-linecap="square">
+                    <rect height="1" width="1" x=".5" y="28.5"/>
+                    <rect height="1" width="1" x="4.5" y="28.5"/>
+                    <rect height="1" width="1" x="8.5" y="28.5"/>
+                    <rect height="1" width="1" x="12.5" y="28.5"/>
+                    <rect height="1" width="1" x="12.5" y="24.5"/>
+                    <rect height="1" width="1" x="12.5" y="20.5"/>
+                    <rect height="1" width="1" x="12.5" y="16.5"/>
+                    <rect height="1" width="1" x="12.5" y="12.5"/>
+                    <rect height="1" width="1" x="8.5" y="12.5"/>
+                    <rect height="1" width="1" x="4.5" y="12.5"/>
+                    <rect height="1" width="1" x=".5" y="12.5"/>
+                    <rect height="1" stroke-width="1.1" width="1" x=".5" y="16.5"/>
+                    <rect height="1" width="1" x=".5" y="20.5"/>
+                    <rect height="1" width="1" x=".5" y="24.5"/>
+                    <rect fill="none" height="16" stroke-width="2" width="12" x="19" y="13"/>
+                </g>
+                <path d="m5.0000094 7.0272534c7.1102506-5.1866626 14.4279716-5.5496417 21.9999996 0" fill="none" stroke-linecap="round" stroke-width="2"/>
+            </g>
+        </symbol>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-selection">
+            <g stroke-linecap="square" stroke-width="2">
+                <rect height="2" width="22" x="1" y="1"/>
+                <rect height="2" width="18" x="1" y="9"/>
+                <rect height="2" width="10" x="1" y="17"/>
+            </g>
+            <path d="m19.80291 31.273278c-1.330678-3.086234-3.638722-5.686653-5.15291-8.703653.01972-1.552241.992744-1.77824 1.991882-1.255751l2.598105 2.94452.0433-9.526387c.105831-.835113 1.648897-1.910943 2.511502-.0866v6.365359l.0433-2.338295c.196919-1.125984 1.76704-1.631921 2.424898-.0866l.0433 3.204331.000002-2.338295c.0491-.63033 1.677514-1.927143 2.4682-.0433l.0433 3.247632v-2.035183c.198937-1.186304 2.047808-1.702563 2.4682-.0433l.0433 5.456022-1.428958 5.239513z" fill="none" stroke-linejoin="round" stroke-opacity=".94117647" stroke-width="1.3"/>
+        </symbol>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-set">
+            <g>
+                <g stroke-linecap="square">
+                    <rect height="1" width="1" x="2.5" y="2.5"/>
+                    <rect height="1" width="1" x="6.5" y="2.5"/>
+                    <rect height="1" width="1" x="10.5" y="2.5"/>
+                    <rect height="1" width="1" x="2.5" y="6.5"/>
+                    <rect height="1" width="1" x="2.5" y="10.5"/>
+                    <rect height="1" width="1" x="2.5" y="14.5"/>
+                    <rect height="1" width="1" x="10.5" y="14.5"/>
+                    <rect height="1" width="1" x="6.5" y="14.5"/>
+                    <rect height="1" width="1" x="10.5" y="10.5"/>
+                    <rect height="1" width="1" x="10.5" y="6.5"/>
+                    <rect fill="none" height="10" stroke-width="2" width="8" x="21" y="19"/>
+                </g>
+                <path d="m15.040022 2.894116c5.26309.105884 8.329088 2.105884 8.366861 7.0000003l0 0" fill="none" stroke-width="1.20000005"/>
+                <rect height="5" stroke-linecap="square" stroke-width=".99999988" width="1" x="24.5" y="12.5"/>
+                <rect height="1" stroke-linecap="square" stroke-width=".99999994" width="7" x="16.5" y="12.5"/>
+                <rect height="9" stroke-linecap="square" width="1" x="16.5" y="14.5"/>
+                <rect height="1" stroke-linecap="square" width="1" x="18.5" y="22.5"/>
+            </g>
+        </symbol>
+        <symbol height="32" viewBox="0 0 32 32" width="32" id="icon-quiz-words">
+            <path d="m23.797983 8.2583321a6.0129229 6.0129229 0 0 0 -3.234024 9.4688099l-5.063959 7.817311.650263 2.764946 2.815844-.371411-.729655-1.95924 2.148286-.0081-.782143-1.959909 2.075183-.02008 2.4519-4.057023a5.9466978 5.9466978 0 0 0 2.720534-.06434 6.0129229 6.0129229 0 1 0 -3.055786-11.6261368zm4.56619 2.9182269a2.0539601 2.0539601 0 1 1 -2.505352-1.476761 2.0539601 2.0539601 0 0 1  2.505352 1.476761z"/>
+            <g stroke-linecap="square" stroke-width="2">
+                <rect height="2" width="18" x="1" y="5"/>
+                <rect height="2" width="14" x="1" y="15"/>
+                <rect height="2" width="10" x="1" y="25"/>
+            </g>
         </symbol>
     </defs>
 </svg>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no

Use the direct output of https://github.com/claroline/icons and prefix icon names with domain name. Also add all the missing icons for existing (boolean) and ongoing question types.

From now on:
- Every icon must be stored in its original inkscape format in that repository. Other tools or storage solutions like owncloud and http://travis.claroline.net/icons-test/ should not be used anymore.
- No manual transformation of svg files must be performed. The contents of *dist/\*/\*.svg* files can be copy/pasted directly in their corresponding distribution files.
- Icons can -- and actually *must* -- be styled using css rules on `fill`/`stroke` attributes.


