### PR TITLE
fix imported items index

### DIFF
--- a/main/core/Library/Transfert/ConfigurationBuilders/Tools/ResourceManagerImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/Tools/ResourceManagerImporter.php
@@ -279,7 +279,7 @@ class ResourceManagerImporter extends Importer implements ConfigurationInterface
                         //let's order everything !
                         if (isset($item['item']['index'])) {
                             $node = $entity->getResourceNode();
-                            $node->setIndex($directory['directory']['index']);
+                            $node->setIndex($item['item']['index']);
                             $this->om->persist($node);
                             $this->om->flush();
                         }


### PR DESCRIPTION
Wrong property was read for imported items index, seems like a copy/paste error

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | 

wrong index property was read during item import.


