### PR TITLE
Log exporter by group

### DIFF
--- a/main/core/Command/Logs/LogsFetcherCommand.php
+++ b/main/core/Command/Logs/LogsFetcherCommand.php
@@ -23,7 +23,7 @@ class LogsFetcherCommand extends ContainerAwareCommand
         parent::configure();
 
         $this->setName('claroline:logs:fetch')
-            ->setDescription('Send a friend request to a Claroline platform');
+            ->setDescription('Export logs by group');
         $this->setDefinition(
             [
                 new InputArgument('group', InputArgument::REQUIRED, 'The group to fetch'),

--- a/main/core/Command/Logs/LogsFetcherCommand.php
+++ b/main/core/Command/Logs/LogsFetcherCommand.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\CoreBundle\Command\Logs;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class LogsFetcherCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        parent::configure();
+
+        $this->setName('claroline:logs:fetch')
+            ->setDescription('Send a friend request to a Claroline platform');
+        $this->setDefinition(
+            [
+                new InputArgument('group', InputArgument::REQUIRED, 'The group to fetch'),
+                //1472688000 1st sept 2016
+                new InputArgument('from', InputArgument::REQUIRED, 'timestamp from'),
+            ]
+        );
+    }
+
+    protected function interact(InputInterface $input, OutputInterface $output)
+    {
+        $params = [
+            'group' => 'group',
+            'from' => 'from',
+        ];
+
+        foreach ($params as $argument => $argumentName) {
+            if (!$input->getArgument($argument)) {
+                $input->setArgument(
+                    $argument, $this->askArgument($output, $argumentName)
+                );
+            }
+        }
+    }
+
+    protected function askArgument(OutputInterface $output, $argumentName)
+    {
+        $argument = $this->getHelper('dialog')->askAndValidate(
+            $output,
+            "Enter the platform {$argumentName}: ",
+            function ($argument) {
+                if (empty($argument)) {
+                    throw new \Exception('This argument is required');
+                }
+
+                return $argument;
+            }
+        );
+
+        return $argument;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $name = $input->getArgument('group');
+        $om = $this->getContainer()->get('claroline.persistence.object_manager');
+        $logRepo = $om->getRepository('Claroline\CoreBundle\Entity\Log\Log');
+        $xlsExporter = $this->getContainer()->get('claroline.exporter.xls');
+
+        $query = $logRepo->findFilteredLogsQuery(
+            'all',
+            [$input->getArgument('from'), time()],
+            null,
+            [],
+            null,
+            -1,
+            null,
+            null,
+            $name
+        );
+
+        $results = $query->getResult();
+
+        $titles = [
+          'id', 'action', 'date', /*'details',*/ 'user',
+        ];
+
+        $lines = [];
+
+        foreach ($results as $result) {
+            $lines[] = [
+            $result->getId(),
+            $result->getAction(),
+            $result->getDateLog()->format('d-m-Y H:i:s'),
+            //serialize($result->getDetails()),
+            $result->getDoer()->getUsername(),
+          ];
+        }
+
+        $path = $xlsExporter->export($titles, $lines);
+        $output->writeln('Check your file at '.$path);
+    }
+}

--- a/main/core/Command/Logs/LogsFetcherCommand.php
+++ b/main/core/Command/Logs/LogsFetcherCommand.php
@@ -87,19 +87,17 @@ class LogsFetcherCommand extends ContainerAwareCommand
 
         $results = $query->getResult();
 
-        $titles = [
-          'id', 'action', 'date', /*'details',*/ 'user',
-        ];
+        $titles = ['date', 'action', 'user', 'username', 'details'];
 
         $lines = [];
 
         foreach ($results as $result) {
             $lines[] = [
-            $result->getId(),
-            $result->getAction(),
             $result->getDateLog()->format('d-m-Y H:i:s'),
-            //serialize($result->getDetails()),
+            $result->getAction(),
             $result->getDoer()->getUsername(),
+            $result->getDoer()->getFirstName().' '.$result->getDoer()->getLastName(),
+            $this->getContainer()->get('claroline.log.manager')->getDetails($result),
           ];
         }
 

--- a/main/core/Form/Log/AdminLogFilterType.php
+++ b/main/core/Form/Log/AdminLogFilterType.php
@@ -42,35 +42,46 @@ class AdminLogFilterType extends AbstractType
 
         $builder
             ->add(
-                'action', 'twolevelselect', array(
+                'action', 'twolevelselect', [
                     'label' => 'Show actions for',
                     'translation_domain' => 'log',
-                    'attr' => array('class' => 'input-sm'),
+                    'attr' => ['class' => 'input-sm'],
                     'choices' => $actionChoices,
                     'choices_as_values' => true,
-                    'theme_options' => array('label_width' => 'col-md-3'),
-                )
+                    'theme_options' => ['label_width' => 'col-md-3'],
+                ]
             )
             ->add(
                 'range',
                 'daterange',
-                array(
+                [
                     'label' => 'for_period',
                     'required' => false,
-                    'attr' => array('class' => 'input-sm'),
-                    'theme_options' => array('label_width' => 'col-md-3', 'control_width' => 'col-md-3'),
-                )
+                    'attr' => ['class' => 'input-sm'],
+                    'theme_options' => ['label_width' => 'col-md-3', 'control_width' => 'col-md-3'],
+                ]
             )
             ->add(
                 'user',
                 'simpleautocomplete',
-                array(
+                [
                     'label' => 'for user',
                     'entity_reference' => 'user',
                     'required' => false,
-                    'attr' => array('class' => 'input-sm'),
-                    'theme_options' => array('label_width' => 'col-md-3', 'control_width' => 'col-md-3'),
-                )
+                    'attr' => ['class' => 'input-sm'],
+                    'theme_options' => ['label_width' => 'col-md-3', 'control_width' => 'col-md-3'],
+                ]
+            )
+            ->add(
+                'group',
+                'simpleautocomplete',
+                [
+                    'label' => 'for group',
+                    'entity_reference' => 'group',
+                    'required' => false,
+                    'attr' => ['class' => 'input-sm'],
+                    'theme_options' => ['label_width' => 'col-md-3', 'control_width' => 'col-md-3'],
+                ]
             );
     }
 
@@ -83,9 +94,9 @@ class AdminLogFilterType extends AbstractType
     {
         $resolver
         ->setDefaults(
-            array(
+            [
                 'translation_domain' => 'log',
-            )
+            ]
         );
     }
 }

--- a/main/core/Form/Log/ResourceLogFilterType.php
+++ b/main/core/Form/Log/ResourceLogFilterType.php
@@ -3,8 +3,8 @@
 namespace Claroline\CoreBundle\Form\Log;
 
 use Claroline\CoreBundle\Event\Log\LogGenericEvent;
-use JMS\DiExtraBundle\Annotation as DI;
 use Claroline\CoreBundle\Manager\EventManager;
+use JMS\DiExtraBundle\Annotation as DI;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -38,33 +38,44 @@ class ResourceLogFilterType extends AbstractType
             ->add(
                 'action',
                 'choice',
-                array(
+                [
                     'label' => 'Show actions for',
-                    'attr' => array('class' => 'input-sm'),
-                    'theme_options' => array('label_width' => 'col-md-3', 'control_width' => 'col-md-3'),
+                    'attr' => ['class' => 'input-sm'],
+                    'theme_options' => ['label_width' => 'col-md-3', 'control_width' => 'col-md-3'],
                     'choices' => $actionChoices,
-                )
+                ]
             )
             ->add(
                 'range',
                 'daterange',
-                array(
+                [
                     'label' => 'for_period',
                     'required' => false,
-                    'attr' => array('class' => 'input-sm'),
-                    'theme_options' => array('label_width' => 'col-md-3', 'control_width' => 'col-md-3'),
-                )
+                    'attr' => ['class' => 'input-sm'],
+                    'theme_options' => ['label_width' => 'col-md-3', 'control_width' => 'col-md-3'],
+                ]
             )
             ->add(
                 'user',
                 'simpleautocomplete',
-                array(
+                [
                     'label' => 'for user',
                     'entity_reference' => 'user',
                     'required' => false,
-                    'attr' => array('class' => 'input-sm'),
-                    'theme_options' => array('label_width' => 'col-md-3', 'control_width' => 'col-md-3'),
-                )
+                    'attr' => ['class' => 'input-sm'],
+                    'theme_options' => ['label_width' => 'col-md-3', 'control_width' => 'col-md-3'],
+                ]
+            )
+            ->add(
+                'group',
+                'simpleautocomplete',
+                [
+                    'label' => 'for group',
+                    'entity_reference' => 'group',
+                    'required' => false,
+                    'attr' => ['class' => 'input-sm'],
+                    'theme_options' => ['label_width' => 'col-md-3', 'control_width' => 'col-md-3'],
+                ]
             );
     }
 
@@ -75,6 +86,6 @@ class ResourceLogFilterType extends AbstractType
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setDefaults(array('translation_domain' => 'log'));
+        $resolver->setDefaults(['translation_domain' => 'log']);
     }
 }

--- a/main/core/Form/Log/WorkspaceLogFilterType.php
+++ b/main/core/Form/Log/WorkspaceLogFilterType.php
@@ -12,8 +12,8 @@
 namespace Claroline\CoreBundle\Form\Log;
 
 use Claroline\CoreBundle\Event\Log\LogGenericEvent;
-use JMS\DiExtraBundle\Annotation as DI;
 use Claroline\CoreBundle\Manager\EventManager;
+use JMS\DiExtraBundle\Annotation as DI;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -42,32 +42,41 @@ class WorkspaceLogFilterType extends AbstractType
 
         $builder
             ->add(
-                'action', 'twolevelselect', array(
+                'action', 'twolevelselect', [
                     'label' => 'Show actions for',
                     'translation_domain' => 'log',
-                    'attr' => array('class' => 'input-sm'),
+                    'attr' => ['class' => 'input-sm'],
                     'choices' => $actionChoices,
                     'choices_as_values' => true,
                     'empty_value' => 'all',
                     'empty_data' => null,
-                )
+                ]
             )
             ->add(
-                'range', 'daterange', array(
+                'range', 'daterange', [
                     'label' => 'for_period',
                     'required' => false,
-                    'attr' => array('class' => 'input-sm'),
-                    'theme_options' => array('label_width' => 'col-md-3', 'control_width' => 'col-md-3'),
-                )
+                    'attr' => ['class' => 'input-sm'],
+                    'theme_options' => ['label_width' => 'col-md-3', 'control_width' => 'col-md-3'],
+                ]
             )
             ->add(
-                'user', 'simpleautocomplete', array(
+                'user', 'simpleautocomplete', [
                     'label' => 'for user',
                     'entity_reference' => 'user',
                     'required' => false,
-                    'attr' => array('class' => 'input-sm'),
-                    'theme_options' => array('label_width' => 'col-md-3', 'control_width' => 'col-md-3'),
-                )
+                    'attr' => ['class' => 'input-sm'],
+                    'theme_options' => ['label_width' => 'col-md-3', 'control_width' => 'col-md-3'],
+                ]
+            )
+            ->add(
+                'group', 'simpleautocomplete', [
+                    'label' => 'for group',
+                    'entity_reference' => 'group',
+                    'required' => false,
+                    'attr' => ['class' => 'input-sm'],
+                    'theme_options' => ['label_width' => 'col-md-3', 'control_width' => 'col-md-3'],
+                ]
             );
     }
 
@@ -80,10 +89,10 @@ class WorkspaceLogFilterType extends AbstractType
     {
         $resolver
         ->setDefaults(
-            array(
+            [
                 'translation_domain' => 'log',
                 'csrf_protection' => false,
-            )
+            ]
         );
     }
 }

--- a/main/core/Manager/LogManager.php
+++ b/main/core/Manager/LogManager.php
@@ -11,6 +11,7 @@
 
 namespace Claroline\CoreBundle\Manager;
 
+use Claroline\CoreBundle\Entity\Log\Log;
 use Claroline\CoreBundle\Entity\Log\LogWidgetConfig;
 use Claroline\CoreBundle\Entity\User;
 use Claroline\CoreBundle\Entity\Widget\WidgetInstance;
@@ -794,5 +795,29 @@ class LogManager
         }
 
         return ['ids' => $topUsersIdList, 'userData' => $topUsersFormatedArray];
+    }
+
+    public function getDetails(Log $log)
+    {
+        $details = $log->getDetails();
+        $translator = $this->container->get('translator');
+        $receiverUser = isset($details['receiverUser']) ? $details['receiverUser']['firstName'].' '.$details['receiverUser']['lastName'] : null;
+        $receiverGroup = isset($details['receiverGroup']) ? $details['receiverGroup']['name'] : null;
+        $role = isset($details['role']) ? $details['role']['name'] : null;
+        $workspace = isset($details['workspace']) ? $details['workspace']['name'] : null;
+        $resource = $log->getResourceNode() ? $details['resource']['path'] : null;
+
+        return $translator->trans(
+          'log_'.$log->getAction().'_sentence',
+          [
+            '%resource%' => $resource,
+            '%receiver_user%' => $receiverUser,
+            '%receiver_group%' => $receiverGroup,
+            '%role%' => $role,
+            '%workspace%' => $workspace,
+            '%tool%' => $translator->trans($log->getToolName(), [], 'tool'),
+          ],
+          'log'
+        );
     }
 }

--- a/main/core/Manager/LogManager.php
+++ b/main/core/Manager/LogManager.php
@@ -333,7 +333,8 @@ class LogManager
             $workspaceIds,
             $maxResult,
             $resourceType,
-            $resourceNodeIds
+            $resourceNodeIds,
+            $data['group']
         );
 
         $adapter = new DoctrineORMAdapter($query);
@@ -354,7 +355,8 @@ class LogManager
             $workspaceIds,
             false,
             $resourceType,
-            $resourceNodeIds
+            $resourceNodeIds,
+            $data['group']
         );
 
         //List item delegation
@@ -671,6 +673,8 @@ class LogManager
             }
             $range = isset($formData['range']) ? $formData['range'] : null;
             $userSearch = isset($formData['user']) ? $formData['user'] : null;
+            $groupSearch = isset($formData['group']) ? $formData['group'] : null;
+
             if (!empty($data['orderBy'])) {
                 $orderBy = $data['orderBy'];
                 $order = $data['order'];
@@ -689,6 +693,7 @@ class LogManager
         $data['action'] = $action;
         $data['range'] = $range;
         $data['user'] = $userSearch;
+        $data['group'] = $groupSearch;
 
         if (isset($orderBy) && isset($order)) {
             $data['orderBy'] = $orderBy;

--- a/main/core/Repository/Log/LogRepository.php
+++ b/main/core/Repository/Log/LogRepository.php
@@ -51,7 +51,8 @@ class LogRepository extends EntityRepository
         $workspaceIds = null,
         $unique = false,
         $resourceType = null,
-        $resourceNodeIds = null
+        $resourceNodeIds = null,
+        $groupSearch = null
     ) {
         $queryBuilder = $this
             ->createQueryBuilder('log')
@@ -68,6 +69,7 @@ class LogRepository extends EntityRepository
         $queryBuilder = $this->addDateRangeFilterToQueryBuilder($queryBuilder, $range);
         $queryBuilder = $this->addUserFilterToQueryBuilder($queryBuilder, $userSearch);
         $queryBuilder = $this->addResourceTypeFilterToQueryBuilder($queryBuilder, $resourceType);
+        $queryBuilder = $this->addGroupFilterToQueryBuilder($queryBuilder, $groupSearch);
 
         if ($workspaceIds !== null && count($workspaceIds) > 0) {
             $queryBuilder = $this->addWorkspaceFilterToQueryBuilder($queryBuilder, $workspaceIds);

--- a/main/core/Repository/Log/LogRepository.php
+++ b/main/core/Repository/Log/LogRepository.php
@@ -13,9 +13,9 @@ namespace Claroline\CoreBundle\Repository\Log;
 
 use Claroline\CoreBundle\Entity\User;
 use Claroline\CoreBundle\Event\Log\LogUserLoginEvent;
+use Doctrine\ORM\EntityRepository;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
-use Doctrine\ORM\EntityRepository;
 
 class LogRepository extends EntityRepository
 {
@@ -27,7 +27,7 @@ class LogRepository extends EntityRepository
      */
     public function countByDayThroughConfigs($configs, $range)
     {
-        if ($configs === null || count($configs) == 0) {
+        if ($configs === null || count($configs) === 0) {
             return;
         }
 
@@ -87,7 +87,7 @@ class LogRepository extends EntityRepository
      */
     public function findLogsThroughConfigs($configs, $maxResult = -1)
     {
-        if ($configs === null || count($configs) == 0) {
+        if ($configs === null || count($configs) === 0) {
             return;
         }
 
@@ -113,7 +113,8 @@ class LogRepository extends EntityRepository
         $workspaceIds = null,
         $maxResult = -1,
         $resourceType = null,
-        $resourceNodeIds = null
+        $resourceNodeIds = null,
+        $groupSearch = null
     ) {
         $queryBuilder = $this
             ->createQueryBuilder('log')
@@ -123,6 +124,7 @@ class LogRepository extends EntityRepository
         $queryBuilder = $this->addDateRangeFilterToQueryBuilder($queryBuilder, $range);
         $queryBuilder = $this->addUserFilterToQueryBuilder($queryBuilder, $userSearch);
         $queryBuilder = $this->addResourceTypeFilterToQueryBuilder($queryBuilder, $resourceType);
+        $queryBuilder = $this->addGroupFilterToQueryBuilder($queryBuilder, $groupSearch);
 
         if ($workspaceIds !== null && count($workspaceIds) > 0) {
             $queryBuilder = $this->addWorkspaceFilterToQueryBuilder($queryBuilder, $workspaceIds);
@@ -319,10 +321,10 @@ class LogRepository extends EntityRepository
                 .'doer.username, count(log.id) AS actions'
             )
             ->groupBy('doer');
-        if ($orderBy == 'name') {
+        if ($orderBy === 'name') {
             $orderBy = 'sortingName';
         }
-        if ($orderBy == null) {
+        if ($orderBy === null) {
             $orderBy = 'actions';
         }
         $queryBuilder->orderBy($orderBy, $order);
@@ -395,9 +397,9 @@ class LogRepository extends EntityRepository
         $action,
         $range,
         $actionsRestriction,
-        $workspaceIds = null,
-        $resourceType = null,
-        $resourceNodeIds = null,
+        $workspaceIds,
+        $resourceType,
+        $resourceNodeIds,
         $userIds
     ) {
         $queryBuilder = $this
@@ -471,7 +473,7 @@ class LogRepository extends EntityRepository
      */
     public function addDateRangeFilterToQueryBuilder(QueryBuilder $queryBuilder, $range)
     {
-        if ($range !== null && count($range) == 2) {
+        if ($range !== null && count($range) === 2) {
             $startDate = new \DateTime();
             $startDate->setTimestamp($range[0]);
             $startDate->setTime(0, 0, 0);
@@ -526,11 +528,34 @@ class LogRepository extends EntityRepository
         return $queryBuilder;
     }
 
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @param string       $userSearch
+     *
+     * @return QueryBuilder
+     */
+    private function addGroupFilterToQueryBuilder(QueryBuilder $queryBuilder, $groupSearch)
+    {
+        if ($groupSearch !== null && $groupSearch !== '') {
+            $upperUserSearch = strtoupper($groupSearch);
+            $upperUserSearch = trim($groupSearch);
+            $upperUserSearch = preg_replace('/\s+/', ' ', $upperUserSearch);
+
+            $queryBuilder->leftJoin('log.doer', 'doer');
+            $queryBuilder->leftJoin('doer.groups', 'groupDoer');
+            $queryBuilder->andWhere('groupDoer.name LIKE :groupSearch');
+
+            $queryBuilder->setParameter('groupSearch', '%'.$upperUserSearch.'%');
+        }
+
+        return $queryBuilder;
+    }
+
     private function addWorkspaceFilterToQueryBuilder($queryBuilder, $workspaceIds)
     {
         if ($workspaceIds !== null && count($workspaceIds) > 0) {
             $queryBuilder->leftJoin('log.workspace', 'workspace');
-            if (count($workspaceIds) == 1) {
+            if (count($workspaceIds) === 1) {
                 $queryBuilder->andWhere('workspace.id = :workspaceId');
                 $queryBuilder->setParameter('workspaceId', $workspaceIds[0]);
             } else {
@@ -544,7 +569,7 @@ class LogRepository extends EntityRepository
     private function addUserIdsFilterToQueryBuilder($queryBuilder, $userIds)
     {
         if ($userIds !== null && count($userIds) > 0) {
-            if (count($userIds) == 1) {
+            if (count($userIds) === 1) {
                 $queryBuilder->andWhere('doer.id = :userId');
                 $queryBuilder->setParameter('userId', $userIds[0]);
             } else {
@@ -559,7 +584,7 @@ class LogRepository extends EntityRepository
     {
         if ($resourceNodeIds !== null && count($resourceNodeIds) > 0) {
             $queryBuilder->leftJoin('log.resourceNode', 'resource');
-            if (count($resourceNodeIds) == 1) {
+            if (count($resourceNodeIds) === 1) {
                 $queryBuilder->andWhere('resource.id = :resourceId');
                 $queryBuilder->setParameter('resourceId', $resourceNodeIds[0]);
             } else {
@@ -579,7 +604,6 @@ class LogRepository extends EntityRepository
      */
     private function addConfigurationFilterToQueryBuilder(QueryBuilder $queryBuilder, $configs)
     {
-        $actionIndex = 0;
         foreach ($configs as $config) {
             $workspaceId = $config->getWidgetInstance()->getWorkspace()->getId();
             $queryBuilder
@@ -610,12 +634,12 @@ class LogRepository extends EntityRepository
 
     public function extractChartData($result, $range)
     {
-        $chartData = array();
+        $chartData = [];
         if (count($result) > 0) {
             //We send an array indexed by date dans contains count
             $lastDay = null;
             $endDay = null;
-            if ($range !== null && count($range) == 2) {
+            if ($range !== null && count($range) === 2) {
                 $lastDay = new \DateTime();
                 $lastDay->setTimestamp($range[0]);
 
@@ -626,7 +650,7 @@ class LogRepository extends EntityRepository
             foreach ($result as $line) {
                 if ($lastDay !== null) {
                     while ($lastDay->getTimestamp() < $line['shortDate']->getTimestamp()) {
-                        $chartData[] = array($lastDay->getTimestamp() * 1000, 0);
+                        $chartData[] = [$lastDay->getTimestamp() * 1000, 0];
                         $lastDay->add(new \DateInterval('P1D')); // P1D means a period of 1 day
                     }
                 } else {
@@ -634,11 +658,11 @@ class LogRepository extends EntityRepository
                 }
                 $lastDay->add(new \DateInterval('P1D')); // P1D means a period of 1 day
 
-                $chartData[] = array($line['shortDate']->getTimestamp() * 1000, intval($line['total']));
+                $chartData[] = [$line['shortDate']->getTimestamp() * 1000, intval($line['total'])];
             }
 
             while ($lastDay->getTimestamp() <= $endDay->getTimestamp()) {
-                $chartData[] = array($lastDay->getTimestamp() * 1000, 0);
+                $chartData[] = [$lastDay->getTimestamp() * 1000, 0];
 
                 $lastDay->add(new \DateInterval('P1D')); // P1D means a period of 1 day
             }

--- a/main/core/Resources/translations/log.en.json
+++ b/main/core/Resources/translations/log.en.json
@@ -5,6 +5,7 @@
     "click_to_choose": "Click to display actions list",
     "download_csv_list": "Download list in .CSV format",
     "for user": "For user",
+    "for group": "For group:",
     "global_tracking": "Global tracking",
     "log_add_user": "Add user",
     "log_change_right": "Change rights",

--- a/main/core/Resources/translations/log.fr.json
+++ b/main/core/Resources/translations/log.fr.json
@@ -5,6 +5,7 @@
     "click_to_choose": "Cliquer pour afficher la liste des actions",
     "download_csv_list": "Télécharger la liste au format .csv",
     "for user": "Filtrer sur l'utilisateur:",
+    "for group": "Filtrer sur le groupe:",
     "global_tracking": "Suivi global",
     "group": "Groupe",
     "log_add_user": "Ajout d'un utilisateur",

--- a/main/core/Resources/views/Log/tool_view_list.html.twig
+++ b/main/core/Resources/views/Log/tool_view_list.html.twig
@@ -58,6 +58,15 @@
                             </div>
                         </div>
                     </div>
+                    <div class="row">
+                        <div class="form-group col-md-12">
+                            {{ form_label(filterForm.group) }}
+                            {{ form_errors(filterForm.group) }}
+                            <div class="{{ filterForm.group.vars.theme_options.control_width }}">
+                                {{ form_widget(filterForm.group) }}
+                            </div>
+                        </div>
+                    </div>
                     <br/>
                     {{ form_rest(filterForm) }}
                     <input type="submit" value="{{ 'log_filter_actions'|trans({}, 'log') }}" class="btn btn-primary"/>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no

We should be able to filter logs by groups and export the result as an excel/csv file.
This is a draft for a CLI tool doing it but it would be better to do it at the GUI level.

edit: I guess I can remove the CLI tool now.

@ptsavdar Where is the resource log form used ? It's the only only one I didn't touch. Did I miss something else ?