### PR TITLE
[CoreBundle] Fixed minor issue if ldap is disabled after having enabled at least once

### DIFF
--- a/main/core/Manager/AuthenticationManager.php
+++ b/main/core/Manager/AuthenticationManager.php
@@ -94,7 +94,10 @@ class AuthenticationManager
         $driver = explode('.', $parts[0]);
 
         if (isset($driver[1])) {
-            return $this->container->get($driver[0].'.'.$driver[1].'_bundle.manager.'.$driver[1].'_manager');
+            $serviceName = $driver[0].'.'.$driver[1].'_bundle.manager.'.$driver[1].'_manager';
+            if ($this->container->has($serviceName)) {
+                return $this->container->get($serviceName);
+            }
         }
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | 

If ldap bundle was once enabled and user had already created some ldap servers, if bundle was the disabled, it generated an error in some user forms (typically on add new user).


