### PR TITLE
[BlogBundle] Fix searching post or tag by slug

### DIFF
--- a/plugin/blog/Controller/API/ApiController.php
+++ b/plugin/blog/Controller/API/ApiController.php
@@ -157,7 +157,7 @@ class ApiController extends BaseController
         $this->checkAccess('OPEN', $blog);
 
         $post = null;
-        if ((int) $postId) {
+        if (preg_match('/^\d+$/', $postId)) {
             $post = $this->get('icap.blog.post_repository')->findOneBy([
                 'blog' => $blog,
                 'id' => $postId,
@@ -223,7 +223,7 @@ class ApiController extends BaseController
         $this->checkAccess('OPEN', $blog);
 
         $tag = null;
-        if ((int) $tagId) {
+        if (preg_match('/^\d+$/', $tagId)) {
             $tag = $this->get('icap.blog.tag_repository')->findOneById($tagId);
         } else {
             $tag = $this->get('icap.blog.tag_repository')->findOneBySlug($tagId);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | 

This commit fixes a bug where a post or tag can not be found by the API if its slug starts with a number.

