### PR TITLE
[PathBundle] fixes text overflow and enhances responsive

### DIFF
--- a/plugin/path/Resources/modules/summary/Partial/edit.html
+++ b/plugin/path/Resources/modules/summary/Partial/edit.html
@@ -12,7 +12,7 @@
         </h2>
 
         <div class="summary-controls">
-            <button type="button" class="summary-control btn btn-link" data-ng-click="summaryEditCtrl.togglePinned()" data-ng-class="{ 'active': summaryEditCtrl.state.pinned }">
+            <button type="button" class="summary-control summary-control-pin btn btn-link" data-ng-click="summaryEditCtrl.togglePinned()" data-ng-class="{ 'active': summaryEditCtrl.state.pinned }">
                 <span class="fa fa-fw fa-map-pin"></span>
             </button>
 

--- a/plugin/path/Resources/modules/summary/Partial/show.html
+++ b/plugin/path/Resources/modules/summary/Partial/show.html
@@ -12,17 +12,15 @@
         </h2>
 
         <div class="summary-controls">
-            <button type="button" class="summary-control btn btn-link" data-ng-click="summaryShowCtrl.togglePinned()" data-ng-class="{ 'active': summaryShowCtrl.state.pinned }">
+            <button type="button" class="summary-control summary-control-pin btn btn-link" data-ng-click="summaryShowCtrl.togglePinned()" data-ng-class="{ 'active': summaryShowCtrl.state.pinned }">
                 <span class="fa fa-fw fa-map-pin"></span>
             </button>
 
             <button type="button" class="summary-control btn btn-link" data-ng-click="summaryShowCtrl.toggleOpened()">
-                <span class="fa fa-fw"
-                      data-ng-class="{
-                          'fa-chevron-left': summaryShowCtrl.state.opened,
-                          'fa-chevron-right': !summaryShowCtrl.state.opened
-                      }"
-                ></span>
+                <span class="fa fa-fw fa-chevron-right" data-ng-if="!summaryShowCtrl.state.opened"></span>
+                <span class="hidden-xs fa fa-fw fa-chevron-left" data-ng-if="summaryShowCtrl.state.opened"></span>
+                <span class="visible-xs fa fa-fw fa-chevron-down" data-ng-if="summaryShowCtrl.state.opened"></span>
+
                 <span class="sr-only">{{ 'summary'|trans:{}:'path_wizards' }}</span>
             </button>
         </div>

--- a/plugin/path/Resources/styles/components/summary.less
+++ b/plugin/path/Resources/styles/components/summary.less
@@ -4,36 +4,22 @@
 
 .summary-container {
     position: absolute;
-    left: 0;
-    // Take full height of the viewport / content (if taller than than viewport)
-    top: 0;
-    bottom: 0;
 
     color: @path-summary-color;
     background: @path-summary-bg;
     padding: @path-summary-padding;
-    box-shadow: @path-summary-box-shadow;
     border-radius: @summary-border-radius;
-    width: @path-summary-collapsed-width;
     overflow-x: hidden;
-
-    + .content-container {
-        margin-left: @path-summary-collapsed-width;
-        padding-left: floor(@path-grid-spacing-x / 2); // fake bootstrap grid
-    }
 
     .summary-header {
         display: flex;
         flex-direction: row;
         justify-content: space-between;
         align-items: center;
-        margin-bottom: @path-summary-header-margin-bottom;
     }
 
     // todo : those selectors are ugly
-    .summary-title,
-    .summary-controls .summary-control:first-child,
-    .step-name,
+    .summary-control-pin,
     .step-actions {
         display: none;
     }
@@ -43,15 +29,14 @@
     }
 
     &.opened {
-        width: @path-summary-width;
-        .summary-controls .summary-control:first-child {
+        .summary-control-pin,
+        .summary-title,
+        .step-actions {
             display: inline-block;
         }
 
-        .summary-title,
-        .step *,
-        .step-actions {
-            display: inline-block;
+        .step-name {
+            display: inline;
         }
 
         .step-children {
@@ -68,10 +53,8 @@
         }
     }
 
-    &.opened.pinned {
-        + .content-container {
-            margin-left: @path-summary-width;
-        }
+    .path-summary-tree {
+        margin-top: @path-summary-header-margin-bottom;
     }
 }
 
@@ -173,6 +156,7 @@
 
 // todo : rename it in step indicator
 .step-progression {
+    display: inline-block;
     line-height: inherit;
     width: @path-summary-collapsed-width - (@path-summary-padding * 2);
     text-align: center;
@@ -186,3 +170,126 @@
     &.done      { color: @step-status-done-color; }
     &.to_review { color: @step-status-to_review-color; }
 }
+
+// XS screens :
+//   - summary can not be pinned
+//   - closed summary is a bar at the top of the step content
+//   - summary is full width (12 bs cols)
+@media (max-width: @screen-xs-max) {
+    .summary-container {
+        box-shadow: @path-summary-box-shadow-h;
+        height: @path-summary-collapsed-width;
+
+        // Take full width of the viewport
+        top: 0;
+        left: 0;
+        right: 0;
+
+        // hide tree when closed
+        .path-summary-tree {
+            display: none;
+        }
+
+        .summary-control-pin {
+            display: none !important;
+        }
+
+        &.opened {
+            height: 100%; // todo : find better. it can be small if their is no content in the current step
+            bottom: 0;
+
+            .path-summary-tree {
+                display: block;
+            }
+        }
+
+        + .content-container {
+            margin-top: @path-summary-collapsed-width;
+            padding-top: floor(@path-grid-spacing-x / 2); // fake bootstrap grid
+        }
+    }
+}
+
+// SM screens :
+//   - summary can not be pinned
+//   - closed summary is a bar at the left of the step content
+//   - summary is 50% width (6 bs cols)
+@media (min-width: @screen-sm-min) and (max-width: @screen-sm-max) {
+    .summary-container {
+        box-shadow: @path-summary-box-shadow-v;
+        width: @path-summary-collapsed-width;
+
+        // Take full height of the viewport / content (if taller than than viewport)
+        left: 0;
+        top: 0;
+        bottom: 0;
+
+        // hide title when closed
+        .summary-title {
+            display: none;
+        }
+
+        .summary-control-pin {
+            display: none !important;
+        }
+
+        &.opened {
+            width: @path-summary-width-sm;
+        }
+
+        + .content-container {
+            margin-left: @path-summary-collapsed-width;
+            padding-left: floor(@path-grid-spacing-x / 2); // fake bootstrap grid
+        }
+    }
+}
+
+// MD & LG screens :
+//   - summary can be pinned
+//   - closed summary is a bar at the left of the step content
+//   - summary is ~40% width (5 bs cols) by default
+//   - summary is ~33% width (4 bs cols) in fullscreen mode
+@media (min-width: @screen-sm-max) {
+    .summary-container {
+        box-shadow: @path-summary-box-shadow-v;
+        width: @path-summary-collapsed-width;
+
+        // Take full height of the viewport / content (if taller than than viewport)
+        left: 0;
+        top: 0;
+        bottom: 0;
+
+        // hide title when closed
+        .summary-title {
+            display: none;
+        }
+
+        &.opened {
+            width: @path-summary-width-md;
+        }
+
+        &.opened.pinned {
+            + .content-container {
+                margin-left: @path-summary-width-md;
+            }
+        }
+
+        + .content-container {
+            margin-left: @path-summary-collapsed-width;
+            padding-left: floor(@path-grid-spacing-x / 2); // fake bootstrap grid
+        }
+    }
+
+    .page.fullscreen {
+        .summary-container {
+            width: @path-summary-fullscreen-width;
+
+            &.opened.pinned {
+                + .content-container {
+                    margin-left: @path-summary-fullscreen-width;
+                }
+            }
+        }
+    }
+}
+

--- a/plugin/path/Resources/styles/variables.less
+++ b/plugin/path/Resources/styles/variables.less
@@ -35,14 +35,19 @@
 // -
 // Summary
 // ---
-@path-summary-width:                percentage((5 / @grid-columns)); // do not affect sm screens : in this case, summary is full screen
+// their is no sizing for xs because it's always 100% in this case
+@path-summary-width-sm:             percentage((6 / @grid-columns));
+@path-summary-width-md:             percentage((5 / @grid-columns));
+//@path-summary-width:                percentage((5 / @grid-columns)); // do not affect sm screens : in this case, summary is full screen
+@path-summary-fullscreen-width:     percentage((4 / @grid-columns)); // width of the summary in fullscreen mode (only for md & lg screens)
 @path-summary-collapsed-width:      50px;
 
 @path-summary-font:                 @summary-font;
 @path-summary-padding:              @summary-padding;
 @path-summary-bg:                   @summary-bg;
 @path-summary-color:                @summary-color;
-@path-summary-box-shadow:           @summary-box-shadow-v;
+@path-summary-box-shadow-h:         @summary-box-shadow-h;
+@path-summary-box-shadow-v:         @summary-box-shadow-v;
 @path-summary-lvl-indent:           20px; // indent children of a step in the summary
 
 // Header

--- a/plugin/path/Resources/views/Path/edit.html.twig
+++ b/plugin/path/Resources/views/Path/edit.html.twig
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block content %}
-    <div data-ng-cloak="" data-ng-app="PathEditorApp" class="page-container">
+    <div data-ng-cloak="" data-ng-app="PathEditorApp" class="page-container path-container">
         {# Path Form (we not directly alter the entity, but work with a JSON structure which stores info before publishing) #}
         <path-edit
             data-path="{{ _resource.structure | raw | escape }}"

--- a/plugin/path/Resources/views/Path/open.html.twig
+++ b/plugin/path/Resources/views/Path/open.html.twig
@@ -1,7 +1,7 @@
 {% extends "InnovaPathBundle:Path:layout.html.twig" %}
 
 {% block content %}
-    <div data-ng-cloak="" data-ng-app="PathPlayerApp" class="page-container">
+    <div data-ng-cloak="" data-ng-app="PathPlayerApp" class="page-container path-container">
         {# Path Player (convert Path Entity into a JSON object to make it understandable by AngularJS) #}
         <path-show
             data-path="{{ _resource | json_encode }}"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes

New sizing rules are :

XS screens :
   - summary can not be pinned
   - closed summary is a bar at the top of the step content
   - summary is full width (12 bs cols)

SM screens :
   - summary can not be pinned
   - closed summary is a bar at the left of the step content
   - summary is 50% width (6 bs cols)

MD & LG screens :
   - summary can be pinned
   - closed summary is a bar at the left of the step content
   - summary is ~40% width (5 bs cols) by default
   - summary is ~33% width (4 bs cols) in fullscreen mode
