### PR TITLE
[BlogBundle] Limit post title length in Angular template

### DIFF
--- a/plugin/blog/Resources/modules/post/post.controller.js
+++ b/plugin/blog/Resources/modules/post/post.controller.js
@@ -88,6 +88,17 @@ export default class PostController {
     return this.blog.tags.filter(element => element.text.includes($query))
   }
 
+  getErrorMessage($errors) {
+    let errorMessage = ''
+    if ('required' in $errors) {
+      errorMessage = _transFilter.get(this)('required_field', {}, 'icap_blog')
+    }
+    if ('maxlength' in $errors) {
+      errorMessage = _transFilter.get(this)('maxlength_field', {}, 'icap_blog')
+    }
+    return errorMessage
+  }
+
   filterByTag(tag) {
     _$location.get(this).url(`/tag/${tag.slug}`)
   }

--- a/plugin/blog/Resources/modules/post/postcreate.partial.html
+++ b/plugin/blog/Resources/modules/post/postcreate.partial.html
@@ -20,10 +20,11 @@
                     class="form-control"
                     data-ng-model="vm.blog.newPost.title"
                     data-ng-class="{'error': newPostForm.newPostTitle.$dirty && newPostForm.newPostTitle.$invalid}"
-                    data-uib-tooltip="{{'required_field' | trans:{}:'icap_blog'}}"
+                    data-uib-tooltip="{{ vm.getErrorMessage(newPostForm.newPostTitle.$error) }}"
                     data-tooltip-class="errorTooltip"
                     data-tooltip-trigger="none"
-                    data-tooltip-is-open="newPostForm.newPostTitle.$dirty && newPostForm.newPostTitle.$invalid">
+                    data-tooltip-is-open="newPostForm.newPostTitle.$dirty && newPostForm.newPostTitle.$invalid"
+                    data-ng-maxlength="255">
             </div>
         </div>
     </div>

--- a/plugin/blog/Resources/translations/icap_blog.de.json
+++ b/plugin/blog/Resources/translations/icap_blog.de.json
@@ -1,5 +1,6 @@
 {
     "close": "",
     "apply": "Anwenden",
-    "search": "Suchen"
+    "search": "Suchen",
+    "maxlength_field": ""
 }

--- a/plugin/blog/Resources/translations/icap_blog.en.json
+++ b/plugin/blog/Resources/translations/icap_blog.en.json
@@ -90,6 +90,7 @@
     "infobar": "Info bar",
     "informations": "Information",
     "limit_to": "Limit display to the",
+    "maxlength_field": "Text too long",
     "modified_at": "Modified on",
     "new_post": "New post",
     "no_archives": "No archive",

--- a/plugin/blog/Resources/translations/icap_blog.es.json
+++ b/plugin/blog/Resources/translations/icap_blog.es.json
@@ -2,5 +2,6 @@
     "select": "Séleccionar",
     "apply": "Aplicar",
     "close": "Cerrar",
-    "search": "Buscar"
+    "search": "Buscar",
+    "maxlength_field": ""
 }

--- a/plugin/blog/Resources/translations/icap_blog.fr.json
+++ b/plugin/blog/Resources/translations/icap_blog.fr.json
@@ -89,6 +89,7 @@
     "infobar": "Barre d'informations",
     "informations": "Informations",
     "limit_to": "Limiter l'affichage aux",
+    "maxlength_field": "Texte trop long",
     "modified_at": "Modifié le",
     "new_post": "Nouvel article",
     "no_archives": "Aucune archive",

--- a/plugin/blog/Resources/translations/icap_blog.it.json
+++ b/plugin/blog/Resources/translations/icap_blog.it.json
@@ -1,1 +1,3 @@
-{}
+{
+  "maxlength_field": ""
+}

--- a/plugin/blog/Resources/translations/icap_blog.nl.json
+++ b/plugin/blog/Resources/translations/icap_blog.nl.json
@@ -90,6 +90,7 @@
     "icap_blog_post_unpublish_error": "Er is een fout opgetreden bij het verwijderen van het artikel.",
     "icap_blog_post_unpublish_success": "Artikel met succes verwijderd",
     "informations": "Informatie",
+    "maxlength_field": "",
     "modified_at": "Bewerkt op",
     "new_post": "Nieuw artikel",
     "no_archives": "Geen archief",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #2335 

Angular template now limits post title size to 255 chars (limit fixed in Symfony annotation on Post entity). 
Fixes #2335 


