### PR TITLE
[DropZoneBundle] Fix admin pages layout

### DIFF
--- a/plugin/dropzone/Resources/views/Dropzone/editCommon.html.twig
+++ b/plugin/dropzone/Resources/views/Dropzone/editCommon.html.twig
@@ -112,7 +112,7 @@
             <strong>{{ 'scheduleByDatePlanning'|trans({}, 'icap_dropzone') }}</strong>
         </label>
 
-        <div id="planning_dates">
+        <div id="planning_dates" class="container-fluid">
             <div class="row form-group">
                 <div class="col-md-offset-2 col-xs-offset-2 col-sm-offset-1">
                     {{ form_row(form.startAllowDrop, {'label_attr': {'class': 'control-label col-xs-offset-2 col-xs-12 col-sm-2', 'style': 'font-weight: normal;' }}

--- a/plugin/dropzone/Resources/views/Dropzone/editCriteria.html.twig
+++ b/plugin/dropzone/Resources/views/Dropzone/editCriteria.html.twig
@@ -288,8 +288,8 @@
     </div>
 
     {{ form_rest(form) }}
-    <div class="row">
-        <div class="btn-group pull-right">
+    <div class="row container-fluid">
+        <div class="btn-group pull-right container-fluid">
             <a href="{{ path('icap_dropzone_edit_common', {'resourceId': dropzone.getId()}) }}"
                class="btn btn-default criteria-form-button back-button">{{ 'Return'|trans({}, 'icap_dropzone') }}</a>
             <button id="submit_global_form" type="submit"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | 

Fixes admin pages overflow : content (and its padding) is now contained into page boundaries.


