### PR TITLE
Importers patch

### DIFF
--- a/main/core/Command/Dev/ImportWorkspaceModelCommand.php
+++ b/main/core/Command/Dev/ImportWorkspaceModelCommand.php
@@ -12,10 +12,13 @@
 namespace Claroline\CoreBundle\Command\Dev;
 
 use Claroline\CoreBundle\Entity\Workspace\Workspace;
+use Claroline\CoreBundle\Manager\WorkspaceManager;
+use Claroline\CoreBundle\Persistence\ObjectManager;
 use Psr\Log\LogLevel;
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpFoundation\File\File;
@@ -35,6 +38,12 @@ class ImportWorkspaceModelCommand extends ContainerAwareCommand
                 new InputArgument('directory_path', InputArgument::REQUIRED, 'The absolute path to the zip file.'),
                 new InputArgument('owner_username', InputArgument::REQUIRED, 'The owner username'),
             ]
+        );
+        $this->addOption(
+            'skip',
+            null,
+            InputOption::VALUE_NONE,
+            'When set to true, skip existing workspaces'
         );
     }
 
@@ -84,34 +93,56 @@ class ImportWorkspaceModelCommand extends ContainerAwareCommand
         $workspaceManager->setLogger($consoleLogger);
         $dirPath = $input->getArgument('directory_path');
         $username = $input->getArgument('owner_username');
+        $skip = $input->getOption('skip');
         $om = $this->getContainer()->get('claroline.persistence.object_manager');
         $total = 0;
-        $iterator = new \DirectoryIterator($dirPath);
 
-        foreach ($iterator as $pathinfo) {
-            if ($pathinfo->isFile()) {
-                ++$total;
-            }
-        }
-
-        $i = 0;
-        $output->writeln('<comment> Removing workspaces... </comment>');
-
-        foreach ($iterator as $pathinfo) {
-            if ($pathinfo->isFile()) {
-                $code = pathinfo($pathinfo->getFileName(), PATHINFO_FILENAME);
-                $workspace = $om->getRepository('ClarolineCoreBundle:Workspace\Workspace')->findOneByCode($code);
-                if ($workspace) {
-                    $output->writeln("<error> Removing {$workspace->getCode()} </error>");
-                    $this->getContainer()->get('claroline.manager.workspace_manager')->deleteWorkspace($workspace);
-                    $om->clear();
+        //import directory content
+        if (is_dir($dirPath)) {
+            $iterator = new \DirectoryIterator($dirPath);
+            //delete existing workspaces
+            if (!$skip) {
+                $output->writeln('<comment> Removing workspaces... </comment>');
+                foreach ($iterator as $pathinfo) {
+                    if ($pathinfo->isFile()) {
+                        $this->cleanWorkspace(new File($pathinfo->getPathname()), $output, $om);
+                    }
                 }
             }
+            //count
+            foreach ($iterator as $pathinfo) {
+                if ($pathinfo->isFile() && $pathinfo->getExtension() === 'zip') {
+                    ++$total;
+                }
+            }
+            //import workspaces
+            $i = 1;
+            foreach ($iterator as $pathinfo) {
+                if ($pathinfo->isFile()) {
+                    $this->importWorkspace(new File($pathinfo->getPathname()), $username, $output, $workspaceManager, $om, $i, $total, $skip);
+                    ++$i;
+                }
+            }
+        //import one specific workspace
+        } else {
+            $file = new File($dirPath);
+            if (!$skip) {
+                $output->writeln('<comment> Removing workspace... </comment>');
+                $this->cleanWorkspace($file, $output, $om);
+            }
+            $this->importWorkspace($file, $username, $output, $workspaceManager, $om, 1, 1, $skip);
         }
+    }
 
-        foreach ($iterator as $pathinfo) {
-            if ($pathinfo->isFile()) {
-                ++$i;
+    protected function importWorkspace(File $file, $username, OutputInterface $output, WorkspaceManager $workspaceManager, ObjectManager $om, $i, $total, $skip = false)
+    {
+        if ($file->getExtension() === 'zip') {
+            $workspace = null;
+            if ($skip) {
+                $workspace = $this->getWorkspaceFromCode($file, $output, $om);
+            }
+
+            if ($workspace === null) {
                 $output->writeln('<comment> Clearing object manager... </comment>');
                 $om->clear();
                 $user = $this->getContainer()->get('claroline.manager.user_manager')->getUserByUsername($username);
@@ -119,10 +150,28 @@ class ImportWorkspaceModelCommand extends ContainerAwareCommand
                 $this->getContainer()->get('security.context')->setToken($token);
                 $workspace = new Workspace();
                 $workspace->setCreator($user);
-                $file = new File($pathinfo->getPathname());
                 $workspaceManager->create($workspace, $file);
                 $output->writeln("<comment> Workspace {$i}/{$total} created. </comment>");
+            } else {
+                $output->writeln("<comment> Workspace {$workspace->getCode()} already exists. {$i}/{$total} skipped.</comment>");
             }
         }
+    }
+
+    protected function cleanWorkspace(File $file, OutputInterface $output, ObjectManager $om)
+    {
+        $workspace = $this->getWorkspaceFromCode($file, $output, $om);
+        if ($workspace) {
+            $output->writeln("<comment> Removing {$workspace->getCode()} </comment>");
+            $this->getContainer()->get('claroline.manager.workspace_manager')->deleteWorkspace($workspace);
+            $om->clear();
+        }
+    }
+
+    protected function getWorkspaceFromCode(File $file, OutputInterface $output, ObjectManager $om)
+    {
+        $code = pathinfo($file->getFileName(), PATHINFO_FILENAME);
+
+        return $om->getRepository('ClarolineCoreBundle:Workspace\Workspace')->findOneByCode($code);
     }
 }

--- a/main/core/Controller/WorkspaceController.php
+++ b/main/core/Controller/WorkspaceController.php
@@ -1355,34 +1355,26 @@ class WorkspaceController extends Controller
         $this->workspaceManager->setLogger($logger);
 
         if ($form->isValid()) {
-            $urlImport = false;
             if ($form->get('workspace')->getData()) {
                 $file = $form->get('workspace')->getData();
                 $template = new File($file);
             } elseif ($form->get('fileUrl')->getData() && filter_var($form->get('fileUrl')->getData(), FILTER_VALIDATE_URL)) {
-                $urlImport = true;
                 $url = $form->get('fileUrl')->getData();
                 $template = $this->importFromUrl($url);
-                if (!$template) {
+                if ($template === null) {
                     $msg = $this->translator->trans(
                         'invalid_host',
                         ['%url%' => $url],
                         'platform'
                     );
-                    $flashBag = $this->session->getFlashBag();
-                    $flashBag->add('error', $msg);
+                    $this->session->getFlashBag() > add('error', $msg);
                 }
             }
 
-            if ($template) {
+            if ($template !== null) {
                 $workspace = $form->getData();
                 $workspace->setCreator($this->tokenStorage->getToken()->getUser());
                 $this->workspaceManager->create($workspace, $template);
-                //delete manually created tmp if url import
-                if ($urlImport) {
-                    $fs = new FileSystem();
-                    $fs->remove($template);
-                }
                 $this->tokenUpdater->update($this->tokenStorage->getToken());
 
                 $route = $this->router->generate('claro_workspace_by_user');
@@ -1391,7 +1383,7 @@ class WorkspaceController extends Controller
                     ['%name%' => $form->get('name')->getData()],
                     'platform'
                 );
-                $this->get('request')->getSession()->getFlashBag()->add('success', $msg);
+                $this->session->getFlashBag()->add('success', $msg);
 
                 return new RedirectResponse($route);
             }
@@ -1407,32 +1399,48 @@ class WorkspaceController extends Controller
 
     private function importFromUrl($url)
     {
-        //REST URI hash used as unique file identifier for temporary template
-        $filepath = $this->container->get('claroline.config.platform_config_handler')->getParameter('tmp_dir').DIRECTORY_SEPARATOR.md5($url).'.zip';
-        //if already exists resume using it, no need to upload it again
-        if (file_exists($filepath)) {
-            return new File($filepath);
-        } else {
-            $fileWriter = fopen($filepath, 'w+');
-            $ch = curl_init();
-            curl_setopt($ch, CURLOPT_URL, $url);
-            curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-            curl_setopt($ch, CURLOPT_FILE, $fileWriter);
-            curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 15);
-            curl_setopt($ch, CURLOPT_TIMEOUT, 900);
-            curl_exec($ch);
-            $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-            $template = null;
-            if (!curl_errno($ch)) {
-                if ($httpcode === 200 || $httpcode === 201) {
+        $template = null;
+
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 15);
+        curl_setopt($ch, CURLOPT_NOBODY, true);
+        curl_exec($ch);
+
+        //check if url is a valid provider
+        $retcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        if ($retcode === 200 || $retcode === 201) {
+            $import_sub_folder = 'import'.DIRECTORY_SEPARATOR;
+            $import_folder_path = $this->container->get('claroline.config.platform_config_handler')->getParameter('tmp_dir').DIRECTORY_SEPARATOR.$import_sub_folder;
+            $fs = new FileSystem();
+            if (!$fs->exists($import_folder_path)) {
+                $fs->mkdir($import_folder_path);
+            }
+
+            //REST URI hash used as unique file identifier for temporary template
+            $filepath = $import_folder_path.md5($url).'.zip';
+
+            //if already exists resume using it, no need to upload it again
+            if (file_exists($filepath)) {
+                return new File($filepath);
+            } else {
+                $fileWriter = fopen($filepath, 'w+');
+                curl_setopt($ch, CURLOPT_NOBODY, false);
+                curl_setopt($ch, CURLOPT_FILE, $fileWriter);
+                curl_setopt($ch, CURLOPT_TIMEOUT, 900);
+                curl_exec($ch);
+
+                if (!curl_errno($ch)) {
                     $template = new File($filepath);
                 }
+                fclose($fileWriter);
             }
-            curl_close($ch);
-            fclose($fileWriter);
-
-            return $template;
         }
+        curl_close($ch);
+
+        return $template;
     }
 
     /**

--- a/main/core/Controller/WorkspaceController.php
+++ b/main/core/Controller/WorkspaceController.php
@@ -1367,7 +1367,7 @@ class WorkspaceController extends Controller
                         ['%url%' => $url],
                         'platform'
                     );
-                    $this->session->getFlashBag() > add('error', $msg);
+                    $this->session->getFlashBag()->add('error', $msg);
                 }
             }
 

--- a/main/core/Controller/WorkspaceController.php
+++ b/main/core/Controller/WorkspaceController.php
@@ -1355,10 +1355,12 @@ class WorkspaceController extends Controller
         $this->workspaceManager->setLogger($logger);
 
         if ($form->isValid()) {
+            $urlImport = false;
             if ($form->get('workspace')->getData()) {
                 $file = $form->get('workspace')->getData();
                 $template = new File($file);
             } elseif ($form->get('fileUrl')->getData() && filter_var($form->get('fileUrl')->getData(), FILTER_VALIDATE_URL)) {
+                $urlImport = true;
                 $url = $form->get('fileUrl')->getData();
                 $template = $this->importFromUrl($url);
                 if ($template === null) {
@@ -1375,6 +1377,11 @@ class WorkspaceController extends Controller
                 $workspace = $form->getData();
                 $workspace->setCreator($this->tokenStorage->getToken()->getUser());
                 $this->workspaceManager->create($workspace, $template);
+                //delete manually created tmp if url import
+                if ($urlImport) {
+                    $fs = new FileSystem();
+                    $fs->remove($template);
+                }
                 $this->tokenUpdater->update($this->tokenStorage->getToken());
 
                 $route = $this->router->generate('claro_workspace_by_user');

--- a/main/core/Library/Transfert/ConfigurationBuilders/Tools/Resources/FileImporter.php
+++ b/main/core/Library/Transfert/ConfigurationBuilders/Tools/Resources/FileImporter.php
@@ -89,18 +89,13 @@ class FileImporter extends Importer implements ConfigurationInterface, RichTextI
 
     public function import(array $array, $name, $created, $workspace)
     {
-        $ds = DIRECTORY_SEPARATOR;
-
         foreach ($array['data'] as $item) {
             $file = new File();
-            $tmpFile = new SfFile($this->getRootPath().$ds.$item['file']['path']);
-            $content = file_get_contents($this->getRootPath().DIRECTORY_SEPARATOR.$item['file']['path']);
+            $tmpFile = new SfFile($this->getRootPath().DIRECTORY_SEPARATOR.$item['file']['path']);
 
             $file = $this->container->get('claroline.listener.file_listener')->createFile(
                 $file, $tmpFile,  $name, $item['file']['mime_type'], $workspace
             );
-
-            file_put_contents(realpath($this->getRootPath()).$ds.$item['file']['path'], $content);
 
             return $file;
         }

--- a/main/core/Manager/TransferManager.php
+++ b/main/core/Manager/TransferManager.php
@@ -17,6 +17,7 @@ use Claroline\CoreBundle\Entity\Resource\ResourceNode;
 use Claroline\CoreBundle\Entity\User;
 use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Claroline\CoreBundle\Library\Transfert\Importer;
+use Claroline\CoreBundle\Library\Transfert\Resolver;
 use Claroline\CoreBundle\Library\Transfert\RichTextInterface;
 use Claroline\CoreBundle\Library\Transfert\ToolRichTextInterface;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -117,6 +118,31 @@ class TransferManager
         array $entityRoles,
         $importRoles = true
     ) {
+        return $this->populateWorkspaceFromTemplate($workspace, $data, $this->templateDirectory.$template->getBasename('.zip'), $root, $entityRoles, $importRoles);
+    }
+
+    /**
+     * Populates a workspace content with the content of an zip archive. In other words, it ignores the
+     * many properties of the configuration object and use an existing workspace as base.
+     *
+     * This will set the $this->data var
+     * This will set the $this->workspace var
+     *
+     * @param Workspace $workspace
+     * @param File      $template
+     * @param Directory $root
+     * @param array     $entityRoles
+     * @param bool      $isValidated
+     * @param bool      $importRoles
+     */
+    private function populateWorkspaceFromTemplate(
+        Workspace $workspace,
+        array $data,
+        $template,
+        Directory $root,
+        array $entityRoles,
+        $importRoles = true
+    ) {
         $this->om->startFlushSuite();
         $this->setWorkspaceForImporter($workspace);
         if ($importRoles) {
@@ -133,11 +159,11 @@ class TransferManager
         $this->om->endFlushSuite();
         //flush has to be forced unless it's a default template
         $defaults = [
-            realpath($this->container->getParameter('claroline.param.default_template')),
-            realpath($this->container->getParameter('claroline.param.personal_template')),
+            pathinfo(realpath($this->container->getParameter('claroline.param.default_template')), PATHINFO_DIRNAME),
+            pathinfo(realpath($this->container->getParameter('claroline.param.personal_template')), PATHINFO_DIRNAME),
         ];
 
-        if (!in_array(realpath($template->getPathname()), $defaults)) {
+        if (!in_array($template, $defaults)) {
             $this->om->forceFlush();
         }
 
@@ -174,6 +200,58 @@ class TransferManager
         $isValidated = false
     ) {
         $data = $this->container->get('claroline.manager.workspace_manager')->getTemplateData($template, true);
+        $workspace = $this->createWorkspaceFromData($workspace, $data, $this->templateDirectory.$template->getBasename('.zip'), $isValidated);
+        $this->container->get('claroline.manager.workspace_manager')->removeTemplate($template);
+
+        return $workspace;
+    }
+
+    /**
+     * @param $template Directory uncompressed template in plateform templateDirectory
+     * @param User $owner
+     * @param bool $isValidated
+     *
+     * @throws InvalidConfigurationException
+     *
+     * @return SimpleWorkbolspace
+     *
+     * The template doesn't need to be validated anymore if
+     *  - it comes from the self::import() function
+     *  - we want to create a user from the default template (it should work no matter what)
+     */
+    public function createWorkspaceFromTemplate(
+        Workspace $workspace,
+        $templatePath,
+        $isValidated = false
+    ) {
+        $resolver = new Resolver($templatePath);
+        $this->importData = $resolver->resolve();
+        $data = $this->importData;
+        $workspace = $this->createWorkspaceFromData($workspace, $data, $templatePath, $isValidated);
+        $this->container->get('claroline.manager.workspace_manager')->removeTemplateDirectory($templatePath);
+
+        return $workspace;
+    }
+
+    /**
+     * @param File $template
+     * @param User $owner
+     * @param bool $isValidated
+     *
+     * @throws InvalidConfigurationException
+     *
+     * @return SimpleWorkbolspace
+     *
+     * The template doesn't need to be validated anymore if
+     *  - it comes from the self::import() function
+     *  - we want to create a user from the default template (it should work no matter what)
+     */
+    private function createWorkspaceFromData(
+        Workspace $workspace,
+        array $data,
+        $template,
+        $isValidated = false
+    ) {
         $data = $this->reorderData($data);
 
         if ($workspace->getCode() === null && isset($data['parameters'])) {
@@ -185,10 +263,9 @@ class TransferManager
         }
 
         //just to be sure doctrine is ok before doing all the workspace
-
         $this->om->startFlushSuite();
         $data = $this->reorderData($data);
-        $this->setImporters($template, $workspace->getCreator(), $data);
+        $this->setImportersForTemplate($template, $workspace->getCreator(), $data);
 
         if (!$isValidated) {
             $data = $this->validate($data, false);
@@ -213,8 +290,13 @@ class TransferManager
             true
         );
 
-        //batch import with default template shouldn't be flushed
-        if (strpos($template->getPathname(), 'default.zip') === false && strpos($template->getPathname(), 'personal.zip') === false) {
+        //flush has to be forced unless it's a default template
+        $defaults = [
+            pathinfo(realpath($this->container->getParameter('claroline.param.default_template')), PATHINFO_DIRNAME),
+            pathinfo(realpath($this->container->getParameter('claroline.param.personal_template')), PATHINFO_DIRNAME),
+        ];
+
+        if (!in_array($template, $defaults)) {
             $this->om->forceFlush();
         }
 
@@ -251,8 +333,7 @@ class TransferManager
         );
 
         $this->log('Populating the workspace...');
-        $this->populateWorkspace($workspace, $data, $template, $root, $entityRoles, false);
-        $this->container->get('claroline.manager.workspace_manager')->removeTemplate($template);
+        $this->populateWorkspaceFromTemplate($workspace, $data, $template, $root, $entityRoles, false);
         $this->container->get('claroline.manager.workspace_manager')->createWorkspace($workspace);
         $this->om->endFlushSuite();
 
@@ -419,8 +500,19 @@ class TransferManager
      */
     private function setImporters(File $template, User $owner, array $data)
     {
+        $this->setImportersForTemplate($this->templateDirectory.$template->getBasename('.zip'), $owner, $data);
+    }
+
+    /**
+     * Inject the rootPath.
+     *
+     * @param $template template path
+     * @param array $data
+     */
+    private function setImportersForTemplate($template, User $owner, array $data)
+    {
         foreach ($this->listImporters as $importer) {
-            $importer->setRootPath($this->templateDirectory.$template->getBasename('.zip'));
+            $importer->setRootPath($template);
             $importer->setOwner($owner);
             $importer->setConfiguration($data);
             $importer->setListImporters($this->listImporters);

--- a/main/core/Manager/TransferManager.php
+++ b/main/core/Manager/TransferManager.php
@@ -207,13 +207,13 @@ class TransferManager
     }
 
     /**
-     * @param $template Directory uncompressed template in plateform templateDirectory
-     * @param User $owner
-     * @param bool $isValidated
+     * @param Workspace $workspace
+     * @param string    $templatePath
+     * @param bool      $isValidated
      *
      * @throws InvalidConfigurationException
      *
-     * @return SimpleWorkbolspace
+     * @return Workspace
      *
      * The template doesn't need to be validated anymore if
      *  - it comes from the self::import() function
@@ -234,13 +234,14 @@ class TransferManager
     }
 
     /**
-     * @param File $template
-     * @param User $owner
+     * @param Workspace $workspace
+     * @param array     $data
+     * @param string template
      * @param bool $isValidated
      *
      * @throws InvalidConfigurationException
      *
-     * @return SimpleWorkbolspace
+     * @return Workspace
      *
      * The template doesn't need to be validated anymore if
      *  - it comes from the self::import() function
@@ -506,8 +507,9 @@ class TransferManager
     /**
      * Inject the rootPath.
      *
-     * @param $template template path
-     * @param array $data
+     * @param string $template
+     * @param User   $owner
+     * @param array  $data
      */
     private function setImportersForTemplate($template, User $owner, array $data)
     {

--- a/main/core/Manager/WorkspaceManager.php
+++ b/main/core/Manager/WorkspaceManager.php
@@ -177,6 +177,27 @@ class WorkspaceManager
     }
 
     /**
+     * Creates a workspace.
+     *
+     * @param Workspace $workspace
+     * @param $template uncompressed template
+     *
+     * @return \Claroline\CoreBundle\Entity\Workspace\AbstractWorkspace
+     */
+    public function createFromTemplate(Workspace $workspace, $templateDirectory)
+    {
+        $transferManager = $this->container->get('claroline.manager.transfer_manager');
+
+        if ($this->logger) {
+            $transferManager->setLogger($this->logger);
+        }
+
+        $workspace = $transferManager->createWorkspaceFromTemplate($workspace, $templateDirectory, false);
+
+        return $workspace;
+    }
+
+    /**
      * @param \Claroline\CoreBundle\Entity\Workspace\Workspace $workspace
      */
     public function createWorkspace(Workspace $workspace)
@@ -1249,6 +1270,11 @@ class WorkspaceManager
     {
         $fileName = $file->getBasename('.zip');
         $extractPath = $this->templateDirectory.DIRECTORY_SEPARATOR.$fileName;
+        $this->removeTemplateDirectory($extractPath);
+    }
+
+    public function removeTemplateDirectory($extractPath)
+    {
         $fs = new FileSystem();
         $fs->remove($extractPath);
     }

--- a/main/core/Manager/WorkspaceManager.php
+++ b/main/core/Manager/WorkspaceManager.php
@@ -1247,7 +1247,7 @@ class WorkspaceManager
 
     public function removeTemplate(File $file)
     {
-        $fileName = $file->getBasename();
+        $fileName = $file->getBasename('.zip');
         $extractPath = $this->templateDirectory.DIRECTORY_SEPARATOR.$fileName;
         $fs = new FileSystem();
         $fs->remove($extractPath);

--- a/main/core/Resources/views/Workspace/importForm.html.twig
+++ b/main/core/Resources/views/Workspace/importForm.html.twig
@@ -22,6 +22,7 @@
     <div class="page-header">
         <h1>{{ 'import'|trans({}, 'platform') }}</h1>
     </div>
+    {{ macros.flashBox() }}
     <form role="form" class="form-horizontal panel panel-default" id="ws_import_form" action="{{ path('claro_workspace_import') }}" method="post" {{ form_enctype(form) }}>
         <div class="panel-body">
             {{ form_errors(form) }}

--- a/plugin/bibliography/Transfert/BibliographyImporter.php
+++ b/plugin/bibliography/Transfert/BibliographyImporter.php
@@ -5,6 +5,7 @@ namespace Icap\BibliographyBundle\Transfert;
 use Claroline\CoreBundle\Library\Transfert\Importer;
 use Icap\BibliographyBundle\Manager\BookReferenceManager;
 use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Processor;
 
@@ -48,6 +49,8 @@ class BibliographyImporter extends Importer implements ConfigurationInterface
                 ->scalarNode('coverUrl')->end()
             ->end()
         ->end();
+
+        return $treeBuilder;
     }
 
     public function getName()

--- a/plugin/blog/Manager/BlogManager.php
+++ b/plugin/blog/Manager/BlogManager.php
@@ -170,7 +170,7 @@ class BlogManager
         $this->objectManager->forceFlush();
 
         //Copy banner bg image to web folder
-        if ($optionsData['banner_background_image'] !== null && !filter_var($optionsData['banner_background_image'], FILTER_VALIDATE_URL)) {
+        if (isset($optionsData['banner_background_image']) && $optionsData['banner_background_image'] !== null && !filter_var($optionsData['banner_background_image'], FILTER_VALIDATE_URL)) {
             $this->createUploadFolder(DIRECTORY_SEPARATOR.$this->uploadDir);
             $uniqid = uniqid();
             copy(

--- a/plugin/forum/Transfert/ForumImporter.php
+++ b/plugin/forum/Transfert/ForumImporter.php
@@ -72,6 +72,8 @@ class ForumImporter extends Importer implements ConfigurationInterface, RichText
                                             ->children()
                                                 ->scalarNode('name')->end()
                                                 ->scalarNode('creator')->end()
+                                                ->scalarNode('author')->end()
+                                                ->scalarNode('creation_date')->end()
                                                 ->arrayNode('messages')
                                                     ->prototype('array')
                                                         ->children()
@@ -126,8 +128,16 @@ class ForumImporter extends Importer implements ConfigurationInterface, RichText
                         $creator = $repo->findOneByUsername($subject['subject']['creator']);
                     }
 
+                    if (isset($subject['subject']['creation_date'])) {
+                        $subjectEntity->setCreationDate(new \DateTime($subject['subject']['creation_date']));
+                    }
+
                     if ($creator === null) {
                         $creator = $this->container->get('security.context')->getToken()->getUser();
+                    }
+
+                    if (isset($subject['subject']['author'])) {
+                        $subjectEntity->setAuthor($subject['subject']['author']);
                     }
 
                     $subjectEntity->setCreator($creator);
@@ -149,6 +159,14 @@ class ForumImporter extends Importer implements ConfigurationInterface, RichText
 
                         if ($creator === null) {
                             $creator = $this->container->get('security.context')->getToken()->getUser();
+                        }
+
+                        if (isset($message['message']['creation_date'])) {
+                            $messageEntity->setCreationDate(new \DateTime($message['message']['creation_date']));
+                        }
+
+                        if (isset($message['message']['modification_date'])) {
+                            $messageEntity->setModificationDate(new \DateTime($message['message']['modification_date']));
                         }
 
                         $messageEntity->setCreator($creator);

--- a/plugin/forum/Transfert/ForumImporter.php
+++ b/plugin/forum/Transfert/ForumImporter.php
@@ -74,6 +74,7 @@ class ForumImporter extends Importer implements ConfigurationInterface, RichText
                                                 ->scalarNode('creator')->end()
                                                 ->scalarNode('author')->end()
                                                 ->scalarNode('creation_date')->end()
+                                                ->booleanNode('sticked')->defaultFalse()->end()
                                                 ->arrayNode('messages')
                                                     ->prototype('array')
                                                         ->children()
@@ -126,6 +127,10 @@ class ForumImporter extends Importer implements ConfigurationInterface, RichText
 
                     if ($subject['subject']['creator'] !== null) {
                         $creator = $repo->findOneByUsername($subject['subject']['creator']);
+                    }
+
+                    if (isset($subject['subject']['sticked'])) {
+                        $subjectEntity->setIsSticked($subject['subject']['sticked']);
                     }
 
                     if (isset($subject['subject']['creation_date'])) {

--- a/plugin/url/Manager/UrlManager.php
+++ b/plugin/url/Manager/UrlManager.php
@@ -32,13 +32,18 @@ class UrlManager
     public function setUrl(Url $url)
     {
         $address = $url->getUrl();
-        $baseUrl = $this->request->getCurrentRequest()->getSchemeAndHttpHost().$this->request->getCurrentRequest()->getScriptName();
-        $baseUrlEscapeQuote = preg_quote($baseUrl);
+        $baseUrlEscapeQuote = null;
+        $baseUrl = null;
         $url->setInternalUrl(false);
 
-        if (preg_match("#$baseUrlEscapeQuote#", $address)) {
-            $url->setUrl(substr($address, strlen($baseUrl)));
-            $url->setInternalUrl(true);
+        if ($this->request->getCurrentRequest() !== null) {
+            $baseUrl = $this->request->getCurrentRequest()->getSchemeAndHttpHost().$this->request->getCurrentRequest()->getScriptName();
+            $baseUrlEscapeQuote = preg_quote($baseUrl);
+
+            if (preg_match("#$baseUrlEscapeQuote#", $address)) {
+                $url->setUrl(substr($address, strlen($baseUrl)));
+                $url->setInternalUrl(true);
+            }
         }
 
         return $url;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Fixed tickets | 

- adds a method to create workspace from uncompressed template
- adds options to ImportWorkspaceModelCommand command line (--skip to skip existing workspaces and not deleting them, --uncompressed to import provided directory_path as an uncompressed template)
- removes unecessary file copy in memory during file import, it was doing twice the job, and mounting big files in memory provoked memory limit exceptions.
- fixes missing 'sticked', 'creation_date', ''modification_date' properties in forum importer
- adds http context check in url importer, otherwise crashed if called from command line
- fixes blog import banner detection
- fixes bibliography importer
- fixes missing flashbag in importForm.html.twig



