### PR TITLE
API getUserAction() route fix

### DIFF
--- a/main/core/Controller/API/User/UserController.php
+++ b/main/core/Controller/API/User/UserController.php
@@ -263,7 +263,7 @@ class UserController extends FOSRestController
     /**
      * @View(serializerGroups={"api_user"})
      * @ParamConverter("user", class="ClarolineCoreBundle:User", options={"repository_method" = "findForApi"})
-     * @Get("/user/{user}/format", name="get_user", options={ "method_prefix" = false })
+     * @Get("/user/{user}/get", name="get_user", options={ "method_prefix" = false })
      */
     public function getUserAction(User $user)
     {

--- a/main/core/Controller/API/User/UserController.php
+++ b/main/core/Controller/API/User/UserController.php
@@ -263,7 +263,7 @@ class UserController extends FOSRestController
     /**
      * @View(serializerGroups={"api_user"})
      * @ParamConverter("user", class="ClarolineCoreBundle:User", options={"repository_method" = "findForApi"})
-     * @Get("/user/{user}", name="get_user", options={ "method_prefix" = false })
+     * @Get("/user/{user}/format", name="get_user", options={ "method_prefix" = false })
      */
     public function getUserAction(User $user)
     {

--- a/main/core/Tests/API/User/UserControllerTest.php
+++ b/main/core/Tests/API/User/UserControllerTest.php
@@ -222,7 +222,7 @@ class UserControllerTest extends TransactionalTestCase
 
         //tests
         $this->logIn($adminOrga);
-        $this->client->request('GET', "api/user/{$john->getId()}.json");
+        $this->client->request('GET', "api/user/{$john->getId()}/get.json");
         $data = $this->client->getResponse()->getContent();
         $data = json_decode($data, true);
         $this->assertEquals(403, $this->client->getResponse()->getStatusCode());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets 

 @Get("/user/{user}") expects a login or email as parameter, but fails if they contain dots (e.g. firstname.lastname, and most emails), which defeats the purpose of the method. Problem comes from the use of the dot as separator for 'format' parameter in routing (FOSRestBundle ?).
Adding a new part to the route splits up the 'user' and 'format' parameters thus fixing the problem.


