### PR TITLE
[CoreBundle] removes duplicated trait use

### DIFF
--- a/main/core/DataFixtures/PostInstall/LoadPostInstallFixturesData.php
+++ b/main/core/DataFixtures/PostInstall/LoadPostInstallFixturesData.php
@@ -11,7 +11,6 @@
 
 namespace Claroline\CoreBundle\DataFixtures\PostInstall;
 
-use Claroline\BundleRecorder\Log\LoggableTrait;
 use Claroline\CoreBundle\DataFixtures\Required\LoadRequiredFixturesData;
 
 /**
@@ -20,5 +19,4 @@ use Claroline\CoreBundle\DataFixtures\Required\LoadRequiredFixturesData;
  */
 class LoadPostInstallFixturesData extends LoadRequiredFixturesData
 {
-    use LoggableTrait;
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no

The trait is already loaded in the parent class `LoadRequiredFixturesData`.
This should fix travis on claroline/Claroline.


