### PR TITLE
typo on object tag

### DIFF
--- a/main/core/Library/Transfert/RichTextFormatter.php
+++ b/main/core/Library/Transfert/RichTextFormatter.php
@@ -568,7 +568,7 @@ class RichTextFormatter
             );
             //embed flash by default
             if (!isset($embed) || $embed) {
-                return '<object '.$cssStyle." type='".$node->getMimeType()."' src='".$url."'>".
+                return '<object '.$cssStyle." type='".$node->getMimeType()."' data='".$url."'>".
                             "<param name='allowFullScreen' value='true' />".
                             "<param name='src' value='".$url."' />".
                         '</object>';


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | 

typo on object tag, source attribute is data, not src


