### PR TITLE
[DevBundle] Fixed to point to local php-cs-fixer inside vendor/bin

### DIFF
--- a/main/dev/Resources/hooks/pre-commit-phpcs
+++ b/main/dev/Resources/hooks/pre-commit-phpcs
@@ -29,7 +29,7 @@ foreach ($files as $file) {
 
         if ($return === 0) {
             // fix file and add it back
-            exec("php-cs-fixer fix {$fileName} --level=symfony --fixers=ordered_use,short_array_syntax; git add {$fileName}");
+            exec("{$csFixer} fix {$fileName} --level=symfony --fixers=ordered_use,short_array_syntax; git add {$fileName}");
         } else {
             echo implode("\n", $output)."\n";
             exit(1);


### PR DESCRIPTION
php-cs-fixer was pointing to machine's global php-cs-fixer. As a result if machine's php-cs-fixer was updated to a version >= 2 the hook didn't work.

