### PR TITLE
[WebsiteBundle]Changed import 'target' default value

### DIFF
--- a/plugin/website/Entity/WebsitePage.php
+++ b/plugin/website/Entity/WebsitePage.php
@@ -561,6 +561,7 @@ class WebsitePage
             }
         } elseif ($this->type === WebsitePageTypeEnum::URL_PAGE) {
             $this->url = $optionsArray['url'];
+            $this->target = 1;
         }
     }
 


### PR DESCRIPTION

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets 

Fixes default target for external links in website importer. 
Forces default target value to new tab instead of iframe, to prevent crossdomain issues.


