### PR TITLE
[CoreBundle] adds react-router-dom and core UI components

### DIFF
--- a/main/core/Resources/modules/administration/workspace/components/workspaces.jsx
+++ b/main/core/Resources/modules/administration/workspace/components/workspaces.jsx
@@ -18,8 +18,13 @@ import {select as paginationSelect} from '#/main/core/layout/pagination/selector
 import {select as listSelect} from '#/main/core/layout/list/selectors'
 import {select} from '#/main/core/administration/workspace/selectors'
 
-import {Page, PageHeader, PageContent} from '#/main/core/layout/page/components/page.jsx'
-import {PageActions, PageAction} from '#/main/core/layout/page/components/page-actions.jsx'
+import {
+  PageContainer as Page,
+  PageHeader,
+  PageContent,
+  PageActions,
+  PageAction
+} from '#/main/core/layout/page/index'
 
 import {LIST_PROP_DEFAULT, LIST_PROP_DISPLAYED, LIST_PROP_DISPLAYABLE, LIST_PROP_FILTERABLE} from '#/main/core/layout/list/utils'
 import {DataList} from '#/main/core/layout/list/components/data-list.jsx'

--- a/main/core/Resources/modules/administration/workspace/components/workspaces.jsx
+++ b/main/core/Resources/modules/administration/workspace/components/workspaces.jsx
@@ -13,7 +13,6 @@ import {actions as paginationActions} from '#/main/core/layout/pagination/action
 import {actions as listActions} from '#/main/core/layout/list/actions'
 import {actions} from '#/main/core/administration/workspace/actions'
 
-import {select as modalSelect} from '#/main/core/layout/modal/selectors'
 import {select as paginationSelect} from '#/main/core/layout/pagination/selectors'
 import {select as listSelect} from '#/main/core/layout/list/selectors'
 import {select} from '#/main/core/administration/workspace/selectors'
@@ -86,12 +85,7 @@ class Workspaces extends Component {
 
   render() {
     return (
-      <Page
-        id="workspace-management"
-        modal={this.props.modal}
-        fadeModal={this.props.fadeModal}
-        hideModal={this.props.hideModal}
-        >
+      <Page id="workspace-management">
         <PageHeader
           title={t('workspaces_management')}
         >
@@ -231,14 +225,7 @@ Workspaces.propTypes = {
   toggleSelect: T.func.isRequired,
   toggleSelectAll: T.func.isRequired,
 
-  modal: T.shape({
-    type: T.string,
-    fading: T.bool.isRequired,
-    props: T.object.isRequired
-  }),
-  showModal: T.func.isRequired,
-  fadeModal: T.func.isRequired,
-  hideModal: T.func.isRequired
+  showModal: T.func.isRequired
 }
 
 function mapStateToProps(state) {
@@ -251,8 +238,7 @@ function mapStateToProps(state) {
       current:  paginationSelect.current(state)
     },
     filters: listSelect.filters(state),
-    sortBy: listSelect.sortBy(state),
-    modal: modalSelect.modal(state)
+    sortBy: listSelect.sortBy(state)
   }
 }
 
@@ -309,12 +295,6 @@ function mapDispatchToProps(dispatch) {
     // modals
     showModal(modalType, modalProps) {
       dispatch(modalActions.showModal(modalType, modalProps))
-    },
-    fadeModal() {
-      dispatch(modalActions.fadeModal())
-    },
-    hideModal() {
-      dispatch(modalActions.hideModal())
     }
   }
 }

--- a/main/core/Resources/modules/administration/workspace/index.js
+++ b/main/core/Resources/modules/administration/workspace/index.js
@@ -1,56 +1,58 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import {Provider} from 'react-redux'
+import {bootstrap} from '#/main/core/utilities/app/bootstrap'
 
-import {createStore} from '#/main/core/utilities/redux'
+// modals
 import {registerModalType} from '#/main/core/layout/modal'
 import {ConfirmModal} from '#/main/core/layout/modal/components/confirm.jsx'
 import {UserPickerModal} from '#/main/core/layout/modal/components/user-picker.jsx'
 
-import {reducer} from '#/main/core/administration/workspace/reducer'
+// reducers
+import {reducer as apiReducer} from '#/main/core/api/reducer'
+import {reducer as modalReducer} from '#/main/core/layout/modal/reducer'
+import {reducer as paginationReducer} from '#/main/core/layout/pagination/reducer'
+import {makeListReducer} from '#/main/core/layout/list/reducer'
+import {reducer as workspacesReducer} from '#/main/core/administration/workspace/reducer'
+
 import {Workspaces} from '#/main/core/administration/workspace/components/workspaces.jsx'
 
-class WorkspaceAdministration {
-  constructor(initialData) {
-    registerModalType('CONFIRM_MODAL', ConfirmModal)
-    registerModalType('MODAL_USER_PICKER', UserPickerModal)
+// register custom modals for the app
+registerModalType('CONFIRM_MODAL', ConfirmModal)
+registerModalType('MODAL_USER_PICKER', UserPickerModal)
 
-    this.store = createStore(reducer, initialData)
-  }
+// mount the react application
+bootstrap(
+  // app DOM container (also holds initial app data as data attributes)
+  '.workspace-administration-container',
 
-  render(element) {
-    ReactDOM.render(
-      React.createElement(
-        Provider,
-        {store: this.store},
-        React.createElement(Workspaces)
-      ),
-      element
-    )
-  }
-}
+  // app main component (accepts either a `routedApp` or a `ReactComponent`)
+  Workspaces,
 
-const container = document.querySelector('.workspace-administration-container')
-const workspaces = JSON.parse(container.dataset.workspaces)
-const count = parseInt(container.dataset.count)
-const page = parseInt(container.dataset.page)
-const pageSize = parseInt(container.dataset.pagesize)
-const filters = JSON.parse(container.dataset.filters)
-const sortBy = JSON.parse(container.dataset.orderby)
+  // app store configuration
+  {
+    // app reducers
+    workspaces: workspacesReducer,
 
-const adminTool = new WorkspaceAdministration({
-  workspaces: {
-    data: workspaces,
-    totalResults: count
+    // generic reducers
+    currentRequests: apiReducer,
+    modal: modalReducer,
+    list: makeListReducer(),
+    pagination: paginationReducer
   },
-  pagination: {
-    pageSize,
-    current: page
-  },
-  list: {
-    filters,
-    sortBy
-  }
-})
 
-adminTool.render(container)
+  // remap data-attributes set on the app DOM container
+  (initialData) => {
+    return {
+      workspaces: {
+        data: initialData.workspaces,
+        totalResults: initialData.count
+      },
+      pagination: {
+        pageSize: initialData.pageSize,
+        current: initialData.page
+      },
+      list: {
+        filters: initialData.filters,
+        sortBy: initialData.sortBy ? initialData.sortBy : undefined
+      }
+    }
+  }
+)

--- a/main/core/Resources/modules/administration/workspace/reducer.js
+++ b/main/core/Resources/modules/administration/workspace/reducer.js
@@ -1,9 +1,6 @@
-import {makeReducer, combineReducers} from '#/main/core/utilities/redux'
-import {reducer as apiReducer} from '#/main/core/api/reducer'
-import {reducer as modalReducer} from '#/main/core/layout/modal/reducer'
-import {reducer as paginationReducer} from '#/main/core/layout/pagination/reducer'
-import {makeListReducer} from '#/main/core/layout/list/reducer'
 import cloneDeep from 'lodash/cloneDeep'
+
+import {makeReducer} from '#/main/core/utilities/redux'
 
 import {
   WORKSPACES_LOAD,
@@ -34,16 +31,10 @@ const handlers = {
   }
 }
 
-const reducer = combineReducers({
-  currentRequests: apiReducer,
-  workspaces: makeReducer({
-    data: [],
-    totalResults: 0
-  }, handlers),
-  pagination: paginationReducer,
-  list: makeListReducer(),
-  modal: modalReducer
-})
+const reducer = makeReducer({
+  data: [],
+  totalResults: 0
+}, handlers)
 
 export {
   reducer

--- a/main/core/Resources/modules/layout/page/components/page-actions.jsx
+++ b/main/core/Resources/modules/layout/page/components/page-actions.jsx
@@ -111,7 +111,6 @@ const MoreAction = props =>
     <DropdownButton
       id="page-more"
       title={<span className="page-action-icon fa fa-ellipsis-v" />}
-      bsStyle=""
       className="btn page-action-btn"
       noCaret={true}
       pullRight={true}
@@ -121,7 +120,16 @@ const MoreAction = props =>
   </TooltipElement>
 
 MoreAction.propTypes = {
-  children: T.node.isRequired
+  children: T.node.isRequired/*,
+  actionGroups: T.arrayOf(T.shape({
+    name: T.string.isRequired,
+    actions: T.arrayOf(T.shape({
+      icon: T.string,
+      label: T.string.isRequired,
+      action: T.oneOfType([T.string, T.func]).isRequired,
+      isDangerous: T.bool
+    })).isRequired
+  })).isRequired*/
 }
 
 /**

--- a/main/core/Resources/modules/layout/page/components/page.jsx
+++ b/main/core/Resources/modules/layout/page/components/page.jsx
@@ -6,36 +6,11 @@ import classes from 'classnames'
 import {makeModal} from '#/main/core/layout/modal'
 
 /**
- * Container for the current page.
- *
- * Its only purpose is to initialize the flex layout to auto fill the available space.
- * As most of the time we use SPA for building UI it's a common practice to just add
- * the class `.page-container` to the mount element of the SPA.
- *
- * @param props
- * @constructor
- */
-const PageContainer = props =>
-  <div className="page-container">
-    {props.children}
-  </div>
-
-PageContainer.propTypes = {
-  /**
-   * The root of the current page
-   *
-   * You may experience display issue (because of the flex layout)
-   * if you don't use the <Page> component or an HTML container with the `.page` class.
-   * For now we don't constrain it for more flexibility.
-   */
-  children: T.node.isRequired
-}
-
-/**
  * Root of the current page.
  *
- * We manage full screen feature here and not in the container
- * because container component may not exist (@see PageContainer doc block for more info).
+ * For now, modals are managed here.
+ * In future version, when the layout will be in React,
+ * it'll be moved in higher level.
  *
  * @param props
  * @constructor
@@ -161,7 +136,6 @@ PageContent.propTypes = {
 }
 
 export {
-  PageContainer,
   Page,
   PageHeader,
   PageContent

--- a/main/core/Resources/modules/layout/page/containers/page.jsx
+++ b/main/core/Resources/modules/layout/page/containers/page.jsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import {PropTypes as T} from 'prop-types'
+import {connect} from 'react-redux'
+
+import {select as modalSelect} from '#/main/core/layout/modal/selectors'
+import {actions as modalActions} from '#/main/core/layout/modal/actions'
+
+import {Page as PageComponent} from '#/main/core/layout/page/components/page.jsx'
+
+/**
+ * Connected container for pages.
+ *
+ * Connects the <Page> component to a redux store.
+ * If you don't use redux in your implementation @see Page functional component.
+ *
+ * Requires the following reducers to be registered in your store :
+ *   - modal
+ *
+ * @param props
+ * @constructor
+ */
+const Page = props =>
+  <PageComponent
+    {...props}
+  >
+    {props.children}
+  </PageComponent>
+
+Page.propTypes = {
+  /**
+   * Content to display in the page.
+   */
+  children: T.node.isRequired
+}
+
+
+function mapStateToProps(state) {
+  return {
+    modal: modalSelect.modal(state)
+  }
+}
+
+// connects the container to redux
+const PageContainer = connect(mapStateToProps, Object.assign({}, modalActions))(Page)
+
+export {
+  PageContainer
+}

--- a/main/core/Resources/modules/layout/page/index.js
+++ b/main/core/Resources/modules/layout/page/index.js
@@ -1,2 +1,20 @@
-export * from './components/page.jsx'
-export * from './components/page-actions.jsx'
+
+// presentational components
+export {
+  Page,
+  PageHeader,
+  PageContent
+} from './components/page.jsx'
+
+export {
+  PageAction,
+  FullScreenAction,
+  MoreAction,
+  PageGroupActions,
+  PageActions
+} from './components/page-actions.jsx'
+
+// containers
+export {
+  PageContainer
+} from './containers/page.jsx'

--- a/main/core/Resources/modules/utilities/app/bootstrap.js
+++ b/main/core/Resources/modules/utilities/app/bootstrap.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import {Provider} from 'react-redux'
+
+import {combineReducers, createStore} from '#/main/core/utilities/redux'
+
+/**
+ * Bootstraps a new React/Redux app.
+ *
+ * @param {string}   containerSelector - a selector to retrieve the HTML element which will hold the JS app.
+ * @param {mixed}    rootComponent     - the React root component of the app.
+ * @param {object}   reducers          - an object containing the reducers of the app.
+ * @param {function} transformData     - a function to transform data before adding them to the store.
+ */
+export function bootstrap(containerSelector, rootComponent, reducers, transformData = (data) => data) {
+  // Retrieve app container
+  const container = document.querySelector(containerSelector)
+  if (!container) {
+    throw new Error(`Container "${containerSelector}" for app can not be found.`)
+  }
+
+  // Get initial data from container data attributes
+  const initialData = {}
+  if (container.dataset) {
+    for (let prop in container.dataset) {
+      if (container.dataset.hasOwnProperty(prop) && 0 < container.dataset[prop].length) {
+        initialData[prop] = JSON.parse(container.dataset[prop])
+      }
+    }
+  }
+
+  // Render app
+  ReactDOM.render(
+    React.createElement(
+      Provider,
+      {
+        store: createStore(combineReducers(reducers), transformData(initialData))
+      },
+      React.createElement(rootComponent)
+    ),
+    container
+  )
+}

--- a/main/core/Resources/modules/utilities/app/router.js
+++ b/main/core/Resources/modules/utilities/app/router.js
@@ -1,0 +1,63 @@
+import React from 'react'
+import {
+  hashHistory,
+  HashRouter as Router,
+  Route,
+  Switch
+} from 'react-router-dom'
+
+function getRouteComponent(route) {
+  // todo validate route config
+
+  const routeProps = {
+    key: route.path,
+    path: route.path,
+    exact: !!route.exact
+  }
+
+  if (route.routes) {
+    routeProps.children = React.createElement(Switch, {}, route.routes.map(routeConfig => getRouteComponent(routeConfig)))
+  } else {
+    routeProps.component = route.component
+  }
+
+  return React.createElement(Route, routeProps)
+}
+
+/**
+ * Creates react router components based on config.
+ *
+ * NB:
+ *   if you use connected components that needs to access route params,
+ *   you have to tell them there is a router.
+ *   @see https://reacttraining.com/react-router/web/guides/redux-integration
+ *
+ * Example of simple routing config :
+ *   [
+ *     {path: '',     component: MyComponent, exact: true},
+ *     {path: '/:id', component: MyOtherComponent}
+ *   ]
+ *
+ * Example of nested routing config :
+ *   [{
+ *     path: '/main',
+ *     routes: [
+ *       {path: '',     component: MyComponent, exact: true},
+ *       {path: '/:id', component: MyOtherComponent}
+ *     ]
+ *   }]
+ *
+ * @param {Array}  routesConfig
+ * @param {string} basePath
+ */
+export function routedApp(routesConfig, basePath = '') {
+  return () => {
+    const RoutedApp = React.createElement(Router, {
+      history: hashHistory
+    }, React.createElement(Route, {
+      path: basePath
+    }, React.createElement(Switch, {}, routesConfig.map(route => getRouteComponent(route)))))
+
+    return RoutedApp
+  }
+}

--- a/main/core/Resources/modules/utilities/redux.js
+++ b/main/core/Resources/modules/utilities/redux.js
@@ -26,6 +26,13 @@ export function makeActionCreator(type, ...argNames) {
   }
 }
 
+// syntax sugar to avoid writing reducers as big switches.
+// Example :
+//   makeReducer([], {
+//     [LIST_RESET_SELECT]: resetSelect,
+//     [LIST_TOGGLE_SELECT]: toggleSelect,
+//     [LIST_TOGGLE_SELECT_ALL]: toggleSelectAll
+//   })
 export function makeReducer(initialState, handlers) {
   return function reducer(state = initialState, action) {
     if (handlers.hasOwnProperty(action.type)) {
@@ -36,6 +43,7 @@ export function makeReducer(initialState, handlers) {
   }
 }
 
+// pre-configure store for all redux apps
 if (process.env.NODE_ENV !== 'production') {
   const freeze = require('redux-freeze')
   middleware.push(freeze)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "claroline-distribution",
   "version": "1.0.0",
   "description": "Claroline distribution frontend dependencies",
+  "license": "GPL-3.0",
+  "repository": "https://github.com/claroline/Distribution",
   "dependencies": {
     "classnames": "^2.2.5",
     "checklist-model": "^0.10.0",
@@ -24,6 +26,7 @@
     "react-dnd-touch-backend": "^0.3.6",
     "react-dom": "^15.4.0",
     "react-redux": "^4.4.5",
+    "react-router-dom": "^4.1.1",
     "redux": "^3.5.2",
     "redux-thunk": "^2.1.0",
     "reselect": "^2.5.3",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no

Adds react-router-dom as dependency (https://www.npmjs.com/package/react-router-dom)

ping @ngodfraind @kitan1982 

Adds a new `Page` redux container (used in WS management) so this is now longer needed to manually bind modales in implementations. Simplifications can be seen here : https://github.com/claroline/Distribution/pull/2732/files#diff-1cdf53377728baa51a013530940ea96b.

**Sugar synthax to bootstrap a react app.**

Implementation is here : https://github.com/claroline/Distribution/blob/react-router/main/core/Resources/modules/utilities/app/bootstrap.js#L15.

It can be seen in action in the workspace management : https://github.com/claroline/Distribution/blob/react-router/main/core/Resources/modules/administration/workspace/index.js#L22.

**Sugar synthax to bootstrap a routed react app.**

Implementation is here : https://github.com/claroline/Distribution/blob/react-router/main/core/Resources/modules/utilities/app/router.js#L53.

For now, it's not used in the 10.x branch. An example, can be found in theme management (which should be merged soon) https://github.com/claroline/Distribution/blob/elorfin-themes/main/core/Resources/modules/administration/theme/index.js#L18.