### PR TITLE
[CoreBundle] Fix drag-n-drop of resources for ws admins

### DIFF
--- a/main/core/Controller/ResourceController.php
+++ b/main/core/Controller/ResourceController.php
@@ -786,7 +786,9 @@ class ResourceController extends Controller
             $this->checkAccess('OPEN', $collection);
 
             if ($user !== 'anon.') {
-                if ($user === $node->getCreator() || $this->authorization->isGranted('ROLE_ADMIN')) {
+                if ($user === $node->getCreator() || $this->authorization->isGranted('ROLE_ADMIN')
+                    || $this->authorization->isGranted('ADMINISTRATE', $node)
+                ) {
                     $canChangePosition = true;
                 }
             }
@@ -1108,7 +1110,9 @@ class ResourceController extends Controller
      */
     public function insertAt(ResourceNode $node, User $user, $index)
     {
-        if ($user !== $node->getParent()->getCreator() && !$this->authorization->isGranted('ROLE_ADMIN')) {
+        if ($user !== $node->getParent()->getCreator() && !$this->authorization->isGranted('ROLE_ADMIN')
+            && !$this->authorization->isGranted('ADMINISTRATE', $node->getParent())
+        ) {
             throw new AccessDeniedException();
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | 

Until now, only platform admins and creators could re-order the resources inside a Workspace (or a folder in a workspace). This fix allows anyone that has the right to administrate a container resource to drag-n-drop its children resources.
