### PR TITLE
[OAuth2] Added a 'display name' to be rendered in the login page button

### DIFF
--- a/main/core/Resources/less/users/login.less
+++ b/main/core/Resources/less/users/login.less
@@ -119,6 +119,13 @@
                 content: "\f1c0";
                 border-right-color: #18918B;
             }
+            &.generic-connect {
+                background-color: #91C020;
+            }
+            &.generic-connect::before {
+                content: "\f2be";
+                border-right-color: #628314;
+            }
         }
     }
 }

--- a/plugin/oauth/Controller/OauthController.php
+++ b/plugin/oauth/Controller/OauthController.php
@@ -84,6 +84,7 @@ class OauthController extends Controller
                 $data[$service.'_scope'] = $form['scope']->getData();
                 $data[$service.'_paths_login'] = $form['paths_login']->getData();
                 $data[$service.'_paths_email'] = $form['paths_email']->getData();
+                $data[$service.'_display_name'] = $form['display_name']->getData();
             }
 
             $errors = $this->oauthManager->validateService(

--- a/plugin/oauth/Form/ConfigurationType.php
+++ b/plugin/oauth/Form/ConfigurationType.php
@@ -87,6 +87,10 @@ class ConfigurationType extends AbstractType
             ->add('paths_email', 'text', [
                 'required' => false,
                 'label' => 'paths_email',
+            ])
+            ->add('display_name', 'text', [
+                'required' => false,
+                'label' => 'display_name',
             ]);
         }
 

--- a/plugin/oauth/Listener/ExternalAuthenticationListener.php
+++ b/plugin/oauth/Listener/ExternalAuthenticationListener.php
@@ -46,10 +46,17 @@ class ExternalAuthenticationListener
     public function onRenderButton(RenderAuthenticationButtonEvent $event)
     {
         $services = $this->oauthManager->getActiveServices();
+        $buttons = [];
+
+        foreach ($services as $service) {
+            $config = $this->oauthManager->getConfiguration($service);
+            $buttons[] = ['service' => $service, 'display_name' => $config->getDisplayName()];
+        }
+
         if (count($services) > 0) {
             $content = $this->templating->render(
                 'IcapOAuthBundle::buttons.html.twig',
-                ['services' => $services]
+                ['buttons' => $buttons]
             );
 
             $event->addContent($content);

--- a/plugin/oauth/Manager/OauthManager.php
+++ b/plugin/oauth/Manager/OauthManager.php
@@ -186,6 +186,7 @@ class OauthManager
             $config->setScope($this->platformConfigHandler->getParameter($service.'_scope'));
             $config->setPathsLogin($this->platformConfigHandler->getParameter($service.'_paths_login'));
             $config->setPathsEmail($this->platformConfigHandler->getParameter($service.'_paths_email'));
+            $config->setDisplayName($this->platformConfigHandler->getParameter($service.'_display_name'));
         }
 
         return $config;

--- a/plugin/oauth/Model/Configuration.php
+++ b/plugin/oauth/Model/Configuration.php
@@ -25,6 +25,7 @@ class Configuration
     private $infosUrl = null;
     private $pathsLogin = null;
     private $pathsEmail = null;
+    private $displayName = null;
 
     public function __construct($id, $secret, $active, $forceReauthenticate = false, $domain = null, $version = null)
     {
@@ -257,6 +258,26 @@ class Configuration
     public function setPathsEmail($pathsEmail)
     {
         $this->pathsEmail = $pathsEmail;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDisplayName()
+    {
+        return $this->displayName;
+    }
+
+    /**
+     * @param string $displayName
+     *
+     * @return $this
+     */
+    public function setDisplayName($displayName)
+    {
+        $this->displayName = $displayName;
 
         return $this;
     }

--- a/plugin/oauth/Resources/translations/icap_oauth.en.json
+++ b/plugin/oauth/Resources/translations/icap_oauth.en.json
@@ -9,6 +9,7 @@
     "scope": "Scope",
     "paths_login": "New user (login field)",
     "paths_email": "New user (email field)",
+    "display_name": "Login button label",
     "client_tenant_domain": "Domain",
     "create_new_oauth_account": "Create new account",
     "error_connecting_with_oauth": "An error occured during the authentication process with the selected service. Here's the error message : %msg%",

--- a/plugin/oauth/Resources/translations/icap_oauth.fr.json
+++ b/plugin/oauth/Resources/translations/icap_oauth.fr.json
@@ -9,6 +9,7 @@
     "scope": "Scope",
     "paths_login": "Nouvel utilisateur (champ identifiant)",
     "paths_email": "Nouvel utilisateur (champ email)",
+    "display_name": "Label du bouton de login",
     "client_tenant_domain": "Domaine",
     "create_new_oauth_account": "Créer un nouveau compte",
     "error_connecting_with_oauth": "Une erreur s'est produite pendant l'authentification avec le service choisi. Voici le message de l'erreur: %msg%",

--- a/plugin/oauth/Resources/views/buttons.html.twig
+++ b/plugin/oauth/Resources/views/buttons.html.twig
@@ -1,7 +1,11 @@
-{% if services|length > 0 %}
-{% for service in services %}
-    <a href="{{ url("hwi_oauth_service_redirect", {service: service}) }}" type="button" id="{{ service }}-connect-btn" class='btn {{ service }}-connect btn-third-party-login btn-block'>
-        {{ 'login_with_third_party'|trans({'%name%':service|trans({}, 'icap_oauth')}, 'platform') }}
+{% if buttons|length > 0 %}
+{% for button in buttons %}
+    <a href="{{ url("hwi_oauth_service_redirect", {service: button['service']}) }}" type="button" id="{{ button['service'] }}-connect-btn" class='btn {{ button['service'] }}-connect btn-third-party-login btn-block'>
+        {% if button['display_name'] is not empty %}
+            {{ button['display_name'] }}
+        {% else %}
+            {{ 'login_with_third_party'|trans({'%name%':service|trans({}, 'icap_oauth')}, 'platform') }}
+        {% endif %}
     </a>
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed tickets |

Added a simple CSS rule to handle the new oauth generic resource owner style in the login page.
The text displayed in the button is defined in a new parameter or is displayed as previously defined in the translated fields.


