### PR TITLE
[CoreBundle] Store resource node view count

### DIFF
--- a/main/core/API/Serializer/Resource/ResourceNodeSerializer.php
+++ b/main/core/API/Serializer/Resource/ResourceNodeSerializer.php
@@ -111,6 +111,7 @@ class ResourceNodeSerializer
             ],
             'shortcuts' => $this->getShortcuts($resourceNode),
             'breadcrumb' => $this->breadcrumbManager->getBreadcrumb($resourceNode),
+            'views_count' => $resourceNode->getViewsCount(),
         ];
 
         if (!empty($resourceNode->getWorkspace())) {

--- a/main/core/Entity/Resource/ResourceNode.php
+++ b/main/core/Entity/Resource/ResourceNode.php
@@ -306,6 +306,13 @@ class ResourceNode
      */
     protected $accesses = [];
 
+    /**
+     * @var int
+     *
+     * @ORM\Column(nullable=true, type="integer", name="views_count")
+     */
+    protected $viewsCount;
+
     public function __construct()
     {
         $this->guid = Uuid::uuid4()->toString();
@@ -984,5 +991,31 @@ class ResourceNode
         ) {
             return $this->getAccesses()['code'];
         }
+    }
+
+    /**
+     * Gets how many times a resource has been viewed.
+     *
+     * @return int
+     */
+    public function getViewsCount()
+    {
+        return $this->viewsCount;
+    }
+
+    /**
+     * Adds one unit to the resource view count.
+     *
+     * @return ResourceNode
+     */
+    public function addView()
+    {
+        if ($this->getViewsCount() === null) {
+            $this->viewsCount = 1;
+        } else {
+            ++$this->viewsCount;
+        }
+
+        return $this;
     }
 }

--- a/main/core/Manager/Resource/ResourceNodeManager.php
+++ b/main/core/Manager/Resource/ResourceNodeManager.php
@@ -299,4 +299,13 @@ class ResourceNodeManager
 
         return true;
     }
+
+    public function addView(ResourceNode $node)
+    {
+        $node->addView();
+        $this->om->persist($node);
+        $this->om->flush();
+
+        return $node;
+    }
 }

--- a/main/core/Migrations/pdo_mysql/Version20171030163115.php
+++ b/main/core/Migrations/pdo_mysql/Version20171030163115.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Claroline\CoreBundle\Migrations\pdo_mysql;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution.
+ *
+ * Generation date: 2017/10/30 04:31:16
+ */
+class Version20171030163115 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql('
+            ALTER TABLE claro_resource_node 
+            ADD views_count INT DEFAULT NULL
+        ');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql('
+            ALTER TABLE claro_resource_node 
+            DROP views_count
+        ');
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | 

This PR : 
- stores the number of times a resource is viewed instead of counting rows from the log table.
- adds this information to the serialized resource node when requested through the API


