### PR TITLE
Enable API search by multiple resource types

### DIFF
--- a/main/core/API/Finder/ResourceNodeFinder.php
+++ b/main/core/API/Finder/ResourceNodeFinder.php
@@ -60,7 +60,11 @@ class ResourceNodeFinder implements FinderInterface
         foreach ($searches as $filterName => $filterValue) {
             switch ($filterName) {
                 case 'resourceType':
-                    $qb->andWhere("ort.name LIKE :{$filterName}");
+                    if (is_array($filterValue)) {
+                        $qb->andWhere("ort.name IN (:{$filterName})");
+                    } else {
+                        $qb->andWhere("ort.name LIKE :{$filterName}");
+                    }
                     $qb->setParameter($filterName, $filterValue);
                     break;
                 default:


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed tickets | 

This PR provides support for multiple values in resource type filter for API search.


