### PR TITLE
[CoreBundle] New fields for resource node edit form

### DIFF
--- a/main/core/API/Serializer/Resource/ResourceNodeSerializer.php
+++ b/main/core/API/Serializer/Resource/ResourceNodeSerializer.php
@@ -102,7 +102,7 @@ class ResourceNodeSerializer
         $serializedNode = [
             'id' => $resourceNode->getGuid(),
             'name' => $resourceNode->getName(),
-            'poster' => null, // todo : add as ResourceNode prop
+            'poster' => $resourceNode->getThumbnail() ? $resourceNode->getThumbnail()->getRelativeUrl() : null, // todo : add as ResourceNode prop
             'thumbnail' => null,
             'meta' => $this->getMeta($resourceNode),
             'parameters' => $this->getParameters($resourceNode),

--- a/main/core/Controller/ResourcePropertiesController.php
+++ b/main/core/Controller/ResourcePropertiesController.php
@@ -195,11 +195,15 @@ class ResourcePropertiesController extends Controller
         if ($form->isValid()) {
             $name = $form->get('name')->getData();
             $file = $form->get('newIcon')->getData();
+            $thumbnail = $form->get('newThumbnail')->getData();
             $isRecursive = $this->request->get('isRecursive');
             $publish = $form->get('published')->getData();
 
             if ($file) {
                 $this->resourceManager->changeIcon($node, $file);
+            }
+            if ($thumbnail) {
+                $this->resourceManager->changeThumbnail($node, $thumbnail);
             }
 
             $this->resourceManager->rename($node, $name);
@@ -336,8 +340,8 @@ class ResourcePropertiesController extends Controller
     {
         if (!$this->hasAccess($permission, $collection)) {
             throw new ResourceAccessException(
-              $collection->getErrorsForDisplay(),
-              $collection->getResources()
+                $collection->getErrorsForDisplay(),
+                $collection->getResources()
             );
         }
     }

--- a/main/core/Entity/Resource/ResourceNode.php
+++ b/main/core/Entity/Resource/ResourceNode.php
@@ -111,6 +111,17 @@ class ResourceNode
     protected $icon;
 
     /**
+     * @var ResourceThumbnail
+     *
+     * @ORM\OneToOne(
+     *     targetEntity="Claroline\CoreBundle\Entity\Resource\ResourceThumbnail",
+     *     cascade={"persist"}
+     * )
+     * @ORM\JoinColumn(onDelete="SET NULL")
+     */
+    protected $thumbnail;
+
+    /**
      * @var string
      *
      * @Gedmo\TreePathSource
@@ -512,6 +523,26 @@ class ResourceNode
     public function setIcon(ResourceIcon $icon)
     {
         $this->icon = $icon;
+    }
+
+    /**
+     * Returns the resource thumbnail.
+     *
+     * @return ResourceThumbnail
+     */
+    public function getThumbnail()
+    {
+        return $this->thumbnail;
+    }
+
+    /**
+     * Sets the resource thumbnail.
+     *
+     * @param ResourceThumbnail $thumbnail
+     */
+    public function setThumbnail(ResourceThumbnail $thumbnail)
+    {
+        $this->thumbnail = $thumbnail;
     }
 
     /**
@@ -986,8 +1017,8 @@ class ResourceNode
     public function getAccessCode()
     {
         if (
-          !empty($this->getAccesses()['code']) &&
-          trim($this->getAccesses()['code'], ' ') !== ''
+            !empty($this->getAccesses()['code']) &&
+            trim($this->getAccesses()['code'], ' ') !== ''
         ) {
             return $this->getAccesses()['code'];
         }

--- a/main/core/Entity/Resource/ResourceThumbnail.php
+++ b/main/core/Entity/Resource/ResourceThumbnail.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\CoreBundle\Entity\Resource;
+
+use Claroline\CoreBundle\Entity\Model\UuidTrait;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass="Claroline\CoreBundle\Repository\ResourceThumbnailRepository")
+ * @ORM\Table(name="claro_resource_thumbnail")
+ */
+class ResourceThumbnail
+{
+    use UuidTrait;
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column()
+     */
+    protected $mimeType;
+
+    /**
+     * @ORM\Column(name="is_shortcut", type="boolean")
+     */
+    protected $isShortcut = false;
+
+    /**
+     * @ORM\Column(name="relative_url", nullable=true)
+     *
+     * The url from the /web folder.
+     * This is a "legacy parameter". Now we use the PublicFileUse entity.
+     */
+    protected $relativeUrl;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Claroline\CoreBundle\Entity\Resource\ResourceIcon", cascade={"all"})
+     * @ORM\JoinColumn(name="shortcut_id", onDelete="SET NULL")
+     */
+    protected $shortcutIcon;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->abstractResources = new ArrayCollection();
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getMimeType()
+    {
+        return $this->mimeType;
+    }
+
+    public function setMimeType($mimeType)
+    {
+        $this->mimeType = $mimeType;
+    }
+
+    public function isShortcut()
+    {
+        return $this->isShortcut;
+    }
+
+    public function setShortcut($boolean)
+    {
+        $this->isShortcut = $boolean;
+    }
+
+    public function getShortcutIcon()
+    {
+        return $this->shortcutIcon;
+    }
+
+    public function setShortcutIcon(ResourceIcon $shortcutIcon)
+    {
+        $this->shortcutIcon = $shortcutIcon;
+    }
+
+    public function setRelativeUrl($url)
+    {
+        $this->relativeUrl = $url;
+    }
+
+    public function getRelativeUrl()
+    {
+        return $this->relativeUrl;
+    }
+}

--- a/main/core/Form/ResourcePropertiesType.php
+++ b/main/core/Form/ResourcePropertiesType.php
@@ -29,59 +29,72 @@ class ResourcePropertiesType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $dateFormat = $this->translator->trans('date_form_format', array(), 'platform');
-        $attrParams = array(
+        $dateFormat = $this->translator->trans('date_form_format', [], 'platform');
+        $attrParams = [
                 'class' => 'datepicker input-small',
-                'data-date-format' => $this->translator->trans('date_form_datepicker_format', array(), 'platform'),
+                'data-date-format' => $this->translator->trans('date_form_datepicker_format', [], 'platform'),
                 'autocomplete' => 'off',
-            );
+            ];
 
-        $dateParams = array(
+        $dateParams = [
             'format' => $dateFormat,
             'widget' => 'single_text',
             'input' => 'datetime',
             'attr' => $attrParams,
-        );
+        ];
 
-        $builder->add('name', 'text', array('label' => 'name'));
+        $builder->add('name', 'text', ['label' => 'name']);
         $builder->add(
             'newIcon',
             'file',
-            array(
+            [
                 'required' => false,
                 'mapped' => false,
                 'label' => 'icon',
-            )
+            ]
         );
         $builder->add(
             'creationDate',
             'date',
-            array(
+            [
                 'disabled' => true,
                 'widget' => 'single_text',
                 'format' => $dateFormat,
                 'label' => 'creation_date',
-            )
+            ]
         );
         $builder->add(
             'modificationDate',
             'date',
-            array(
+            [
                 'disabled' => true,
                 'widget' => 'single_text',
                 'format' => $dateFormat,
                 'label' => 'last_modification',
-            )
+            ]
         );
         $builder->add(
             'published',
             'checkbox',
-            array('required' => true, 'label' => 'published')
+            ['required' => true, 'label' => 'published']
         );
         $builder->add(
             'publishedToPortal',
             'checkbox',
-            array('required' => false, 'label' => 'published_to_portal')
+            ['required' => false, 'label' => 'published_to_portal']
+        );
+        $builder->add('description', 'textarea', [
+            'label' => 'description',
+            'attr' => [
+                'class' => 'form-control',
+            ],
+        ]);
+        $builder->add('newThumbnail', 'file',
+            [
+                'required' => false,
+                'mapped' => false,
+                'label' => $this->translator->trans('thumbnail', [], 'platform'),
+            ]
         );
         $accessibleFromParams = $dateParams;
         $accessibleFromParams['label'] = 'accessible_from';
@@ -92,7 +105,7 @@ class ResourcePropertiesType extends AbstractType
         $builder->add(
             'resourceType',
             'entity',
-            array(
+            [
                 'class' => 'Claroline\CoreBundle\Entity\Resource\ResourceType',
                 'choice_translation_domain' => true,
                 'translation_domain' => 'resource',
@@ -101,33 +114,33 @@ class ResourcePropertiesType extends AbstractType
                 'property' => 'name',
                 'disabled' => true,
                 'label' => 'resource_type',
-            )
+            ]
         );
         $builder->add(
             'creator',
             'text',
-            array(
+            [
                 'data' => $this->creator,
                 'mapped' => false,
                 'disabled' => true,
                 'label' => 'creator',
-            )
+            ]
         );
         $builder->add(
             'license',
             'text',
-            array(
+            [
                 'label' => 'license',
                 'required' => false,
-            )
+            ]
         );
         $builder->add(
             'author',
             'text',
-            array(
+            [
                 'label' => 'author',
                 'required' => false,
-            )
+            ]
         );
     }
 
@@ -138,6 +151,6 @@ class ResourcePropertiesType extends AbstractType
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $resolver->setDefaults(array('translation_domain' => 'platform'));
+        $resolver->setDefaults(['translation_domain' => 'platform']);
     }
 }

--- a/main/core/Manager/ResourceManager.php
+++ b/main/core/Manager/ResourceManager.php
@@ -197,7 +197,7 @@ class ResourceManager
         $this->checkResourcePrepared($resource);
 
         /** @var ResourceNode $node */
-        $node = $this->om->factory('Claroline\CoreBundle\Entity\Resource\ResourceNode');
+        $node = new ResourceNode();
         $node->setResourceType($resourceType);
         $node->setPublished($isPublished);
         $node->setGuid($this->container->get('claroline.utilities.misc')->generateGuid());
@@ -810,7 +810,7 @@ class ResourceManager
         $env = $this->container->get('kernel')->getEnvironment();
 
         if ($resource instanceof ResourceShortcut) {
-            $copy = $this->om->factory('Claroline\CoreBundle\Entity\Resource\ResourceShortcut');
+            $copy = new ResourceShortcut();
             $copy->setTarget($resource->getTarget());
             $newNode = $this->copyNode($node, $parent, $user, $withRights, $rights, $index);
             $copy->setResourceNode($newNode);
@@ -1346,7 +1346,7 @@ class ResourceManager
      */
     public function createResource($class, $name)
     {
-        $entity = $this->om->factory($class);
+        $entity = new $class();
 
         if ($entity instanceof AbstractResource) {
             $entity->setName($name);
@@ -1590,7 +1590,7 @@ class ResourceManager
         $index = null
     ) {
         /** @var ResourceNode $newNode */
-        $newNode = $this->om->factory('Claroline\CoreBundle\Entity\Resource\ResourceNode');
+        $newNode = new ResourceNode();
         $newNode->setResourceType($node->getResourceType());
         $newNode->setCreator($user);
         $newNode->setWorkspace($newParent->getWorkspace());

--- a/main/core/Manager/ResourceManager.php
+++ b/main/core/Manager/ResourceManager.php
@@ -78,6 +78,8 @@ class ResourceManager
     private $maskManager;
     /** @var IconManager */
     private $iconManager;
+    /** @var ThumbnailManager */
+    private $thumbnailManager;
     /** @var StrictDispatcher */
     private $dispatcher;
     /** @var ObjectManager */
@@ -100,6 +102,7 @@ class ResourceManager
      * @DI\InjectParams({
      *     "roleManager"           = @DI\Inject("claroline.manager.role_manager"),
      *     "iconManager"           = @DI\Inject("claroline.manager.icon_manager"),
+     *     "thumbnailManager"      = @DI\Inject("claroline.manager.thumbnail_manager"),
      *     "maskManager"           = @DI\Inject("claroline.manager.mask_manager"),
      *     "container"             = @DI\Inject("service_container"),
      *     "rightsManager"         = @DI\Inject("claroline.manager.rights_manager"),
@@ -113,6 +116,7 @@ class ResourceManager
      *
      * @param RoleManager                  $roleManager
      * @param IconManager                  $iconManager
+     * @param ThumbnailManager             $thumbnailManager
      * @param ContainerInterface           $container
      * @param RightsManager                $rightsManager
      * @param StrictDispatcher             $dispatcher
@@ -126,6 +130,7 @@ class ResourceManager
     public function __construct(
         RoleManager $roleManager,
         IconManager $iconManager,
+        ThumbnailManager $thumbnailManager,
         ContainerInterface $container,
         RightsManager $rightsManager,
         StrictDispatcher $dispatcher,
@@ -144,6 +149,7 @@ class ResourceManager
         $this->directoryRepo = $om->getRepository('ClarolineCoreBundle:Resource\Directory');
         $this->roleManager = $roleManager;
         $this->iconManager = $iconManager;
+        $this->thumbnailManager = $thumbnailManager;
         $this->rightsManager = $rightsManager;
         $this->maskManager = $maskManager;
         $this->dispatcher = $dispatcher;
@@ -191,7 +197,7 @@ class ResourceManager
         $this->checkResourcePrepared($resource);
 
         /** @var ResourceNode $node */
-        $node = new ResourceNode();
+        $node = $this->om->factory('Claroline\CoreBundle\Entity\Resource\ResourceNode');
         $node->setResourceType($resourceType);
         $node->setPublished($isPublished);
         $node->setGuid($this->container->get('claroline.utilities.misc')->generateGuid());
@@ -804,7 +810,7 @@ class ResourceManager
         $env = $this->container->get('kernel')->getEnvironment();
 
         if ($resource instanceof ResourceShortcut) {
-            $copy = new ResourceShortcut();
+            $copy = $this->om->factory('Claroline\CoreBundle\Entity\Resource\ResourceShortcut');
             $copy->setTarget($resource->getTarget());
             $newNode = $this->copyNode($node, $parent, $user, $withRights, $rights, $index);
             $copy->setResourceNode($newNode);
@@ -936,7 +942,16 @@ class ResourceManager
 
         //the following line is required because we wanted to disable the right edition in personal worksspaces...
         //this is not required for everything to work properly.
-        $resourceArray['enableRightsEdition'] = true;
+
+        if (!$node->getWorkspace()) {
+            $resourceArray['enableRightsEdition'] = false;
+        } else {
+            if ($node->getWorkspace()->isPersonal() && !$this->rightsManager->canEditPwsPerm($token)) {
+                $resourceArray['enableRightsEdition'] = false;
+            } else {
+                $resourceArray['enableRightsEdition'] = true;
+            }
+        }
 
         if ($node->getResourceType()->getName() === 'file') {
             if ($node->getClass() === 'Claroline\CoreBundle\Entity\Resource\ResourceShortcut') {
@@ -1102,7 +1117,7 @@ class ResourceManager
 
         $archive = new \ZipArchive();
         $pathArch = $this->container->get('claroline.config.platform_config_handler')
-            ->getParameter('tmp_dir').DIRECTORY_SEPARATOR.$this->ut->generateGuid().'.zip';
+                ->getParameter('tmp_dir').DIRECTORY_SEPARATOR.$this->ut->generateGuid().'.zip';
         $archive->open($pathArch, \ZipArchive::CREATE);
         $nodes = $this->expandResources($elements);
 
@@ -1283,6 +1298,25 @@ class ResourceManager
     }
 
     /**
+     * Changes a node thumbnail.
+     *
+     * @param \Claroline\CoreBundle\Entity\Resource\ResourceNode $node
+     * @param \Symfony\Component\HttpFoundation\File\File        $file
+     *
+     * @return \Claroline\CoreBundle\Entity\Resource\ResourceThumbnail
+     */
+    public function changeThumbnail(ResourceNode $node, File $file)
+    {
+        $this->om->startFlushSuite();
+        $thumbnail = $this->thumbnailManager->createCustomThumbnail($file, $node->getWorkspace());
+        $this->thumbnailManager->replace($node, $thumbnail);
+        $this->logChangeSet($node);
+        $this->om->endFlushSuite();
+
+        return $thumbnail;
+    }
+
+    /**
      * Logs every change on a node.
      *
      * @param \Claroline\CoreBundle\Entity\Resource\ResourceNode $node
@@ -1312,7 +1346,7 @@ class ResourceManager
      */
     public function createResource($class, $name)
     {
-        $entity = new $class();
+        $entity = $this->om->factory($class);
 
         if ($entity instanceof AbstractResource) {
             $entity->setName($name);
@@ -1556,7 +1590,7 @@ class ResourceManager
         $index = null
     ) {
         /** @var ResourceNode $newNode */
-        $newNode = new ResourceNode();
+        $newNode = $this->om->factory('Claroline\CoreBundle\Entity\Resource\ResourceNode');
         $newNode->setResourceType($node->getResourceType());
         $newNode->setCreator($user);
         $newNode->setWorkspace($newParent->getWorkspace());

--- a/main/core/Manager/ThumbnailManager.php
+++ b/main/core/Manager/ThumbnailManager.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\CoreBundle\Manager;
+
+use Claroline\BundleRecorder\Log\LoggableTrait;
+use Claroline\CoreBundle\Entity\Resource\ResourceNode;
+use Claroline\CoreBundle\Entity\Resource\ResourceThumbnail;
+use Claroline\CoreBundle\Entity\Workspace\Workspace;
+use Claroline\CoreBundle\Library\Utilities\ClaroUtilities;
+use Claroline\CoreBundle\Library\Utilities\FileUtilities;
+use Claroline\CoreBundle\Library\Utilities\ThumbnailCreator;
+use Claroline\CoreBundle\Persistence\ObjectManager;
+use Claroline\CoreBundle\Repository\ResourceIconRepository;
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Component\HttpFoundation\File\File;
+
+/**
+ * @DI\Service("claroline.manager.thumbnail_manager")
+ */
+class ThumbnailManager
+{
+    use LoggableTrait;
+
+    /** @var ThumbnailCreator */
+    private $creator;
+    /** @var ResourceIconRepository */
+    private $repo;
+    /** @var string */
+    private $fileDir;
+    /** @var string */
+    private $thumbDir;
+    /** @var string */
+    private $rootDir;
+    /** @var ClaroUtilities */
+    private $ut;
+    /** @var ObjectManager */
+    private $om;
+    /** @var string */
+    private $basepath;
+    /** @var string */
+    private $iconSetRepo;
+    /** @var FileUtilities */
+    private $fu;
+
+    /**
+     * @DI\InjectParams({
+     *     "creator"  = @DI\Inject("claroline.utilities.thumbnail_creator"),
+     *     "fileDir"  = @DI\Inject("%claroline.param.files_directory%"),
+     *     "thumbDir" = @DI\Inject("%claroline.param.thumbnails_directory%"),
+     *     "rootDir"  = @DI\Inject("%kernel.root_dir%"),
+     *     "ut"       = @DI\Inject("claroline.utilities.misc"),
+     *     "om"       = @DI\Inject("claroline.persistence.object_manager"),
+     *     "basepath" = @DI\Inject("%claroline.param.relative_thumbnail_base_path%"),
+     *     "fu"       = @DI\Inject("claroline.utilities.file"),
+     *     "pdir"     = @DI\Inject("%claroline.param.public_files_directory%"),
+     *     "webdir"   = @DI\Inject("%claroline.param.web_directory%"),
+     * })
+     */
+    public function __construct(
+        ThumbnailCreator $creator,
+        $fileDir,
+        $thumbDir,
+        $rootDir,
+        ClaroUtilities $ut,
+        ObjectManager $om,
+        $basepath,
+        FileUtilities $fu,
+        $pdir,
+        $webdir
+    ) {
+        $this->creator = $creator;
+        $this->repo = $om->getRepository('ClarolineCoreBundle:Resource\ResourceIcon');
+        $this->iconSetRepo = $om->getRepository('ClarolineCoreBundle:Icon\IconSet');
+        $this->fileDir = $fileDir;
+        $this->thumbDir = $thumbDir;
+        $this->rootDir = $rootDir;
+        $this->ut = $ut;
+        $this->om = $om;
+        $this->basepath = $basepath;
+        $this->fu = $fu;
+        $this->pdir = $pdir;
+        $this->webdir = $webdir;
+    }
+
+    /**
+     * Creates a custom ResourceThumbnail entity from a File (wich should contain an image).
+     * (for instance if the thumbnail of a resource is changed).
+     *
+     * @param File      $file
+     * @param Workspace $workspace (for the storage directory...)
+     *
+     * @return \Claroline\CoreBundle\Entity\Resource\ResourceThumbnail
+     */
+    public function createCustomThumbnail(File $file, Workspace $workspace = null)
+    {
+        $this->om->startFlushSuite();
+        $mimeElements = explode('/', $file->getMimeType());
+        $ds = DIRECTORY_SEPARATOR;
+
+        $publicFile = $this->createFromFile(
+            $file->getPathname(),
+            $mimeElements[0],
+            $workspace
+        );
+        if ($publicFile) {
+            $thumbnailPath = $this->webdir.$ds.$publicFile->getUrl();
+            $relativeUrl = ltrim(str_replace($this->webdir, '', $thumbnailPath), "{$ds}");
+            //entity creation
+            $thumbnail = $this->om->factory('Claroline\CoreBundle\Entity\Resource\ResourceThumbnail');
+            $thumbnail->setRelativeUrl($relativeUrl);
+            $thumbnail->setMimeType('custom');
+            $thumbnail->setShortcut(false);
+            $thumbnail->setUuid(uniqid('', true));
+            $this->om->persist($thumbnail);
+            $this->om->endFlushSuite();
+
+            return $thumbnail;
+        }
+    }
+
+    /**
+     * Creates an image from a file.
+     *
+     * @param string    $filePath
+     * @param string    $baseMime  (image|video)
+     * @param Workspace $workspace
+     *
+     * @return null|string
+     */
+    public function createFromFile($filePath, $baseMime, Workspace $workspace = null)
+    {
+        $ds = DIRECTORY_SEPARATOR;
+
+        $newPath = $this->pdir.$ds.$this->fu->getActiveDirectoryName().$ds.$this->ut->generateGuid().'.png';
+
+        $thumbnailPath = null;
+
+        if ($baseMime === 'video') {
+            try {
+                $thumbnailPath = $this->creator->fromVideo($filePath, $newPath, 400, 250);
+            } catch (\Exception $e) {
+                //ffmpege extension might be missing
+                $thumbnailPath = null;
+            }
+        }
+
+        if ($baseMime === 'image') {
+            try {
+                $thumbnailPath = $this->creator->fromImage($filePath, $newPath, 400, 250);
+            } catch (\Exception $e) {
+                $thumbnailPath = null;
+                //error handling ? $thumbnailPath = null
+            }
+        }
+
+        if ($thumbnailPath) {
+            return $this->fu->createFile(new File($thumbnailPath));
+        }
+    }
+
+    /**
+     * Replace a node thumbnail.
+     *
+     * @param \Claroline\CoreBundle\Entity\Resource\ResourceNode      $resource
+     * @param \Claroline\CoreBundle\Entity\Resource\ResourceThumbnail $thumbnail
+     *
+     * @return \Claroline\CoreBundle\Entity\Resource\ResourceNode
+     */
+    public function replace(ResourceNode $resource, ResourceThumbnail $thumbnail)
+    {
+        $this->om->startFlushSuite();
+
+        $resource->setThumbnail($thumbnail);
+        $this->om->persist($resource);
+        $this->om->endFlushSuite();
+
+        return $resource;
+    }
+}

--- a/main/core/Manager/ThumbnailManager.php
+++ b/main/core/Manager/ThumbnailManager.php
@@ -115,7 +115,7 @@ class ThumbnailManager
             $thumbnailPath = $this->webdir.$ds.$publicFile->getUrl();
             $relativeUrl = ltrim(str_replace($this->webdir, '', $thumbnailPath), "{$ds}");
             //entity creation
-            $thumbnail = $this->om->factory('Claroline\CoreBundle\Entity\Resource\ResourceThumbnail');
+            $thumbnail = new ResourceThumbnail();
             $thumbnail->setRelativeUrl($relativeUrl);
             $thumbnail->setMimeType('custom');
             $thumbnail->setShortcut(false);

--- a/main/core/Migrations/pdo_mysql/Version20171119140324.php
+++ b/main/core/Migrations/pdo_mysql/Version20171119140324.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Claroline\CoreBundle\Migrations\pdo_mysql;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution.
+ *
+ * Generation date: 2017/11/19 02:03:25
+ */
+class Version20171119140324 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql('
+            CREATE TABLE claro_resource_thumbnail (
+                id INT AUTO_INCREMENT NOT NULL, 
+                shortcut_id INT DEFAULT NULL, 
+                mimeType VARCHAR(255) NOT NULL, 
+                is_shortcut TINYINT(1) NOT NULL, 
+                relative_url VARCHAR(255) DEFAULT NULL, 
+                uuid VARCHAR(36) NOT NULL, 
+                UNIQUE INDEX UNIQ_FF244542D17F50A6 (uuid), 
+                INDEX IDX_FF24454279F0D498 (shortcut_id), 
+                PRIMARY KEY(id)
+            ) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB
+        ');
+        $this->addSql('
+            ALTER TABLE claro_resource_thumbnail 
+            ADD CONSTRAINT FK_FF24454279F0D498 FOREIGN KEY (shortcut_id) 
+            REFERENCES claro_resource_icon (id) 
+            ON DELETE SET NULL
+        ');
+        $this->addSql('
+            ALTER TABLE claro_resource_node 
+            ADD thumbnail_id INT DEFAULT NULL
+        ');
+        $this->addSql('
+            ALTER TABLE claro_resource_node 
+            ADD CONSTRAINT FK_A76799FFFDFF2E92 FOREIGN KEY (thumbnail_id) 
+            REFERENCES claro_resource_thumbnail (id) 
+            ON DELETE SET NULL
+        ');
+        $this->addSql('
+            CREATE UNIQUE INDEX UNIQ_A76799FFFDFF2E92 ON claro_resource_node (thumbnail_id)
+        ');
+        $this->addSql('
+            ALTER TABLE claro_scheduled_task 
+            DROP executed
+        ');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql('
+            ALTER TABLE claro_resource_node 
+            DROP FOREIGN KEY FK_A76799FFFDFF2E92
+        ');
+        $this->addSql('
+            DROP TABLE claro_resource_thumbnail
+        ');
+        $this->addSql('
+            DROP INDEX UNIQ_A76799FFFDFF2E92 ON claro_resource_node
+        ');
+        $this->addSql('
+            ALTER TABLE claro_resource_node 
+            DROP thumbnail_id
+        ');
+        $this->addSql('
+            ALTER TABLE claro_scheduled_task 
+            ADD executed TINYINT(1) NOT NULL
+        ');
+    }
+}

--- a/main/core/Resources/translations/platform.de.json
+++ b/main/core/Resources/translations/platform.de.json
@@ -993,6 +993,7 @@
     "third_party_authentication": "",
     "this_page_requires_authentication": "",
     "this_resource_is_not_published": "",
+    "thumbnail": "",
     "time_col": "",
     "tinymce_all_buttons": "",
     "tips": "",

--- a/main/core/Resources/translations/platform.en.json
+++ b/main/core/Resources/translations/platform.en.json
@@ -1198,6 +1198,7 @@
     "third_party_authentication": "Third party authentication (CAS, LDAP, Office 365, Facebook etc.)",
     "this_page_requires_authentication": "This page requires authentication. Please login.",
     "this_resource_is_not_published": "This resource is not published",
+    "thumbnail": "Thumbnail",
     "time_ago": "%count% %unit% ago",
     "time_col": "Database time column",
     "tinymce_all_buttons": "All tools",

--- a/main/core/Resources/translations/platform.es.json
+++ b/main/core/Resources/translations/platform.es.json
@@ -1001,6 +1001,7 @@
     "third_party_authentication": "",
     "this_page_requires_authentication": "Esta página requiere autenticación. Por favor, iniciar sesión.",
     "this_resource_is_not_published": "Este recurso no esta publicado",
+    "thumbnail": "",
     "time_col": "Columna de tiempo en la base de datos",
     "tinymce_all_buttons": "Todas las herramientas",
     "tips": "",

--- a/main/core/Resources/translations/platform.fr.json
+++ b/main/core/Resources/translations/platform.fr.json
@@ -1215,6 +1215,7 @@
     "third_party_authentication": "Authentification tiers (CAS, LDAP, Office 365, Facebook etc.)",
     "this_page_requires_authentication": "Cette page requiert une authentification. Veuillez vous identifier.",
     "this_resource_is_not_published": "Cette ressource n'est pas publiée",
+    "thumbnail": "Miniature",
     "time_ago": "Il y a %count% %unit%",
     "time_col": "Colonne des durées",
     "tinymce_all_buttons": "Tous les outils",

--- a/main/core/Resources/translations/platform.it.json
+++ b/main/core/Resources/translations/platform.it.json
@@ -18,6 +18,7 @@
     "external_group_list": "",
     "in_workspaces": "",
     "on_desktops": "",
+    "thumbnail": "",
     "widget_type": "",
     "widgets_usage_list": "",
     "widgets_usage_ratio": ""

--- a/main/core/Resources/translations/platform.nl.json
+++ b/main/core/Resources/translations/platform.nl.json
@@ -1153,6 +1153,7 @@
     "third_party_authentication": "",
     "this_page_requires_authentication": "Deze pagina vereist een authenticatie. U moet zich identificeren.",
     "this_resource_is_not_published": "Deze bron is niet gepubliceerd",
+    "thumbnail": "",
     "time_ago": "%count% %unit% geleden",
     "time_col": "Kolom van de duren",
     "tinymce_all_buttons": "Alle tools",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed tickets | 

Resource node edit form enables the user to add a description and a thumbnail poster to a node. This data is intended to be displayed in the resource portal.


