### PR TITLE
[UrlBundle] Get automatic poster image for a Youtube url

### DIFF
--- a/main/core/API/Serializer/Resource/ResourceNodeSerializer.php
+++ b/main/core/API/Serializer/Resource/ResourceNodeSerializer.php
@@ -139,13 +139,20 @@ class ResourceNodeSerializer
      */
     private function decorate(ResourceNode $resourceNode, array $serializedNode)
     {
+        $unauthorizedKeys = array_keys($serializedNode);
+
+        // 'poster' is a key that can be overridden by another plugin. For example: UrlBundle
+        if (($key = array_search('poster', $unauthorizedKeys)) !== false) {
+            unset($unauthorizedKeys[$key]);
+        }
+
         /** @var DecorateResourceNodeEvent $event */
         $event = $this->eventDispatcher->dispatch(
             'serialize_resource_node',
             'Resource\DecorateResourceNode',
             [
                 $resourceNode,
-                array_keys($serializedNode),
+                $unauthorizedKeys,
             ]
         );
 

--- a/plugin/url/Listener/ApiListener.php
+++ b/plugin/url/Listener/ApiListener.php
@@ -41,9 +41,13 @@ class ApiListener
             // Is it a youtube video ?
             $youtubeId = $this->getYoutubeId($resource->getUrl());
             if ($youtubeId !== false) {
-                $thumbnailUrl = 'http://img.youtube.com/vi/'.$youtubeId.'/hqdefault.jpg';
-                $event->add('poster', $thumbnailUrl);
                 $isYoutube = true;
+
+                // Only add remote youTube thumbnail if no local resource node thumbnail is defined
+                if ($resourceNode->getThumbnail() === null) {
+                    $thumbnailUrl = 'http://img.youtube.com/vi/'.$youtubeId.'/hqdefault.jpg';
+                    $event->add('poster', $thumbnailUrl);
+                }
             }
 
             $event->add('url', [

--- a/plugin/url/Listener/ApiListener.php
+++ b/plugin/url/Listener/ApiListener.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace HeVinci\UrlBundle\Listener;
+
+use Claroline\CoreBundle\Event\Resource\DecorateResourceNodeEvent;
+use Claroline\CoreBundle\Persistence\ObjectManager;
+use JMS\DiExtraBundle\Annotation as DI;
+
+/**
+ * Class ApiListener.
+ *
+ * @DI\Service
+ */
+class ApiListener
+{
+    /** @var ObjectManager */
+    private $om;
+
+    /**
+     * @DI\InjectParams({
+     *     "om" = @DI\Inject("claroline.persistence.object_manager"),
+     * })
+     */
+    public function __construct(ObjectManager $om)
+    {
+        $this->om = $om;
+    }
+
+    /**
+     * @DI\Observe("serialize_resource_node")
+     */
+    public function onSerialize(DecorateResourceNodeEvent $event)
+    {
+        $resource = $this->om->getRepository('HeVinciUrlBundle:Url')->findOneByResourceNode($event->getResourceNode());
+
+        // Detect if an automatic poster can be displayed if none has been defined
+        if ($event->getInjectedData()['poster'] === null && $resource !== null) {
+
+            // Is it a youtube video ?
+            $youtubeId = $this->getYoutubeId($resource->getUrl());
+            if ($youtubeId !== false) {
+                $thumbnailUrl = 'http://img.youtube.com/vi/'.$youtubeId.'/hqdefault.jpg';
+                $event->add('poster', $thumbnailUrl);
+            }
+        }
+    }
+
+    private function getYoutubeId($url)
+    {
+        $parsedUrl = parse_url($url);
+
+        switch ($parsedUrl['host']) {
+            case 'www.youtube.com':
+                parse_str($parsedUrl['query'], $parsedQuery);
+
+                return $parsedQuery['v'];
+            case 'youtu.be':
+                return substr($parsedUrl['path'], 1);
+            default:
+                break;
+        }
+
+        return false;
+    }
+}

--- a/plugin/url/Listener/ApiListener.php
+++ b/plugin/url/Listener/ApiListener.php
@@ -33,6 +33,8 @@ class ApiListener
     {
         $resource = $this->om->getRepository('HeVinciUrlBundle:Url')->findOneByResourceNode($event->getResourceNode());
 
+        $isYoutube = false;
+
         // Detect if an automatic poster can be displayed if none has been defined
         if ($event->getInjectedData()['poster'] === null && $resource !== null) {
 
@@ -41,8 +43,13 @@ class ApiListener
             if ($youtubeId !== false) {
                 $thumbnailUrl = 'http://img.youtube.com/vi/'.$youtubeId.'/hqdefault.jpg';
                 $event->add('poster', $thumbnailUrl);
+                $isYoutube = true;
             }
         }
+
+        $event->add('url', [
+            'isYoutube' => $isYoutube,
+        ]);
     }
 
     private function getYoutubeId($url)

--- a/plugin/url/Listener/ApiListener.php
+++ b/plugin/url/Listener/ApiListener.php
@@ -31,12 +31,12 @@ class ApiListener
      */
     public function onSerialize(DecorateResourceNodeEvent $event)
     {
-        $resource = $this->om->getRepository('HeVinciUrlBundle:Url')->findOneByResourceNode($event->getResourceNode());
+        // Restrict listener to Url resources only
+        $resourceNode = $event->getResourceNode();
+        if ($resourceNode->getResourceType()->getName() === 'hevinci_url') {
+            $isYoutube = false;
 
-        $isYoutube = false;
-
-        // Detect if an automatic poster can be displayed if none has been defined
-        if ($event->getInjectedData()['poster'] === null && $resource !== null) {
+            $resource = $this->om->getRepository('HeVinciUrlBundle:Url')->findOneByResourceNode($resourceNode);
 
             // Is it a youtube video ?
             $youtubeId = $this->getYoutubeId($resource->getUrl());
@@ -45,11 +45,11 @@ class ApiListener
                 $event->add('poster', $thumbnailUrl);
                 $isYoutube = true;
             }
-        }
 
-        $event->add('url', [
-            'isYoutube' => $isYoutube,
-        ]);
+            $event->add('url', [
+                'isYoutube' => $isYoutube,
+            ]);
+        }
     }
 
     private function getYoutubeId($url)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed tickets | 

If a url points to a Youtube video, its thumbnail url is automatically added as poster during node serialization.


