### PR TITLE
Error message clearer if exercice not available.

### DIFF
--- a/plugin/exo/Resources/modules/quiz/overview/overview.jsx
+++ b/plugin/exo/Resources/modules/quiz/overview/overview.jsx
@@ -2,13 +2,17 @@ import React, {Component} from 'react'
 import {PropTypes as T} from 'prop-types'
 import classes from 'classnames'
 
+import Alert from 'react-bootstrap/lib/Alert'
 import {tex} from '#/main/core/translation'
+
 import {
   correctionModes,
   markModes,
   quizTypes,
   SHOW_CORRECTION_AT_DATE
 } from './../enums'
+
+
 
 const Parameter = props =>
   <tr>
@@ -138,11 +142,22 @@ const Layout = props =>
           props.meta.userPaperCount < props.parameters.maxAttempts &&
           ((props.meta.userPaperDayCount < props.parameters.maxAttemptsPerDay) || props.parameters.maxAttemptsPerDay === 0)
         )
-      ) && ((props.meta.paperCount < props.parameters.maxPapers) || props.parameters.maxPapers === 0) &&
+      ) && ((props.meta.paperCount < props.parameters.maxPapers) || props.parameters.maxPapers === 0) ?
+        <a href="#play" className="btn btn-start btn-lg btn-primary btn-block">
+          {tex('exercise_start')}
+        </a>:
 
-      <a href="#play" className="btn btn-start btn-lg btn-primary btn-block">
-        {tex('exercise_start')}
-      </a>
+        <Alert bsStyle="danger overview-warning">
+          <span className="fa fa-fw fa-warning">{"\u00A0"}</span>
+          {(props.meta.userPaperCount < props.parameters.maxAttempts &&
+            ((props.meta.userPaperDayCount < props.parameters.maxAttemptsPerDay) || props.parameters.maxAttemptsPerDay === 0)
+          ) ?
+            <span>{tex('exercise_attempt_limit')}</span>:
+          ((props.meta.paperCount < props.parameters.maxPapers) || props.parameters.maxPapers === 0) ?
+            <span>{tex('exercise_paper_limit')}</span>:
+            <span></span>
+          }
+        </Alert>
     }
   </div>
 

--- a/plugin/exo/Resources/styles/quiz/overview.less
+++ b/plugin/exo/Resources/styles/quiz/overview.less
@@ -3,3 +3,7 @@
   max-width: @quiz-container-width;
   width: 100%;
 }
+
+.overview-warning {
+  text-align: center
+}

--- a/plugin/exo/Resources/translations/ujm_exo.en.json
+++ b/plugin/exo/Resources/translations/ujm_exo.en.json
@@ -686,5 +686,7 @@
     "pick-tag": "Tag",
     "number_question_page": "Number of question per page",
     "tag-amount": "Number of question related to the tag that must be picked",
-    "remove_workspaces_confirm": "Are you sure you want to delete the following questions [ %question_list% ]?"
+    "remove_workspaces_confirm": "Are you sure you want to delete the following questions [ %question_list% ]?",
+    "exercise_attempt_limit": "Your limit of attempts as been reached.",
+    "exercise_paper_limit": "The limit of attempts as been reached."
 }

--- a/plugin/exo/Resources/translations/ujm_exo.fr.json
+++ b/plugin/exo/Resources/translations/ujm_exo.fr.json
@@ -687,5 +687,7 @@
     "tag-amount": "Quantité",
     "tag-amount-help": "Nombre de question provenant devant être utilisé au total",
     "number_question_page": "Nombre de question par page",
-    "remove_questions_confirm": "Êtes-vous sûr de vouloir supprimer les questions suivantes [ %question_list% ]?"
+    "remove_questions_confirm": "Êtes-vous sûr de vouloir supprimer les questions suivantes [ %question_list% ]?",
+    "exercise_attempt_limit": "Votre nombre maximum de tentatives de l'exercice a été atteint.",
+    "exercise_paper_limit": "Le nombre maximum de réponses à l'exercice a été atteint."
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes 
| BC breaks?    | no
| Fixed tickets | Fixes partially #3213 

Exercise overview updated with clear messages of what's happening if you can't start it.


