### PR TITLE
[CoreBundle] Disable last open date for resources in resource manager (for performance sake)

### DIFF
--- a/main/core/Controller/ResourceController.php
+++ b/main/core/Controller/ResourceController.php
@@ -794,7 +794,8 @@ class ResourceController extends Controller
             }
 
             $path = $this->resourceManager->getAncestors($node);
-            $nodes = $this->resourceManager->getChildren($node, $currentRoles, $user, true, $canAdministrate);
+            // Disable lastOpenDate for now, until a better logging system is implemented
+            $nodes = $this->resourceManager->getChildren($node, $currentRoles, $user, false, $canAdministrate);
 
             //set "admin" mask if someone is the creator of a resource or the resource workspace owner.
             //if someone needs admin rights, the resource type list will go in this array


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | 

Disabled "lastOpenDate" behavior for now in resource manager for all resources as it was a performance issue for big log tables, until a better logging system is in place.
