### PR TITLE
[ExoBundle] Csv result export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+package-lock.json
+vendor/*
+node_modules/*

--- a/plugin/exo/Controller/Api/PaperController.php
+++ b/plugin/exo/Controller/Api/PaperController.php
@@ -7,6 +7,7 @@ use Claroline\CoreBundle\Library\Security\Collection\ResourceCollection;
 use JMS\DiExtraBundle\Annotation as DI;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration as EXT;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -229,8 +230,10 @@ class PaperController extends AbstractController
             throw new AccessDeniedException();
         }
 
-        return new StreamedResponse(function () use ($exercise) {
-            $this->exerciseManager->exportResultsToCsv($exercise);
+        $data = $this->exerciseManager->exportResultsToCsv($exercise);
+
+        return new StreamedResponse(function () use ($data) {
+            return $data;
         }, 200, [
             'Content-Type' => 'application/force-download',
             'Content-Disposition' => 'attachment; filename="export.csv"',

--- a/plugin/exo/Controller/Api/PaperController.php
+++ b/plugin/exo/Controller/Api/PaperController.php
@@ -7,7 +7,6 @@ use Claroline\CoreBundle\Library\Security\Collection\ResourceCollection;
 use JMS\DiExtraBundle\Annotation as DI;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration as EXT;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;

--- a/plugin/exo/Entity/Item/Item.php
+++ b/plugin/exo/Entity/Item/Item.php
@@ -245,6 +245,16 @@ class Item
     }
 
     /**
+     * Gets content without html.
+     *
+     * @return string
+     */
+    public function getContentText()
+    {
+        return strip_tags($this->content);
+    }
+
+    /**
      * @return ArrayCollection
      */
     public function getObjects()

--- a/plugin/exo/Library/Item/Definition/BooleanDefinition.php
+++ b/plugin/exo/Library/Item/Definition/BooleanDefinition.php
@@ -184,7 +184,7 @@ class BooleanDefinition extends AbstractDefinition
 
     public function getCsvTitles(AbstractItem $item)
     {
-        return ['bool-'.$item->getQuestion()->getUuid()];
+        return [$item->getQuestion()->getContentText()];
     }
 
     public function getCsvAnswers(AbstractItem $item, Answer $answer)

--- a/plugin/exo/Library/Item/Definition/ChoiceDefinition.php
+++ b/plugin/exo/Library/Item/Definition/ChoiceDefinition.php
@@ -198,7 +198,7 @@ class ChoiceDefinition extends AbstractDefinition
 
     public function getCsvTitles(AbstractItem $item)
     {
-        return ['choice-'.$item->getQuestion()->getUuid()];
+        return [$item->getQuestion()->getContentText()];
     }
 
     public function getCsvAnswers(AbstractItem $item, Answer $answer)
@@ -207,7 +207,7 @@ class ChoiceDefinition extends AbstractDefinition
         $answers = [];
 
         foreach ($item->getChoices() as $choice) {
-            if (in_array($choice->getUuid(), $data)) {
+            if (is_array($data) && in_array($choice->getUuid(), $data)) {
                 $answers[] = $choice->getData();
             }
         }

--- a/plugin/exo/Library/Item/Definition/ClozeDefinition.php
+++ b/plugin/exo/Library/Item/Definition/ClozeDefinition.php
@@ -281,8 +281,10 @@ class ClozeDefinition extends AbstractDefinition
         $answers = [];
         $answeredHoles = [];
 
-        foreach ($data as $answer) {
-            $answeredHoles[$answer->holeId] = $answer->answerText;
+        if (is_array($data)) {
+            foreach ($data as $answer) {
+                $answeredHoles[$answer->holeId] = $answer->answerText;
+            }
         }
 
         foreach ($item->getHoles() as $hole) {

--- a/plugin/exo/Library/Item/Definition/GraphicDefinition.php
+++ b/plugin/exo/Library/Item/Definition/GraphicDefinition.php
@@ -225,7 +225,7 @@ class GraphicDefinition extends AbstractDefinition
 
     public function getCsvTitles(AbstractItem $item)
     {
-        return ['graphic-'.$item->getQuestion()->getUuid()];
+        return [$item->getQuestion()->getContentText()];
     }
 
     public function getCsvAnswers(AbstractItem $item, Answer $answer)

--- a/plugin/exo/Library/Item/Definition/MatchDefinition.php
+++ b/plugin/exo/Library/Item/Definition/MatchDefinition.php
@@ -218,7 +218,7 @@ class MatchDefinition extends AbstractDefinition
 
     public function getCsvTitles(AbstractItem $item)
     {
-        return ['match-'.$item->getQuestion()->getUuid()];
+        return [$item->getQuestion()->getContentText()];
     }
 
     public function getCsvAnswers(AbstractItem $item, Answer $answer)

--- a/plugin/exo/Library/Item/Definition/OpenDefinition.php
+++ b/plugin/exo/Library/Item/Definition/OpenDefinition.php
@@ -168,7 +168,7 @@ class OpenDefinition extends AbstractDefinition
 
     public function getCsvTitles(AbstractItem $item)
     {
-        return ['open-'.$item->getQuestion()->getUuid()];
+        return [$item->getQuestion()->getContentText()];
     }
 
     public function getCsvAnswers(AbstractItem $item, Answer $answer)

--- a/plugin/exo/Library/Item/Definition/OrderingDefinition.php
+++ b/plugin/exo/Library/Item/Definition/OrderingDefinition.php
@@ -184,7 +184,7 @@ class OrderingDefinition extends AbstractDefinition
 
     public function getCsvTitles(AbstractItem $item)
     {
-        return ['ordering-'.$item->getQuestion()->getUuid()];
+        return [$item->getQuestion()->getContentText()];
     }
 
     public function getCsvAnswers(AbstractItem $item, Answer $answer)

--- a/plugin/exo/Library/Item/Definition/PairDefinition.php
+++ b/plugin/exo/Library/Item/Definition/PairDefinition.php
@@ -249,7 +249,7 @@ class PairDefinition extends AbstractDefinition
 
     public function getCsvTitles(AbstractItem $item)
     {
-        return ['pair-'.$item->getQuestion()->getUuid()];
+        return [$item->getQuestion()->getContentText()];
     }
 
     public function getCsvAnswers(AbstractItem $item, Answer $answer)

--- a/plugin/exo/Library/Item/Definition/SelectionDefinition.php
+++ b/plugin/exo/Library/Item/Definition/SelectionDefinition.php
@@ -298,7 +298,7 @@ class SelectionDefinition extends AbstractDefinition
 
     public function getCsvTitles(AbstractItem $question)
     {
-        return ['selection-'.$question->getQuestion()->getUuid()];
+        return [$question->getQuestion()->getContentText()];
     }
 
     public function getCsvAnswers(AbstractItem $item, Answer $answer)

--- a/plugin/exo/Library/Item/Definition/SetDefinition.php
+++ b/plugin/exo/Library/Item/Definition/SetDefinition.php
@@ -215,7 +215,7 @@ class SetDefinition extends AbstractDefinition
 
     public function getCsvTitles(AbstractItem $question)
     {
-        return ['set-'.$question->getQuestion()->getUuid()];
+        return [$question->getQuestion()->getContentText()];
     }
 
     public function getCsvAnswers(AbstractItem $item, Answer $answer)

--- a/plugin/exo/Library/Item/Definition/WordsDefinition.php
+++ b/plugin/exo/Library/Item/Definition/WordsDefinition.php
@@ -210,7 +210,7 @@ class WordsDefinition extends AbstractDefinition
 
     public function getCsvTitles(AbstractItem $item)
     {
-        return ['words-'.$item->getQuestion()->getUuid()];
+        return [$item->getQuestion()->getContentText()];
     }
 
     public function getCsvAnswers(AbstractItem $item, Answer $answer)

--- a/plugin/exo/Manager/ExerciseManager.php
+++ b/plugin/exo/Manager/ExerciseManager.php
@@ -316,10 +316,13 @@ class ExerciseManager
         $items = [];
         $questions = [];
 
+        //get the list of titles for the csv (the headers)
+        //this is an array of array because some question types will return...
+        //more than 1 title (ie clozes)
         foreach ($exercise->getSteps() as $step) {
             foreach ($step->getStepQuestions() as $stepQ) {
                 $item = $stepQ->getQuestion();
-                $items[$item->getUuid()] = $item;
+                $items[$item->getId()] = $item;
                 $questions[$stepQ->getQuestion()->getUuid()] = $stepQ->getQuestion();
                 $itemType = $item->getInteraction();
 
@@ -330,6 +333,7 @@ class ExerciseManager
             }
         }
 
+        //this is the same reason why we use an array of array here
         $repo = $this->om->getRepository('UJMExoBundle:Attempt\Paper');
         $papers = $repo->findBy(['exercise' => $exercise]);
 
@@ -337,6 +341,7 @@ class ExerciseManager
             $answers = $paper->getAnswers();
             $csv = [];
             $user = $paper->getUser();
+
             if ($user) {
                 $csv['username'] = [$user->getUsername()];
                 $csv['firstname'] = [$user->getFirstName()];
@@ -347,26 +352,38 @@ class ExerciseManager
                 $csv['firstname'] = ['none'];
             }
 
-            $orderedIds = array_keys($questions);
-            $indexedAnswers = [];
-            $orderedAnswers = [];
+            $notFound = [];
+            foreach ($questions as $question) {
+                $item = $items[$question->getId()];
+                $found = false;
 
-            foreach ($answers as $answer) {
-                $indexedAnswers[$answer->getQuestionId()] = $answer;
-            }
-
-            foreach ($orderedIds as $id) {
-                if (isset($indexedAnswers[$id])) {
-                    $orderedAnswers[] = $indexedAnswers[$id];
+                foreach ($answers as $answer) {
+                    if ($answer->getQuestionId() === $question->getUuid()) {
+                        if ($this->definitions->has($item->getMimeType())) {
+                            $found = true;
+                            $definition = $this->definitions->get($item->getMimeType());
+                            $csv[$answer->getQuestionId()] = $definition->getCsvAnswers($item->getInteraction(), $answer);
+                        }
+                    }
                 }
-            }
 
-            foreach ($orderedAnswers as $answer) {
-                $item = $items[$answer->getQuestionId()];
+                if (!$found) {
+                    $notFound[] = $question->getUuid();
+                    $items[$question->getId()];
+                    $itemType = $item->getInteraction();
+                    $countBlank = 0;
 
-                if ($this->definitions->has($item->getMimeType())) {
-                    $definition = $this->definitions->get($item->getMimeType());
-                    $csv[$answer->getQuestionId()] = $definition->getCsvAnswers($item->getInteraction(), $answer);
+                    if ($this->definitions->has($item->getMimeType())) {
+                        $definition = $this->definitions->get($item->getMimeType());
+                        $countBlank = count($definition->getCsvTitles($itemType));
+                    }
+
+                    $blankData = [];
+                    for ($i = 0; $i < $countBlank; $i++) {
+                        $blankData[] = '';
+                    }
+
+                    $csv[$item->getUuid()] = $blankData;
                 }
             }
 

--- a/plugin/exo/Manager/ExerciseManager.php
+++ b/plugin/exo/Manager/ExerciseManager.php
@@ -379,7 +379,7 @@ class ExerciseManager
                     }
 
                     $blankData = [];
-                    for ($i = 0; $i < $countBlank; $i++) {
+                    for ($i = 0; $i < $countBlank; ++$i) {
                         $blankData[] = '';
                     }
 

--- a/plugin/tag/Manager/TagManager.php
+++ b/plugin/tag/Manager/TagManager.php
@@ -165,7 +165,11 @@ class TagManager
             foreach ($uniqueTags as $tagName) {
                 $tag = $tagsList[$tagName];
 
-                $taggedObject = $this->getOneTaggedObjectByTagAndObject($tag, $objectId, $objectClass);
+                $taggedObject = null;
+                //if tag is scheduled for insertion it's new so no need to search for it
+                if (!$this->getUowScheduledTag($tagName)) {
+                    $taggedObject = $this->getOneTaggedObjectByTagAndObject($tag, $objectId, $objectClass);
+                }
 
                 if (is_null($taggedObject)) {
                     $taggedObject = new TaggedObject();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Je n'ai probablement pas tout testé, mais ça solutionne beaucoup de problème lors de l'export des résulats des exercices en csv. En tout cas mon export en local à base d'exercice par tag que j'ai que j'ai modifié plusieurs fois avec certaines questions dont la réponse est vide est correct de cette manière.

J'ai pas testé tous les types de questions lors qu'on ne répond pas. Pour le reste je pense que c'est bon.
En bonus le libellé n'est plus le Uuid là ou c'était possible.

Voir #3233


