### PR TITLE
[ExoBundle] Fix boolean question paper csv export

### DIFF
--- a/plugin/exo/Library/Item/Definition/BooleanDefinition.php
+++ b/plugin/exo/Library/Item/Definition/BooleanDefinition.php
@@ -197,5 +197,7 @@ class BooleanDefinition extends AbstractDefinition
                 return [$choice->getData()];
             }
         }
+
+        return [''];
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #3374 

Fixes Boolean question CSV export for papers when no answer is provided.


  