### PR TITLE
[CoreBundle] fixes #3420

### DIFF
--- a/main/core/Controller/APINew/User/OrganizationController.php
+++ b/main/core/Controller/APINew/User/OrganizationController.php
@@ -83,7 +83,7 @@ class OrganizationController extends AbstractCrudController
      *
      * @return JsonResponse
      */
-    public function addUsersAction(Organization $organization, Request $request)
+    public function addManagersAction(Organization $organization, Request $request)
     {
         $users = $this->decodeIdsString($request, 'Claroline\CoreBundle\Entity\User');
         $this->crud->patch($organization, 'administrator', Crud::COLLECTION_ADD, $users);
@@ -103,7 +103,7 @@ class OrganizationController extends AbstractCrudController
      *
      * @return JsonResponse
      */
-    public function removeUsersAction(Organization $organization, Request $request)
+    public function removeManagersAction(Organization $organization, Request $request)
     {
         $users = $this->decodeIdsString($request, 'Claroline\CoreBundle\Entity\User');
         $this->crud->patch($organization, 'administrator', Crud::COLLECTION_REMOVE, $users);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed tickets | #3420 

ATTENTION : il s'agit d'une erreur au niveau de l'api. Les utilisateurs qui ont été ajoutés à une Organisation depuis la version 10.9.0 ont été ajouté comme gestionnaire de l'organisation ! Il faut vérifier les données manuellement et corriger en conséquence.


