### PR TITLE
En fait modifier le parent d'une étape c'est compliqué.

### DIFF
--- a/main/core/Resources/modules/data/form/actions.js
+++ b/main/core/Resources/modules/data/form/actions.js
@@ -23,7 +23,7 @@ actions.setErrors = makeInstanceActionCreator(FORM_SET_ERRORS, 'errors')
 actions.submitForm = makeInstanceActionCreator(FORM_SUBMIT)
 actions.submitFormSuccess = makeInstanceActionCreator(FORM_SUBMIT_SUCCESS, 'updatedData')
 actions.submitFormError = makeInstanceActionCreator(FORM_SUBMIT_ERROR, 'errors')
-actions.updateProp = makeInstanceActionCreator(FORM_UPDATE_PROP, 'propName', 'propValue')
+actions.updateProp = makeInstanceActionCreator(FORM_UPDATE_PROP, 'propName', 'propValue', 'oldProp')
 
 actions.cancelChanges = (formName) => (dispatch, getState) => {
   const formNew = formSelect.isNew(formSelect.form(getState(), formName))

--- a/main/core/Resources/modules/data/form/actions.js
+++ b/main/core/Resources/modules/data/form/actions.js
@@ -23,7 +23,7 @@ actions.setErrors = makeInstanceActionCreator(FORM_SET_ERRORS, 'errors')
 actions.submitForm = makeInstanceActionCreator(FORM_SUBMIT)
 actions.submitFormSuccess = makeInstanceActionCreator(FORM_SUBMIT_SUCCESS, 'updatedData')
 actions.submitFormError = makeInstanceActionCreator(FORM_SUBMIT_ERROR, 'errors')
-actions.updateProp = makeInstanceActionCreator(FORM_UPDATE_PROP, 'propName', 'propValue', 'oldProp')
+actions.updateProp = makeInstanceActionCreator(FORM_UPDATE_PROP, 'propName', 'propValue')
 
 actions.cancelChanges = (formName) => (dispatch, getState) => {
   const formNew = formSelect.isNew(formSelect.form(getState(), formName))

--- a/plugin/path/Resources/modules/resources/path/editor/components/editor.jsx
+++ b/plugin/path/Resources/modules/resources/path/editor/components/editor.jsx
@@ -96,6 +96,7 @@ const EditorComponent = props =>
                   removeSecondaryResource={props.removeSecondaryResource}
                   updateSecondaryResourceInheritance={props.updateSecondaryResourceInheritance}
                   removeInheritedResource={props.removeInheritedResource}
+                  steps={props.steps}
                 />
               </PathCurrent>
             )

--- a/plugin/path/Resources/modules/resources/path/editor/components/step-form.jsx
+++ b/plugin/path/Resources/modules/resources/path/editor/components/step-form.jsx
@@ -121,8 +121,11 @@ InheritedResourcesSection.propTypes = {
   removeInheritedResource: T.func.isRequired
 }
 
-const StepForm = props =>
-  <FormContainer
+const StepForm = props => {
+  const listSteps = {}
+  props.steps.filter(step => step.id !== props.id).forEach(step => listSteps[step.id] = step.title)
+
+  return(<FormContainer
     level={3}
     displayLevel={2}
     name="pathForm"
@@ -142,6 +145,13 @@ const StepForm = props =>
             name: 'description',
             type: 'html',
             label: trans('description')
+          },
+          {
+            name: 'parent',
+            type: 'enum',
+            options: {
+              choices: listSteps
+            }
           }
         ]
       }, {
@@ -213,10 +223,12 @@ const StepForm = props =>
         </FormSection>
       }
     </FormSections>
-  </FormContainer>
+  </FormContainer>)
+}
 
 implementPropTypes(StepForm, StepTypes, {
   stepPath: T.string.isRequired,
+  steps: T.array.isRequired,
   customNumbering: T.bool,
   pickPrimaryResource: T.func.isRequired,
   removePrimaryResource: T.func.isRequired,

--- a/plugin/path/Resources/modules/resources/path/editor/reducer.js
+++ b/plugin/path/Resources/modules/resources/path/editor/reducer.js
@@ -12,7 +12,8 @@ import {
   manageInheritedResources,
   generateCopy,
   updateCopyBeforeAdding,
-  getStep
+  getStep,
+  getParents
 } from '#/plugin/path/resources/path/editor/utils'
 
 import {
@@ -46,7 +47,6 @@ const reducer = {
     }),
     data: makeReducer(defaultState.data, {
       ['FORM_UPDATE_PROP/pathForm']: (state, action) => {
-        console.log(state, action)
         let propPath = action.propName.split('.')
 
         const property = propPath.pop()
@@ -55,21 +55,15 @@ const reducer = {
           const currentStep = get(state, propPath.join('.'))
           //currentStep.parent = action.propValue
           const newParent = getStep(newState.steps, action.propValue)
-          const oldParentId = get(state, action.propName)
-          console.log(oldParentId)
-          const oldParent = getStep(newState.steps, oldParentId)
-          console.log(newParent)
-          console.log(oldParent)
+          const oldParents = getParents(newState.steps, currentStep.id)
 
-          //some exceptino if parent are switched
           if (newParent) {
             newParent.children.push(currentStep)
-          }
 
-          /*
-          if (oldParent) {
-            oldParent.children.splice(newParent.children.find(child => child.id === currentStep.id), 1)
-          }*/
+            oldParents.forEach(oldParent => {
+              oldParent.children.splice(newParent.children.find(child => child.id === currentStep.id), 1)
+            })
+          }
 
           return newState
         }

--- a/plugin/path/Resources/modules/resources/path/editor/reducer.js
+++ b/plugin/path/Resources/modules/resources/path/editor/reducer.js
@@ -1,4 +1,5 @@
 import cloneDeep from 'lodash/cloneDeep'
+import get from 'lodash/get'
 
 import {trans} from '#/main/core/translation'
 import {makeId} from '#/main/core/scaffolding/id'
@@ -10,7 +11,8 @@ import {
   getStepPath,
   manageInheritedResources,
   generateCopy,
-  updateCopyBeforeAdding
+  updateCopyBeforeAdding,
+  getStep
 } from '#/plugin/path/resources/path/editor/utils'
 
 import {
@@ -43,6 +45,38 @@ const reducer = {
       [STEP_PASTE]: () => true
     }),
     data: makeReducer(defaultState.data, {
+      ['FORM_UPDATE_PROP/pathForm']: (state, action) => {
+        console.log(state, action)
+        let propPath = action.propName.split('.')
+
+        const property = propPath.pop()
+        if (property === 'parent') {
+          const newState = cloneDeep(state)
+          const currentStep = get(state, propPath.join('.'))
+          //currentStep.parent = action.propValue
+          const newParent = getStep(newState.steps, action.propValue)
+          const oldParentId = get(state, action.propName)
+          console.log(oldParentId)
+          const oldParent = getStep(newState.steps, oldParentId)
+          console.log(newParent)
+          console.log(oldParent)
+
+          //some exceptino if parent are switched
+          if (newParent) {
+            newParent.children.push(currentStep)
+          }
+
+          /*
+          if (oldParent) {
+            oldParent.children.splice(newParent.children.find(child => child.id === currentStep.id), 1)
+          }*/
+
+          return newState
+        }
+
+
+        return state
+      },
       [STEP_ADD]: (state, action) => {
         const newState = cloneDeep(state)
 

--- a/plugin/path/Resources/modules/resources/path/editor/utils.js
+++ b/plugin/path/Resources/modules/resources/path/editor/utils.js
@@ -95,10 +95,22 @@ function updateCopyBeforeAdding(step, lvl, inheritedResources) {
   step.children.forEach(s => updateCopyBeforeAdding(s, lvl, inheritedResources))
 }
 
+function getStep(steps, id)
+{
+    for (let i = 0; i < steps.length; i++) {
+      if (steps[i].id === id) {
+        return steps[i]
+      }
+
+      return getStep(steps[i].children, id)
+    }
+}
+
 export {
   getFormDataPart,
   getStepPath,
   manageInheritedResources,
   generateCopy,
-  updateCopyBeforeAdding
+  updateCopyBeforeAdding,
+  getStep
 }

--- a/plugin/path/Resources/modules/resources/path/editor/utils.js
+++ b/plugin/path/Resources/modules/resources/path/editor/utils.js
@@ -97,13 +97,29 @@ function updateCopyBeforeAdding(step, lvl, inheritedResources) {
 
 function getStep(steps, id)
 {
-    for (let i = 0; i < steps.length; i++) {
-      if (steps[i].id === id) {
-        return steps[i]
-      }
-
-      return getStep(steps[i].children, id)
+  for (let i = 0; i < steps.length; i++) {
+    if (steps[i].id === id) {
+      return steps[i]
     }
+
+    return getStep(steps[i].children, id)
+  }
+}
+
+/**
+ * Utility method for the reducer, allow to find duplicatas
+ */
+function getParents(steps, stepId, parents = []) {
+  steps.forEach(step => {
+    step.children.forEach(child => {
+      if (child.id === stepId) {
+        parents.push(step)
+      }
+      parents = getParents(step.children, stepId, parents)
+    })
+  })
+
+  return parents
 }
 
 export {
@@ -112,5 +128,6 @@ export {
   manageInheritedResources,
   generateCopy,
   updateCopyBeforeAdding,
-  getStep
+  getStep,
+  getParents
 }

--- a/plugin/path/Serializer/PathSerializer.php
+++ b/plugin/path/Serializer/PathSerializer.php
@@ -174,6 +174,7 @@ class PathSerializer
                 return $this->serializeStep($child);
             }, $step->getChildren()->toArray()),
             'userProgression' => $this->serializeUserProgression($step),
+            'parent' => $step->getParent() ? $step->getParent()->getUuid() : null,
         ];
     }
 
@@ -214,7 +215,7 @@ class PathSerializer
     private function serializeUserProgression(Step $step)
     {
         $user = $this->tokenStorage->getToken()->getUser();
-        $userProgression = $user !== 'anon.' ?
+        $userProgression = 'anon.' !== $user ?
             $this->userProgressionRepo->findOneBy(['step' => $step, 'user' => $user]) :
             null;
         $data = [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

Je le met ici en attendant. 
La difficulté consiste à avoir accès à l'ancienne valeur dans le reducer (et pas uniquement la nouvelle).

Il y a moyen de bourriner pour faire sans l'ancienne valeur.

Dans cette pr il faut retirer le 'oldProp' du coup car ça ne fonctionne pas vraiment.

