### PR TITLE
[Dependencies] Removing ZenstruckBundle

### DIFF
--- a/main/core/Resources/views/Form/date_picker.html.twig
+++ b/main/core/Resources/views/Form/date_picker.html.twig
@@ -1,4 +1,4 @@
-{% extends 'ZenstruckFormBundle:Twitter:form_bootstrap3_layout.html.twig' %}
+{% extends 'bootstrap_3_layout.html.twig' %}
 
 {% block custom_widget_attributes %}
 {% spaceless %}

--- a/main/core/Resources/views/Form/date_time_picker.html.twig
+++ b/main/core/Resources/views/Form/date_time_picker.html.twig
@@ -1,4 +1,4 @@
-{% extends 'ZenstruckFormBundle:Twitter:form_bootstrap3_layout.html.twig' %}
+{% extends 'bootstrap_3_layout.html.twig' %}
 
 {% block custom_widget_attributes %}
     {% spaceless %}

--- a/main/core/Resources/views/form_theme.html.twig
+++ b/main/core/Resources/views/form_theme.html.twig
@@ -1,4 +1,4 @@
-{% extends 'ZenstruckFormBundle:Twitter:form_bootstrap3_layout.html.twig' %}
+{% extends 'bootstrap_3_layout.html.twig' %}
 
 {% block form_row %}
     {% spaceless %}

--- a/main/core/Resources/views/form_theme_vertical.html.twig
+++ b/main/core/Resources/views/form_theme_vertical.html.twig
@@ -1,4 +1,4 @@
-{% extends 'ZenstruckFormBundle:Twitter:form_bootstrap3_layout.html.twig' %}
+{% extends 'bootstrap_3_layout.html.twig' %}
 
 {% block form_row %}
     {% spaceless %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

This is just a try and the first commit. We need to remove it first.

- [ ] Fix css/theme
- [ ] Remove custom fields (they were used by Icap for in some bundles, they may be already removed with the angular/react upgrades but I don't know what/where to check).
- [ ] remove the dependency (composer.json, ClarolineCoreBundle, app/config/parameters)