### PR TITLE
[CoreBundle] fixes ResourceNode serializer minimal mode

### DIFF
--- a/plugin/drop-zone/Resources/modules/resources/dropzone/components/documents.jsx
+++ b/plugin/drop-zone/Resources/modules/resources/dropzone/components/documents.jsx
@@ -73,7 +73,7 @@ const DocumentRow = props =>
       }
 
       {props.document.type === constants.DOCUMENT_TYPE_RESOURCE &&
-        <a href={url(['claro_resource_open_short', {node: props.document.data.actualId}])}>
+        <a href={url(['claro_resource_open_short', {node: props.document.data.autoId}])}>
           {props.document.data.name}
         </a>
       }


### PR DESCRIPTION
The old serialized version was not usable by the front.

ResourcePages, DataCards and DataLists can now use it (it's not done here).


