### PR TITLE
Fixing file upload route (for retrocompatibility)

### DIFF
--- a/main/core/Controller/FileController.php
+++ b/main/core/Controller/FileController.php
@@ -37,7 +37,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
- * @EXT\Route("/file", options={"expose"=true})
+ * @EXT\Route(options={"expose"=true})
  */
 class FileController extends AbstractApiController
 {
@@ -129,7 +129,7 @@ class FileController extends AbstractApiController
     }
 
     /**
-     * @EXT\Route("resource/media/{node}", name="claro_file_get_media")
+     * @EXT\Route("/resource/media/{node}", name="claro_file_get_media")
      * @EXT\Method("GET")
      *
      * @param ResourceNode $node


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed tickets | comma-separated list of tickets fixed by the PR, if any

Assez urgent. Répare les liens cassés lors de la migration (vu que les routes ont changées). Les plateformes en prodution ayant déjà rajouté des fichiers via tinymce devront les remettre (à moins de doubler l'url de stream. On le fera s'il le faut mais c'est peu probable vu que le picker dans tiny est cassé).

