### PR TITLE
adds webpack alias for external distribution

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -37,6 +37,7 @@ Encore
   })
   .addPlugin(plugins.circularDependencies())
   .addPlugin(plugins.assetsInfoFile())
+  .addPlugin(plugins.vendorDistributionShortcut())
   .addPlugin(plugins.distributionShortcut())
   .addPlugin(plugins.scaffoldingDllReference())
   .addPlugin(plugins.reactDllReference())

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -36,6 +36,7 @@ Encore
     options.beautify = true
   })
   .addPlugin(plugins.assetsInfoFile())
+  .addPlugin(plugins.vendorDistributionShortcut())
   .addPlugin(plugins.distributionShortcut())
   .addPlugin(plugins.scaffoldingDllReference())
   .addPlugin(plugins.reactDllReference())

--- a/webpack.config.test.js
+++ b/webpack.config.test.js
@@ -33,8 +33,8 @@ Encore
     options.compress = false
     options.beautify = false
   })
+  .addPlugin(plugins.vendorDistributionShortcut())
   .addPlugin(plugins.distributionShortcut())
-  .addPlugin(plugins.configShortcut())
   .addPlugin(plugins.rethrowCompilationErrors())
   // we can not use CommonChunksPlugin (nor DLLs) in test env
   // @see https://github.com/webpack-contrib/karma-webpack/issues/24

--- a/webpack/plugins.js
+++ b/webpack/plugins.js
@@ -8,6 +8,31 @@ const CircularDependencyPlugin = require('circular-dependency-plugin')
 
 /**
  * Adds a custom resolver that will try to convert internal webpack requests for
+ * modules starting with "~/" (i.e by convention, modules located in a distribution in the
+ * vendor packages) into requests with a resolved absolute path. Modules
+ * are expected to live in the "Resources/modules" directory of each bundle,
+ * so that part must be omitted from the import statement.
+ *
+ * Attention : this does not work for vendor packages which contains only one plugin Bundle.
+ *
+ * Example:
+ *
+ * import bar from '~/formalibre/customer-bundle/plugin/culture-courses/foo/bar'
+ *
+ * will be resolved to:
+ *
+ * /path/to/vendor/formalibre/customer-bundle/plugin/culture-courses/Resources/modules/foo/bar
+ */
+const vendorDistributionShortcut = () => {
+  return new webpack.NormalModuleReplacementPlugin(/^~\//, request => {
+    const parts = request.request.substr(2).split('/')
+    const resolved = [...parts.slice(0, 4), 'Resources/modules', ...parts.slice(4)]
+    request.request = [paths.root(), 'vendor', ...resolved].join('/')
+  })
+}
+
+/**
+ * Adds a custom resolver that will try to convert internal webpack requests for
  * modules starting with "#/" (i.e by convention, modules located in the
  * distribution package) into requests with a resolved absolute path. Modules
  * are expected to live in the "Resources/modules" directory of each bundle,
@@ -120,6 +145,7 @@ const circularDependencies = () => new CircularDependencyPlugin({
 })
 
 module.exports = {
+  vendorDistributionShortcut,
   distributionShortcut,
   dlls,
   commonsChunk,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no

For now, it works only for other distribution packages not for standalone plugins.


