### PR TITLE
[CoreBundle] If user can't be self registered, cannot be bypassed by …

### DIFF
--- a/main/core/Controller/RedirectController.php
+++ b/main/core/Controller/RedirectController.php
@@ -16,6 +16,7 @@ use Claroline\CoreBundle\Entity\Workspace\Workspace;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration as EXT;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * This controller is used to do some redirects/route alias. It's not always possible to do it
@@ -76,6 +77,12 @@ class RedirectController extends Controller
         $user = $this->container->get('security.token_storage')->getToken()->getUser();
 
         if ('anon.' === $user) {
+            $configHandler = $this->container->get('claroline.config.platform_config_handler');
+
+            if (!$configHandler->getParameter('registration.self')) {
+                throw new AccessDeniedException();
+            }
+
             return $this->redirectToRoute('claro_workspace_subscription_url_generate_anonymous', [
                 'workspace' => $workspace->getId(),
             ]);

--- a/main/core/Controller/Tool/WorkspaceParametersController.php
+++ b/main/core/Controller/Tool/WorkspaceParametersController.php
@@ -77,6 +77,11 @@ class WorkspaceParametersController extends Controller
     public function anonymousSubscriptionAction(Workspace $workspace)
     {
         $configHandler = $this->container->get('claroline.config.platform_config_handler');
+
+        if (!$configHandler->getParameter('registration.self')) {
+            throw new AccessDeniedException();
+        }
+
         $profilerSerializer = $this->container->get('claroline.serializer.profile');
         $tosManager = $this->container->get('claroline.common.terms_of_service_manager');
         $allowWorkspace = $configHandler->getParameter('allow_workspace_at_registration');


### PR DESCRIPTION
…workspace registration url.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed issues | #5389 

Maintenant, il faut se connecter à la plateforme pour pour utiliser les urls d'inscriptions du type
`http://localhost/nico/ClaroNewReact/web/app_dev.php/ws/monworkspace/subscription`
dans le cas ou registration.self est à false dans le platform_options.json


