### PR TITLE
[PathBundle] fixes duplicated secondary resources

### DIFF
--- a/plugin/path/Entity/Step.php
+++ b/plugin/path/Entity/Step.php
@@ -144,7 +144,7 @@ class Step
      *
      * @var ArrayCollection|SecondaryResource[]
      *
-     * @ORM\OneToMany(targetEntity="Innova\PathBundle\Entity\SecondaryResource", mappedBy="step", cascade={"persist", "remove"})
+     * @ORM\OneToMany(targetEntity="Innova\PathBundle\Entity\SecondaryResource", mappedBy="step", cascade={"persist", "remove"}, orphanRemoval=true)
      * @ORM\OrderBy({"order" = "ASC"})
      */
     protected $secondaryResources;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Cleaning request : 

```
DELETE t1 
FROM innova_step_secondary_resource t1
INNER JOIN innova_step_secondary_resource t2 
WHERE t1.id < t2.id AND t1.step_id = t2.step_id AND t1.resource_id = t2.resource_id;
```