### PR TITLE
Fixing white page for open question correction.

### DIFF
--- a/plugin/exo/Resources/modules/items/match/prop-types.js
+++ b/plugin/exo/Resources/modules/items/match/prop-types.js
@@ -27,7 +27,9 @@ const MatchItem = {
   defaultProps: {
     firstSet: [],
     secondSet: [],
-    solutions: []
+    solutions: [],
+    random: false,
+    penalty: 0
   }
 }
 

--- a/plugin/exo/Resources/modules/quiz/correction/components/answers.jsx
+++ b/plugin/exo/Resources/modules/quiz/correction/components/answers.jsx
@@ -3,7 +3,7 @@ import {PropTypes as T} from 'prop-types'
 import {connect} from 'react-redux'
 import classes from 'classnames'
 
-import {trans, tex} from '#/main/app/intl/translation'
+import {trans} from '#/main/app/intl/translation'
 import {HtmlText} from '#/main/core/layout/components/html-text'
 import {actions} from './../actions'
 import {selectors as correctionSelectors} from './../selectors'
@@ -25,7 +25,7 @@ class AnswerRow extends Component {
             {this.props.data && 0 !== this.props.data.length ?
               <HtmlText className="answer-item">{this.props.data}</HtmlText>
               :
-              <div className="no-answer">{tex('no_answer')}</div>
+              <div className="no-answer">{trans('no_answer', {}, 'quiz')}</div>
             }
 
             {this.state.showFeedback &&
@@ -57,7 +57,7 @@ class AnswerRow extends Component {
               className="btn-link"
               type={CALLBACK_BUTTON}
               icon="fa fa-fw fa-comments-o"
-              label={tex('feedback')}
+              label={trans('feedback', {}, 'quiz')}
               callback={() => this.setState({showFeedback: !this.state.showFeedback})}
             />
           </div>
@@ -78,8 +78,12 @@ AnswerRow.propTypes = {
   updateFeedback: T.func.isRequired
 }
 
-let Answers = props =>
-  <div className="answers-list">
+let Answers = props => {
+  if (!props.question) {
+    return (<div>{trans('please_wait')}</div>)
+  }
+
+  return (<div className="answers-list">
     <h2 className="question-title">
       {props.question.title || props.question.content}
 
@@ -106,10 +110,11 @@ let Answers = props =>
         />
       ) :
       <div className="alert alert-warning">
-        {tex('no_answer_to_correct')}
+        {trans('no_answer_to_correct', {}, 'quiz')}
       </div>
     }
   </div>
+  )}
 
 Answers.propTypes = {
   question: T.shape({

--- a/plugin/exo/Resources/modules/quiz/correction/selectors.js
+++ b/plugin/exo/Resources/modules/quiz/correction/selectors.js
@@ -6,7 +6,9 @@ const quizId = quizSelectors.id
 
 const correction = createSelector(
   [quizSelectors.resource],
-  (resource) => resource.correction
+  (resource) => {
+    return resource.correction
+  }
 )
 
 const questionsFetched = createSelector(
@@ -34,7 +36,8 @@ const questions = createSelector(
 const answers = createSelector(
   [correction],
   (correction) => {
-    return correction.answers.filter(a => a.questionId === correction.currentQuestionId)
+
+    return correction.answers ? correction.answers.filter(a => a.questionId === correction.currentQuestionId): []
   }
 )
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed issues | comma-separated list of issues fixed by the PR, if any

In progress:

```
Sauvegarde de réponse de question ouverte échoue sous certaines conditions
Lorsqu'un exercice est en mode de correction 'après le dernier essai de l'étape' ou 'depuis date', si on revient sur une copie (via l'option de reprise de copie), et qu'on essaie de modifier la réponse d'une question ouverte préalablement sauvegardée, la sauvegarde/changement de page échoue. Erreur 422 Unprocessable Entity:
[{'path':'|/score','message':'instance must be of type number'},{'path':'','message':'instance must match all the schemas listed in allOf'}]
Le problème n'est pas présent si la correction est désactivé ou en mode 'A la fin du test'.
```

