### PR TITLE
[CoreBundle] Use the registerable group list instead of managed.

### DIFF
--- a/main/core/Controller/APINew/User/GroupController.php
+++ b/main/core/Controller/APINew/User/GroupController.php
@@ -55,7 +55,7 @@ class GroupController extends AbstractCrudController
           }, $user->getOrganizations())];
 
         return new JsonResponse($this->finder->search(
-            'Claroline\CoreBundle\Entity\Group',
+            Group::class,
             array_merge($request->query->all(), ['hiddenFilters' => $filters])
         ));
     }
@@ -81,7 +81,7 @@ class GroupController extends AbstractCrudController
           }, $user->getAdministratedOrganizations()->toArray())];
 
         return new JsonResponse($this->finder->search(
-            'Claroline\CoreBundle\Entity\Group',
+            Group::class,
             array_merge($request->query->all(), ['hiddenFilters' => $filters])
         ));
     }

--- a/main/core/Resources/modules/workspace/actions/register-groups.js
+++ b/main/core/Resources/modules/workspace/actions/register-groups.js
@@ -18,7 +18,7 @@ export default (workspaces, refresher) => ({
   // open a modal to select the list of groups to register
   modal: [MODAL_GROUPS_PICKER, {
     title: trans('register_groups'),
-    url: ['apiv2_group_list_managed'],
+    url: ['apiv2_group_list_registerable'],
 
     // load the list of common roles for selected workspaces
     selectAction: (groups) => ({

--- a/main/core/Resources/modules/workspace/user/role/components/role.jsx
+++ b/main/core/Resources/modules/workspace/user/role/components/role.jsx
@@ -221,7 +221,7 @@ const Role = connect(
         definition: GroupList.definition,
         card: GroupList.card,
         fetch: {
-          url: ['apiv2_group_list_managed'],
+          url: ['apiv2_group_list_registerable'],
           autoload: true
         },
         handleSelect: (selected) => dispatch(actions.addGroups(roleId, selected))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed issues | #5713 

J'avoue ne pas avoir pris le temps de reproduire mais je suis quasi sur que ça vient d'une de ces urls et que l'autre pose problème mais que personne ne s'en est jamais plaint.

apiv2_group_list_registerable montre la liste des groupes avec lesquels on a une organisation commune.
apiv2_group_list_managed montre la liste des groupes dont on est gestionnaire de l'organisation.

=> apiv2_group_list_managed est utilisée dans les requête des l'outils d'administration des utilsateurs
=> apiv2_group_list_registerable est (ou devrait s'il elle ne l'est pas) être utilisée dans les autres cas (sinon la liste peut être vide).
