### PR TITLE
[CoreBundle] Check if role exists before creating right.

### DIFF
--- a/main/core/Manager/Workspace/Transfer/OrderedToolTransfer.php
+++ b/main/core/Manager/Workspace/Transfer/OrderedToolTransfer.php
@@ -120,11 +120,13 @@ class OrderedToolTransfer
                     ]);
                 }
 
-                $rights = new ToolRights();
-                $rights->setRole($role);
-                $rights->setMask($restriction['mask']);
-                $rights->setOrderedTool($orderedTool);
-                $om->persist($rights);
+                if ($role) {
+                    $rights = new ToolRights();
+                    $rights->setRole($role);
+                    $rights->setMask($restriction['mask']);
+                    $rights->setOrderedTool($orderedTool);
+                    $om->persist($rights);
+                }
             }
 
             //use event instead maybe ? or tagged service


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed issues | #5794 

C'est plus une vérif anti plantage qu'un véritable fix. Normalement le role devrait exister mais je connais pas du tout le système de synchronisation.
