### PR TITLE
[CoreBundle] Text properly refreshed in the ui on update.

### DIFF
--- a/main/app/Controller/AbstractCrudController.php
+++ b/main/app/Controller/AbstractCrudController.php
@@ -278,6 +278,9 @@ abstract class AbstractCrudController extends AbstractApiController
             return new JsonResponse($object, 400);
         }
 
+        //just in case so we really returns the proper object
+        $this->om->refresh($object);
+
         return new JsonResponse(
             $this->serializer->serialize($object, $options)
         );


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed issues | comma-separated list of issues fixed by the PR, if any

I noticed it when toying around with mercure.
It's because a new entity is created in the Serializer. There might be other instances of such a case.


