### PR TITLE
[CoreBundle] Don't rename the role on update.

### DIFF
--- a/main/core/API/Serializer/User/RoleSerializer.php
+++ b/main/core/API/Serializer/User/RoleSerializer.php
@@ -262,6 +262,7 @@ class RoleSerializer
             $this->sipe('name', 'setName', $data, $role);
 
             $this->sipe('type', 'setType', $data, $role);
+
             if (isset($data['translationKey'])) {
                 $role->setTranslationKey($data['translationKey']);
                 //this is if it's not a workspace and we send the translationKey role
@@ -279,7 +280,10 @@ class RoleSerializer
             if (isset($data['workspace']['uuid'])) {
                 $workspace = $this->om->getRepository('ClarolineCoreBundle:Workspace\Workspace')
                     ->findOneBy(['uuid' => $data['workspace']['uuid']]);
-                $role->setName('ROLE_WS_'.str_replace(' ', '_', strtoupper($data['translationKey'])).'_'.$data['workspace']['uuid']);
+
+                if (!$role->getName()) {
+                    $role->setName('ROLE_WS_'.str_replace(' ', '_', strtoupper($data['translationKey'])).'_'.$data['workspace']['uuid']);
+                }
 
                 if ($workspace) {
                     $role->setWorkspace($workspace);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed issues | #5847 

Role should not be renamed as it's used like an identifier. The translation key can be modified and and be used to generate the name the first time but that's all.


