### PR TITLE
fixes travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
 
 services:
   - xvfb
+  - mysql
   
 mysql:
   adapter: mysql2

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ env:
   matrix:
     - DB=mysql
 
+
+services:
+  - xvfb
+  
 mysql:
   adapter: mysql2
   database: claroline_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ before_install:
   # prepare execution of chromium in js tests
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
   # ensure the target branch is present (original clone is shallowed/single-branched)
   - git remote set-branches --add origin $TRAVIS_BRANCH
   - git fetch origin


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

Travis a changé l'env de build par défaut qui a introduit un breaking change : https://benlimmer.com/2019/01/14/travis-ci-xvfb/.

Je sais pas trop comment ça va se passer avec les PRs déjà ouverte. Elles ne buildent pas sur le même environnement (même quand on les relance). Il faudra peut être clôturer les PRs et les rouvrir...
