### PR TITLE
Command for slugs restoration

### DIFF
--- a/main/core/Command/DatabaseIntegrity/ResourceSlugBuilderCommand.php
+++ b/main/core/Command/DatabaseIntegrity/ResourceSlugBuilderCommand.php
@@ -23,7 +23,6 @@ class ResourceSlugBuilderCommand extends ContainerAwareCommand
         $consoleLogger = ConsoleLogger::get($output);
         $this->setLogger($consoleLogger);
 
-        $tableManager = $this->getContainer()->get('claroline.persistence.table_manager');
         $conn = $this->getContainer()->get('doctrine.dbal.default_connection');
 
         $query = '

--- a/main/core/Command/DatabaseIntegrity/ResourceSlugBuilderCommand.php
+++ b/main/core/Command/DatabaseIntegrity/ResourceSlugBuilderCommand.php
@@ -26,8 +26,8 @@ class ResourceSlugBuilderCommand extends ContainerAwareCommand
         $tableManager = $this->getContainer()->get('claroline.persistence.table_manager');
         $conn = $this->getContainer()->get('doctrine.dbal.default_connection');
 
-        $query = "
-            CREATE TABLE claro_resource_node_temp
+        $query = '
+            CREATE TABLE claro_resource_node_temp_'.uniqud()."
             AS (SELECT * FROM claro_resource_node WHERE slug LIKE '%?%')
         ";
         try {

--- a/main/core/Command/DatabaseIntegrity/ResourceSlugBuilderCommand.php
+++ b/main/core/Command/DatabaseIntegrity/ResourceSlugBuilderCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Claroline\CoreBundle\Command\DatabaseIntegrity;
+
+use Claroline\AppBundle\Logger\ConsoleLogger;
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ResourceSlugBuilderCommand extends ContainerAwareCommand
+{
+    protected function configure()
+    {
+        $this->setName('claroline:resource-slug:builder')
+            ->addOption('clear', 'c', InputOption::VALUE_NONE, 'clear temporary')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'no dry run')
+            ->setDescription('rebuild the resource slugs');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $consoleLogger = ConsoleLogger::get($output);
+        $this->setLogger($consoleLogger);
+
+        $tableManager = $this->getContainer()->get('claroline.persistence.table_manager');
+        $conn = $this->getContainer()->get('doctrine.dbal.default_connection');
+
+        $query = "
+            CREATE TABLE claro_resource_node_temp
+            AS (SELECT * FROM claro_resource_node WHERE slug LIKE '%?%')
+        ";
+        try {
+            $conn->query($query);
+        } catch (\Exception $e) {
+            $this->log('No need backup');
+        }
+
+        $this->log('Generating slugs for resources with bad slugs...');
+        $sql = "
+            UPDATE claro_resource_node node SET slug = REGEXP_REPLACE(SUBSTR(CONCAT(node.name, '-', node.id),1,100), '[^A-Za-z0-9]+', '-') WHERE slug LIKE '%?%'
+        ";
+        $stmt = $conn->prepare($sql);
+        $stmt->execute();
+    }
+
+    private function setLogger($logger)
+    {
+        $this->consoleLogger = $logger;
+    }
+
+    private function log($log)
+    {
+        $this->consoleLogger->info($log);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed issues | comma-separated list of issues fixed by the PR, if any

Ici on fait que garder une copie de la table claro_resource_node et de restaurer de modifier les slugs avec un "?".

J'aurais bien voulu les modifier en plus mais c'est trop compliqué. Les urls en db sont changées et un urlencode ne transforme pas la chaine de caractère comme il faut.

C'est encore une autre forme d'encodage, mais je sais pas laquelle.

