### PR TITLE
[CoreBundle] exposes archived workspaces management

### DIFF
--- a/main/app/Resources/translations/actions.en.json
+++ b/main/app/Resources/translations/actions.en.json
@@ -1,6 +1,7 @@
 {
   "add": "Add",
   "administrate": "Administrate",
+  "archive": "Archive",
   "cancel": "Cancel",
   "change": "Change",
   "click_here": "Click here",
@@ -78,6 +79,7 @@
   "sort": "Sort",
   "start": "Start",
   "test": "Test",
+  "unarchive": "Unarchive",
   "unfollow": "Unfollow",
   "unlike": "Unlike",
   "unlock": "Unlock",

--- a/main/app/Resources/translations/actions.fr.json
+++ b/main/app/Resources/translations/actions.fr.json
@@ -1,6 +1,7 @@
 {
   "add": "Ajouter",
   "administrate": "Administrer",
+  "archive": "Archiver",
   "cancel": "Annuler",
   "change": "Changer",
   "click_here": "Cliquez ici",
@@ -78,6 +79,7 @@
   "sort": "Trier",
   "start": "Commencer",
   "test": "Tester",
+  "unarchive": "Désarchiver",
   "unfollow": "Ne plus suivre",
   "unlike": "Je n'aime plus",
   "unlock": "Déverrouiller",

--- a/main/core/API/Finder/Workspace/WorkspaceFinder.php
+++ b/main/core/API/Finder/Workspace/WorkspaceFinder.php
@@ -47,7 +47,10 @@ class WorkspaceFinder extends AbstractFinder
 
     public function configureQueryBuilder(QueryBuilder $qb, array $searches = [], array $sortBy = null, array $options = ['count' => false, 'page' => 0, 'limit' => -1])
     {
-        $searches['archived'] = false;
+        // force non archived workspaces only if not explicitly requested
+        if (!array_key_exists('archived', $searches)) {
+            $searches['archived'] = false;
+        }
 
         foreach ($searches as $filterName => $filterValue) {
             //remap some filters...
@@ -168,14 +171,6 @@ class WorkspaceFinder extends AbstractFinder
                     if ($filterValue) {
                         $qb->andWhere('r.name like :ROLE_WS_MANAGER');
                         $qb->setParameter('ROLE_WS_MANAGER', 'ROLE_WS_MANAGER%');
-                    }
-                    break;
-                case 'archived':
-                    if (false === $filterValue) {
-                        $qb->andWhere($qb->expr()->orX(
-                            $qb->expr()->isNull('obj.archived'),
-                            $qb->expr()->eq('obj.archived', 0)
-                        ));
                     }
                     break;
                 default:

--- a/main/core/API/Serializer/Workspace/WorkspaceSerializer.php
+++ b/main/core/API/Serializer/Workspace/WorkspaceSerializer.php
@@ -127,23 +127,28 @@ class WorkspaceSerializer
      */
     public function serialize(Workspace $workspace, array $options = [])
     {
+        $thumbnail = null;
+        if ($workspace->getThumbnail()) {
+            /** @var PublicFile $thumbnail */
+            $thumbnail = $this->om->getRepository(PublicFile::class)->findOneBy([
+                'url' => $workspace->getThumbnail(),
+            ]);
+        }
+
+        $poster = null;
+        if ($workspace->getPoster()) {
+            /** @var PublicFile $poster */
+            $poster = $this->om->getRepository(PublicFile::class)->findOneBy([
+                'url' => $workspace->getPoster(),
+            ]);
+        }
+
         $serialized = [
             'name' => $workspace->getName(),
             'code' => $workspace->getCode(),
             'slug' => $workspace->getSlug(),
-            'thumbnail' => $workspace->getThumbnail() && $this->om->getRepository(PublicFile::class)->findOneBy([
-                  'url' => $workspace->getThumbnail(),
-              ]) ? $this->publicFileSerializer->serialize($this->om->getRepository(PublicFile::class)->findOneBy([
-                  'url' => $workspace->getThumbnail(),
-              ])
-            ) : null,
-            'poster' => $workspace->getPoster() && $this->om->getRepository(PublicFile::class)->findOneBy([
-                  'url' => $workspace->getPoster(),
-              ]) ? $this->publicFileSerializer->serialize(
-                $this->om->getRepository(PublicFile::class)->findOneBy([
-                    'url' => $workspace->getPoster(),
-              ])
-            ) : null,
+            'thumbnail' => $thumbnail ? $this->publicFileSerializer->serialize($thumbnail) : null,
+            'poster' => $poster ? $this->publicFileSerializer->serialize($poster) : null,
             'permissions' => [ // TODO it will decrease perfs, should be tested, but it is required in lists
                 'open' => $this->authorization->isGranted('OPEN', $workspace),
                 'delete' => $this->authorization->isGranted('DELETE', $workspace),
@@ -219,6 +224,7 @@ class WorkspaceSerializer
         $data = [
             'lang' => $workspace->getLang(),
             'forceLang' => (bool) $workspace->getLang(),
+            'archived' => $workspace->isArchived(),
             'model' => $workspace->isModel(),
             'personal' => $workspace->isPersonal(),
             'description' => $workspace->getDescription(),

--- a/main/core/Entity/Workspace/Workspace.php
+++ b/main/core/Entity/Workspace/Workspace.php
@@ -739,7 +739,7 @@ class Workspace
         $this->archived = $archived;
     }
 
-    public function getArchived()
+    public function isArchived()
     {
         return $this->archived;
     }

--- a/main/core/Manager/Workspace/WorkspaceManager.php
+++ b/main/core/Manager/Workspace/WorkspaceManager.php
@@ -751,7 +751,7 @@ class WorkspaceManager
         return $workspaceRoles;
     }
 
-    public function archive(Workspace $workspace, array $options = [])
+    public function archive(Workspace $workspace)
     {
         //rename with [archive] and ids
         $workspace->setName('[archive]'.$workspace->getName());
@@ -759,6 +759,17 @@ class WorkspaceManager
         $workspace->setArchived(true);
 
         $this->om->persist($workspace);
+
+        return $workspace;
+    }
+
+    public function unarchive(Workspace $workspace)
+    {
+        $workspace->setArchived(false);
+
+        $this->om->persist($workspace);
+
+        return $workspace;
     }
 
     public function getDefaultModel($isPersonal = false, $restore = false)

--- a/main/core/Resources/modules/plugin.js
+++ b/main/core/Resources/modules/plugin.js
@@ -51,6 +51,7 @@ registry.add('ClarolineCoreBundle', {
 
     workspace: {
       'about'          : () => { return import(/* webpackChunkName: "core-action-workspace-about" */           '#/main/core/workspace/actions/about') },
+      'archive'        : () => { return import(/* webpackChunkName: "core-action-workspace-archive" */         '#/main/core/workspace/actions/archive') },
       'configure'      : () => { return import(/* webpackChunkName: "core-action-workspace-configure" */       '#/main/core/workspace/actions/configure') },
       'copy'           : () => { return import(/* webpackChunkName: "core-action-workspace-copy" */            '#/main/core/workspace/actions/copy') },
       'copy-model'     : () => { return import(/* webpackChunkName: "core-action-workspace-copy-model" */      '#/main/core/workspace/actions/copy-model') },
@@ -60,6 +61,7 @@ registry.add('ClarolineCoreBundle', {
       'register-users' : () => { return import(/* webpackChunkName: "core-action-workspace-register-users" */  '#/main/core/workspace/actions/register-users') },
       'register-groups': () => { return import(/* webpackChunkName: "core-action-workspace-register-groups" */ '#/main/core/workspace/actions/register-groups') },
       'register-self'  : () => { return import(/* webpackChunkName: "core-action-workspace-register-self" */   '#/main/core/workspace/actions/register-self') },
+      'unarchive'      : () => { return import(/* webpackChunkName: "core-action-workspace-unarchive" */       '#/main/core/workspace/actions/unarchive') },
       'unregister-self': () => { return import(/* webpackChunkName: "core-action-workspace-unregister-self" */ '#/main/core/workspace/actions/unregister-self') },
       'view-as'        : () => { return import(/* webpackChunkName: "core-action-workspace-view-as" */         '#/main/core/workspace/actions/view-as') }
     },

--- a/main/core/Resources/modules/tools/workspaces/components/tool.jsx
+++ b/main/core/Resources/modules/tools/workspaces/components/tool.jsx
@@ -29,9 +29,9 @@ const WorkspacesTool = (props) =>
       <Routes
         path={props.path}
         routes={[
-          {path: '/new',            render: () => trans('new_workspace', {}, 'workspace'), disabled: !props.creatable},
-          {path: '/registered',     render: () => trans('my_workspaces', {}, 'workspace')},
-          {path: '/public',         render: () => trans('public_workspaces', {}, 'workspace')},
+          {path: '/new',        render: () => trans('new_workspace', {}, 'workspace'), disabled: !props.creatable},
+          {path: '/registered', render: () => trans('my_workspaces', {}, 'workspace')},
+          {path: '/public',     render: () => trans('public_workspaces', {}, 'workspace')},
           {path: '/managed',        render: () => trans('managed_workspaces', {}, 'workspace')},
           {path: '/model',          render: () => trans('workspace_models', {}, 'workspace'), disabled: !props.creatable}
         ]}
@@ -77,6 +77,18 @@ const WorkspacesTool = (props) =>
               <WorkspaceList
                 url={['apiv2_workspace_list_managed']}
                 name="workspaces.managed"
+                customDefinition={[
+                  {
+                    name: 'meta.archived',
+                    label: trans('archived'),
+                    type: 'boolean',
+                    alias: 'archived',
+                    displayed: false,
+                    displayable: false,
+                    sortable: false,
+                    filterable: true
+                  }
+                ]}
               />
             )
 

--- a/main/core/Resources/modules/workspace/actions/archive.js
+++ b/main/core/Resources/modules/workspace/actions/archive.js
@@ -1,0 +1,40 @@
+import get from 'lodash/get'
+
+import {url} from '#/main/app/api'
+import {ASYNC_BUTTON} from '#/main/app/buttons'
+import {hasPermission} from '#/main/app/security'
+import {trans, transChoice} from '#/main/app/intl/translation'
+
+/**
+ * Archives some workspaces.
+ *
+ * @param {Array}  workspaces - the list of workspaces on which we want to execute the action.
+ * @param {object} refresher  - an object containing methods to update context in response to action (eg. add, update, delete).
+ */
+export default (workspaces, refresher) => {
+  const processable = workspaces.filter(workspace => hasPermission('administrate', workspace) && !get(workspace, 'meta.model') && !get(workspace, 'meta.archived'))
+
+  return {
+    name: 'archive',
+    type: ASYNC_BUTTON,
+    icon: 'fa fa-fw fa-box',
+    label: trans('archive', {}, 'actions'),
+    displayed: 0 !== processable.length,
+    confirm: {
+      title: trans('workspaces_archive_title'),
+      message: transChoice('workspaces_archive_question', processable.length, {count: processable.length})
+    },
+    request: {
+      url: url(
+        ['apiv2_workspace_archive'],
+        {ids: processable.map(workspace => workspace.uuid)}
+      ),
+      request: {
+        method: 'PUT'
+      },
+      success: (response) => refresher.update(response)
+    },
+    group: trans('management'),
+    scope: ['object', 'collection']
+  }
+}

--- a/main/core/Resources/modules/workspace/actions/unarchive.js
+++ b/main/core/Resources/modules/workspace/actions/unarchive.js
@@ -1,0 +1,36 @@
+import get from 'lodash/get'
+
+import {url} from '#/main/app/api'
+import {ASYNC_BUTTON} from '#/main/app/buttons'
+import {hasPermission} from '#/main/app/security'
+import {trans} from '#/main/app/intl/translation'
+
+/**
+ * Unarchives some workspaces.
+ *
+ * @param {Array}  workspaces - the list of workspaces on which we want to execute the action.
+ * @param {object} refresher  - an object containing methods to update context in response to action (eg. add, update, delete).
+ */
+export default (workspaces, refresher) => {
+  const processable = workspaces.filter(workspace => hasPermission('administrate', workspace) && !get(workspace, 'meta.model') && get(workspace, 'meta.archived'))
+
+  return {
+    name: 'unarchive',
+    type: ASYNC_BUTTON,
+    icon: 'fa fa-fw fa-box-open',
+    label: trans('unarchive', {}, 'actions'),
+    displayed: 0 !== processable.length,
+    request: {
+      url: url(
+        ['apiv2_workspace_unarchive'],
+        {ids: processable.map(workspace => workspace.uuid)}
+      ),
+      request: {
+        method: 'PUT'
+      },
+      success: (response) => refresher.update(response)
+    },
+    group: trans('management'),
+    scope: ['object', 'collection']
+  }
+}

--- a/main/core/Resources/modules/workspace/components/card.jsx
+++ b/main/core/Resources/modules/workspace/components/card.jsx
@@ -17,10 +17,10 @@ const WorkspaceCard = props =>
     title={props.data.name}
     subtitle={props.data.code}
     flags={[
-      get(props.data, 'meta.personal')                       && ['fa fa-user',      trans('personal_workspace')],
-      get(props.data, 'meta.model')                          && ['fa fa-briefcase', trans('model')],
-      get(props.data, 'display.displayable')                 && ['fa fa-eye',       trans('displayable_in_workspace_list')],
-      get(props.data, 'registration.selfRegistration')       && ['fa fa-globe',     trans('public_registration')],
+      get(props.data, 'meta.archived')                       && ['fa fa-box',       trans('workspace_archived', {}, 'workspace')],
+      get(props.data, 'meta.personal')                       && ['fa fa-user',      trans('workspace_personal', {}, 'workspace')],
+      get(props.data, 'restrictions.hidden')                 && ['fa fa-eye-slash', trans('workspace_hidden', {}, 'workspace')],
+      get(props.data, 'registration.selfRegistration')       && ['fa fa-globe',     trans('workspace_public_registration', {}, 'workspace')],
       get(props.data, 'registration.waitingForRegistration') && ['fa fa-hourglass', trans('pending')]
     ].filter(flag => !!flag)}
     contentText={get(props.data, 'meta.description')}

--- a/main/core/Resources/modules/workspace/components/list.jsx
+++ b/main/core/Resources/modules/workspace/components/list.jsx
@@ -95,7 +95,7 @@ const Workspaces = (props) => {
             objectClass: 'Claroline\\CoreBundle\\Entity\\Workspace\\Workspace'
           }
         }
-      ]}
+      ].concat(props.customDefinition)}
       card={WorkspaceCard}
 
       primaryAction={(row) => getDefaultAction(row, workspacesRefresher, props.basePath, props.currentUser)}
@@ -109,11 +109,15 @@ Workspaces.propTypes = {
   currentUser: T.object,
   name: T.string.isRequired,
   url: T.oneOfType([T.string, T.array]).isRequired,
+  customDefinition: T.arrayOf(T.shape({
+    // TODO : data list prop types
+  })),
   invalidate: T.func.isRequired
 }
 
 Workspaces.defaultProps = {
-  basePath: ''
+  basePath: '',
+  customDefinition: []
 }
 
 const WorkspaceList = connect(

--- a/main/core/Resources/modules/workspace/components/metrics.jsx
+++ b/main/core/Resources/modules/workspace/components/metrics.jsx
@@ -15,7 +15,7 @@ const WorkspaceMetrics = props =>
         <CountGauge
           className="metric-card-gauge"
           value={props.workspace.meta.totalUsers}
-          total={props.workspace.restrictions.maxUsers}
+          total={props.workspace.restrictions.maxUsers || props.workspace.meta.totalUsers}
           displayValue={(value) => number(value, true)}
           width={props.width}
           height={props.height}
@@ -30,7 +30,7 @@ const WorkspaceMetrics = props =>
         <CountGauge
           className="metric-card-gauge"
           value={props.workspace.meta.totalResources}
-          total={props.workspace.restrictions.maxResources}
+          total={props.workspace.restrictions.maxResources || props.workspace.meta.totalResources}
           displayValue={(value) => number(value, true)}
           width={props.width}
           height={props.height}
@@ -45,7 +45,7 @@ const WorkspaceMetrics = props =>
         <CountGauge
           className="metric-card-gauge"
           value={props.workspace.meta.usedStorage}
-          total={props.workspace.restrictions.maxStorage}
+          total={props.workspace.restrictions.maxStorage || props.workspace.meta.usedStorage}
           displayValue={(value) => fileSize(value, true)}
           unit={trans('bytes_short')}
           width={props.width}

--- a/main/core/Resources/modules/workspace/modals/about/components/about.jsx
+++ b/main/core/Resources/modules/workspace/modals/about/components/about.jsx
@@ -58,39 +58,48 @@ const AboutModal = props =>
               type: 'string'
             }, {
               name: 'meta.model',
-              label: 'Cet espace d\'activités n\'est pas un modèle.',
+              label: trans('workspace_model', {}, 'workspace'),
               type: 'boolean',
               hideLabel: true,
+              displayed: get(props.workspace, 'meta.model'),
               options: {
-                icon: 'fa fa-fw fa-briefcase',
-                labelChecked: 'Cet espace d\'activités est un modèle.'
+                icon: 'fa fa-fw fa-briefcase'
               }
             }, {
               name: 'meta.personal',
-              label: 'Cet espace d\'activités n\'est pas un espace personnel.',
+              label: trans('workspace_personal', {}, 'workspace'),
               type: 'boolean',
               hideLabel: true,
+              displayed: get(props.workspace, 'meta.personal'),
               options: {
-                icon: 'fa fa-fw fa-user',
-                labelChecked: 'Cet espace d\'activités est un espace personnel.'
+                icon: 'fa fa-fw fa-user'
+              }
+            }, {
+              name: 'meta.archived',
+              label: trans('workspace_archived', {}, 'workspace'),
+              type: 'boolean',
+              hideLabel: true,
+              displayed: get(props.workspace, 'meta.archived'),
+              options: {
+                icon: 'fa fa-fw fa-box'
               }
             }, {
               name: 'registration.selfRegistration',
-              label: 'Les inscriptions sont gérées par les gestionnaires.',
+              label: trans('workspace_manager_registration', {}, 'workspace'),
               type: 'boolean',
               hideLabel: true,
               options: {
                 icon: 'fa fa-fw fa-user-plus',
-                labelChecked: 'Les inscriptions sont publiques.'
+                labelChecked: trans('workspace_public_registration', {}, 'workspace')
               }
             }, {
               name: 'registration.selfUnregistration',
-              label: 'Les désinscriptions sont gérées par les gestionnaires.',
+              label: trans('workspace_manager_unregistration', {}, 'workspace'),
               type: 'boolean',
               hideLabel: true,
               options: {
                 icon: 'fa fa-fw fa-user-times',
-                labelChecked: 'Les désinscriptions sont publiques.'
+                labelChecked: trans('workspace_public_unregistration', {}, 'workspace')
               }
             }
           ]

--- a/main/core/Resources/translations/platform.en.json
+++ b/main/core/Resources/translations/platform.en.json
@@ -1762,5 +1762,8 @@
     "disabled": "Disabled",
     "default": "Default",
     "standard": "Standard",
-    "history": "History"
+    "history": "History",
+    "workspaces_archive_title": "Archive workspaces",
+    "workspaces_archive_question": "{1} Are you sure you want to archive the selected workspace ?|[2,Inf[ Are you sure you want to archive the %count% selected workspaces ?",
+    "archived": "Archived"
 }

--- a/main/core/Resources/translations/platform.fr.json
+++ b/main/core/Resources/translations/platform.fr.json
@@ -1795,5 +1795,8 @@
     "disabled": "Inactif",
     "default": "Défaut",
     "standard": "Standard",
-    "history": "Historique"
+    "history": "Historique",
+    "workspaces_archive_title": "Archiver des espaces d'activités",
+    "workspaces_archive_question": "{1} Êtes-vous sûr de vouloir archiver l'espace d'activités sélectionné ?|[2,Inf[ Êtes-vous sur de vouloir archiver les %count% espaces d'activités sélectionnés ?",
+    "archived": "Archivé"
 }

--- a/main/core/Resources/translations/workspace.en.json
+++ b/main/core/Resources/translations/workspace.en.json
@@ -6,5 +6,14 @@
   "managed_workspaces": "Managed workspaces",
   "my_workspaces": "My workspaces",
   "public_workspaces": "Public workspaces",
-  "workspace_models": "Models of workspaces"
+  "workspace_models": "Models of workspaces",
+
+  "workspace_archived": "This workspace is archived.",
+  "workspace_hidden": "This workspace is hidden.",
+  "workspace_model": "This workspace is a model.",
+  "workspace_personal": "This workspace is a personal workspace.",
+  "workspace_manager_registration": "Registration is managed by managers.",
+  "workspace_public_registration": "Registration is public.",
+  "workspace_manager_unregistration": "Unregistration is managed by managers.",
+  "workspace_public_unregistration": "Unregistration is public."
 }

--- a/main/core/Resources/translations/workspace.fr.json
+++ b/main/core/Resources/translations/workspace.fr.json
@@ -6,5 +6,14 @@
   "managed_workspaces": "Espaces d'activités gérés",
   "my_workspaces": "Mes espaces d'activités",
   "public_workspaces": "Espaces d'activités publics",
-  "workspace_models": "Modèles d'espaces d'activités"
+  "workspace_models": "Modèles d'espaces d'activités",
+
+  "workspace_archived": "Cet espace d'activité est archivé.",
+  "workspace_hidden": "Cet espace d'activité est caché.",
+  "workspace_model": "Cet espace d'activité est un modèle.",
+  "workspace_personal": "Cet espace d'activité est un espace personnel.",
+  "workspace_manager_registration": "Les inscriptions sont gérées par les gestionnaires.",
+  "workspace_public_registration": "Les inscriptions sont publiques.",
+  "workspace_manager_unregistration": "Les désinscriptions sont gérées par les gestionnaires.",
+  "workspace_public_unregistration": "Les désinscriptions sont publiques."
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no

- les actions Archiver/Désarchiver un espace sont maintenant disponibles dans l'outil "Espaces d'activités". NB. Il n'est pas possible d'archiver les modèles.
- Il est possible d'afficher les espaces archivés dans "Espaces d'activités gérés" de l'outil "Espaces d'activités". Par défaut, ils sont masqués, il y a un nouveau filtre pour les afficher.
- L'info est également disponible grâce à une icône sur les cartes des espaces archivés et dans la modale "A propos" des espaces (accessible via l'action "Voir les informations").

