### PR TITLE
[AppBundle] File upload fix if not auto upload.

### DIFF
--- a/main/app/Resources/modules/data/types/file/components/input.jsx
+++ b/main/app/Resources/modules/data/types/file/components/input.jsx
@@ -115,10 +115,10 @@ class FileComponent extends Component {
           </div>
         </button>
 
-        {!isEmpty(this.props.value) &&
+        {this.props.value &&
           <div className="file-thumbnails">
             <FileThumbnail
-              type={getType(this.props.value.mimeType)}
+              type={getType(this.props.value.mimeType || this.props.value.type)}
               data={this.props.value}
               canEdit={false}
               canExpand={false}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed issues | comma-separated list of issues fixed by the PR, if any

Si on utilise pas la fonction d'autoupload, c'est un objet file en JS et les props sont pas exactement les même.
Aussi le isEmpty pose problème pour une raison inconnue =/. Après ça me semble plus simple sans, je vois pas dans quel cas ça peut être utile.

Fix https://github.com/claroline/Distribution/issues/6263