### PR TITLE
[Logging] Simplify the Log entity.

### DIFF
--- a/main/core/Entity/Log/Log.php
+++ b/main/core/Entity/Log/Log.php
@@ -17,7 +17,6 @@ use Claroline\CoreBundle\Entity\Resource\ResourceType;
 use Claroline\CoreBundle\Entity\Role;
 use Claroline\CoreBundle\Entity\User;
 use Claroline\CoreBundle\Entity\Workspace\Workspace;
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\ORM\Mapping\Index;
 use Gedmo\Mapping\Annotation as Gedmo;
@@ -87,18 +86,6 @@ class Log
     protected $doerSessionId;
 
     /**
-     * @ORM\ManyToMany(targetEntity="Claroline\CoreBundle\Entity\Role")
-     * @ORM\JoinTable(name="claro_log_doer_platform_roles")
-     */
-    protected $doerPlatformRoles;
-
-    /**
-     * @ORM\ManyToMany(targetEntity="Claroline\CoreBundle\Entity\Role")
-     * @ORM\JoinTable(name="claro_log_doer_workspace_roles")
-     */
-    protected $doerWorkspaceRoles;
-
-    /**
      * @ORM\ManyToOne(targetEntity="Claroline\CoreBundle\Entity\User")
      * @ORM\JoinColumn(onDelete="SET NULL")
      */
@@ -166,15 +153,6 @@ class Log
      * @ORM\Column(name="other_element_id", type="integer", nullable=true)
      */
     protected $otherElementId;
-
-    /**
-     * Constructor.
-     */
-    public function __construct()
-    {
-        $this->doerPlatformRoles = new ArrayCollection();
-        $this->doerWorkspaceRoles = new ArrayCollection();
-    }
 
     /**
      * Get id.
@@ -352,74 +330,6 @@ class Log
     public function getDoer()
     {
         return $this->doer;
-    }
-
-    /**
-     * Add doerPlatformRoles.
-     *
-     * @param Role $doerPlatformRoles
-     *
-     * @return Log
-     */
-    public function addDoerPlatformRole(Role $doerPlatformRoles)
-    {
-        $this->doerPlatformRoles[] = $doerPlatformRoles;
-
-        return $this;
-    }
-
-    /**
-     * Remove doerPlatformRoles.
-     *
-     * @param Role $doerPlatformRoles
-     */
-    public function removeDoerPlatformRole(Role $doerPlatformRoles)
-    {
-        $this->doerPlatformRoles->removeElement($doerPlatformRoles);
-    }
-
-    /**
-     * Get doerPlatformRoles.
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getDoerPlatformRoles()
-    {
-        return $this->doerPlatformRoles;
-    }
-
-    /**
-     * Add doerWorkspaceRoles.
-     *
-     * @param Role $doerWorkspaceRoles
-     *
-     * @return Log
-     */
-    public function addDoerWorkspaceRole(Role $doerWorkspaceRoles)
-    {
-        $this->doerWorkspaceRoles[] = $doerWorkspaceRoles;
-
-        return $this;
-    }
-
-    /**
-     * Remove doerWorkspaceRoles.
-     *
-     * @param Role $doerWorkspaceRoles
-     */
-    public function removeDoerWorkspaceRole(Role $doerWorkspaceRoles)
-    {
-        $this->doerWorkspaceRoles->removeElement($doerWorkspaceRoles);
-    }
-
-    /**
-     * Get doerWorkspaceRoles.
-     *
-     * @return \Doctrine\Common\Collections\Collection
-     */
-    public function getDoerWorkspaceRoles()
-    {
-        return $this->doerWorkspaceRoles;
     }
 
     /**

--- a/main/core/Entity/Log/Log.php
+++ b/main/core/Entity/Log/Log.php
@@ -98,12 +98,6 @@ class Log
     protected $receiverGroup;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Claroline\CoreBundle\Entity\User")
-     * @ORM\JoinColumn(onDelete="SET NULL")
-     */
-    protected $owner;
-
-    /**
      * @ORM\ManyToOne(targetEntity="Claroline\CoreBundle\Entity\Workspace\Workspace")
      * @ORM\JoinColumn(onDelete="SET NULL")
      */
@@ -378,30 +372,6 @@ class Log
     public function getReceiverGroup()
     {
         return $this->receiverGroup;
-    }
-
-    /**
-     * Set owner.
-     *
-     * @param User $owner
-     *
-     * @return Log
-     */
-    public function setOwner(User $owner = null)
-    {
-        $this->owner = $owner;
-
-        return $this;
-    }
-
-    /**
-     * Get owner.
-     *
-     * @return User
-     */
-    public function getOwner()
-    {
-        return $this->owner;
     }
 
     /**

--- a/main/core/Event/Log/LogGenericEvent.php
+++ b/main/core/Event/Log/LogGenericEvent.php
@@ -162,14 +162,6 @@ abstract class LogGenericEvent extends Event implements RestrictionnableInterfac
     }
 
     /**
-     * Returns the action's target owner (from resource).
-     */
-    public function getOwner()
-    {
-        return $this->owner;
-    }
-
-    /**
      * Returns the action's target tool's name.
      */
     public function getToolName()

--- a/main/core/Listener/Log/LogListener.php
+++ b/main/core/Listener/Log/LogListener.php
@@ -131,8 +131,6 @@ class LogListener
             ->setIsDisplayedInWorkspace($event->getIsDisplayedInWorkspace())
             ->setOtherElementId($event->getOtherElementId());
 
-        //Object properties
-        $log->setOwner($event->getOwner());
         if (!(LogUserDeleteEvent::ACTION === $event->getAction() && $event->getReceiver() === $doer)) {
             //Prevent self delete case
             //Sometimes, the entity manager has been cleared, so we must merge the doer.

--- a/main/core/Listener/Log/LogListener.php
+++ b/main/core/Listener/Log/LogListener.php
@@ -173,21 +173,6 @@ class LogListener
             $log->setRole($event->getRole());
         }
 
-        if (null !== $doer) {
-            $platformRoles = $this->roleManager->getPlatformRoles($doer);
-
-            foreach ($platformRoles as $platformRole) {
-                $log->addDoerPlatformRole($platformRole);
-            }
-
-            if (null !== $event->getWorkspace()) {
-                $workspaceRoles = $this->roleManager->getWorkspaceRolesForUser($doer, $event->getWorkspace());
-
-                foreach ($workspaceRoles as $workspaceRole) {
-                    $log->addDoerWorkspaceRole($workspaceRole);
-                }
-            }
-        }
         if (null !== $event->getResource()) {
             $log->setResourceType($event->getResource()->getResourceType());
         }
@@ -206,16 +191,27 @@ class LogListener
                 'publicUrl' => $doer->getPublicUrl(),
             ];
 
-            if (count($log->getDoerPlatformRoles()) > 0) {
+            $doerPlatformRoles = $this->roleManager->getPlatformRoles($doer);
+
+            if ($event->getWorkspace()) {
+                $doerWorkspaceRoles = $this->roleManager->getWorkspaceRolesForUser($doer, $event->getWorkspace());
+            } else {
+                $doerWorkspaceRoles = [];
+            }
+
+            if (count($doerPlatformRoles) > 0) {
                 $doerPlatformRolesDetails = [];
-                foreach ($log->getDoerPlatformRoles() as $platformRole) {
+
+                foreach ($doerPlatformRoles as $platformRole) {
                     $doerPlatformRolesDetails[] = $platformRole->getTranslationKey();
                 }
+
                 $details['doer']['platformRoles'] = $doerPlatformRolesDetails;
             }
-            if (count($log->getDoerWorkspaceRoles()) > 0) {
+
+            if (count($doerWorkspaceRoles) > 0) {
                 $doerWorkspaceRolesDetails = [];
-                foreach ($log->getDoerWorkspaceRoles() as $workspaceRole) {
+                foreach ($doerWorkspaceRoles as $workspaceRole) {
                     $doerWorkspaceRolesDetails[] = $workspaceRole->getTranslationKey();
                 }
                 $details['doer']['workspaceRoles'] = $doerWorkspaceRolesDetails;

--- a/main/core/Resources/views/log/view_details_owner.html.twig
+++ b/main/core/Resources/views/log/view_details_owner.html.twig
@@ -8,17 +8,10 @@
         {% endif %}
     </h4>
 
-    {% if log.getOwner() and log.getDoer() and log.getOwner().getId() == log.getDoer().getId() %}
-        <dl class="dl-horizontal">
-            <dt></dt>
-            <dd>{{ ('log_himself')|trans({}, 'log') }}</dd>
-        </dl>
-    {% else %}
-        <dl class="dl-horizontal">
-            <dt>{{ ('last_name')|trans({}, 'platform') }}</dt>
-            <dd>{{ log.getDetails().owner.firstName }}</dd>
-            <dt>{{ ('first_name')|trans({}, 'platform') }}</dt>
-            <dd>{{ log.getDetails().owner.lastName }}</dd>
-        </dl>
-    {% endif %}
+    <dl class="dl-horizontal">
+        <dt>{{ ('last_name')|trans({}, 'platform') }}</dt>
+        <dd>{{ log.getDetails().owner.firstName }}</dd>
+        <dt>{{ ('first_name')|trans({}, 'platform') }}</dt>
+        <dd>{{ log.getDetails().owner.lastName }}</dd>
+    </dl>
 {% endif %}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed issues | comma-separated list of issues fixed by the PR, if any

J'ai pour le moment des erreurs bizarres avec les tables dynamique, donc je corrige/simplifie ce qui peut l'être à coté pour avancer quand même (new entity found in... c'est l'erreur de l'autre pr)
Donc y a surement un pb avec les metadatas des entités.

Les relation Many to Many entre la table de log et celle de role ne sont jamais utilisées.
Les getters ne sont pas utilisés et l'info est de toute façon stockée dans les détails.

A priori ce changement n'a aucun impact sur la plateforme, c'est juste plus simple.

Même chose avec le owner. La différence entre le owner et le doer est pas claire. C'est utilisé qu'à un endroit et je comprends pas en quoi c'est utile.
