### PR TITLE
[CoreBundle] remove is_locked from database claro_home_tab_config.

### DIFF
--- a/main/core/Migrations/pdo_mysql/Version20191004153353.php
+++ b/main/core/Migrations/pdo_mysql/Version20191004153353.php
@@ -16,26 +16,26 @@ class Version20191004153353 extends AbstractMigration
     {
         $this->addSql('
             CREATE TABLE claro_workspace_requirements (
-                id INT AUTO_INCREMENT NOT NULL, 
-                workspace_id INT NOT NULL, 
-                user_id INT DEFAULT NULL, 
-                role_id INT DEFAULT NULL, 
-                uuid VARCHAR(36) NOT NULL, 
-                UNIQUE INDEX UNIQ_894BE409D17F50A6 (uuid), 
-                INDEX IDX_894BE40982D40A1F (workspace_id), 
-                INDEX IDX_894BE409A76ED395 (user_id), 
-                INDEX IDX_894BE409D60322AC (role_id), 
-                UNIQUE INDEX workspace_user_requirements (workspace_id, user_id), 
-                UNIQUE INDEX workspace_role_requirements (workspace_id, role_id), 
+                id INT AUTO_INCREMENT NOT NULL,
+                workspace_id INT NOT NULL,
+                user_id INT DEFAULT NULL,
+                role_id INT DEFAULT NULL,
+                uuid VARCHAR(36) NOT NULL,
+                UNIQUE INDEX UNIQ_894BE409D17F50A6 (uuid),
+                INDEX IDX_894BE40982D40A1F (workspace_id),
+                INDEX IDX_894BE409A76ED395 (user_id),
+                INDEX IDX_894BE409D60322AC (role_id),
+                UNIQUE INDEX workspace_user_requirements (workspace_id, user_id),
+                UNIQUE INDEX workspace_role_requirements (workspace_id, role_id),
                 PRIMARY KEY(id)
             ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB
         ');
         $this->addSql('
             CREATE TABLE claro_workspace_required_resources (
-                requirements_id INT NOT NULL, 
-                resourcenode_id INT NOT NULL, 
-                INDEX IDX_85A0B2D9296B0ED5 (requirements_id), 
-                INDEX IDX_85A0B2D977C292AE (resourcenode_id), 
+                requirements_id INT NOT NULL,
+                resourcenode_id INT NOT NULL,
+                INDEX IDX_85A0B2D9296B0ED5 (requirements_id),
+                INDEX IDX_85A0B2D977C292AE (resourcenode_id),
                 PRIMARY KEY(
                     requirements_id, resourcenode_id
                 )
@@ -43,68 +43,68 @@ class Version20191004153353 extends AbstractMigration
         ');
         $this->addSql('
             CREATE TABLE claro_workspace_evaluation (
-                id INT AUTO_INCREMENT NOT NULL, 
-                workspace_id INT DEFAULT NULL, 
-                user_id INT DEFAULT NULL, 
-                user_name VARCHAR(255) NOT NULL, 
-                workspace_code VARCHAR(255) NOT NULL, 
-                evaluation_date DATETIME DEFAULT NULL, 
-                evaluation_status VARCHAR(255) DEFAULT NULL, 
-                duration INT DEFAULT NULL, 
-                score DOUBLE PRECISION DEFAULT NULL, 
-                score_min DOUBLE PRECISION DEFAULT NULL, 
-                score_max DOUBLE PRECISION DEFAULT NULL, 
-                custom_score VARCHAR(255) DEFAULT NULL, 
-                progression INT DEFAULT NULL, 
-                progression_max INT DEFAULT NULL, 
-                uuid VARCHAR(36) NOT NULL, 
-                UNIQUE INDEX UNIQ_E0FF6754D17F50A6 (uuid), 
-                INDEX IDX_E0FF675482D40A1F (workspace_id), 
-                INDEX IDX_E0FF6754A76ED395 (user_id), 
-                UNIQUE INDEX workspace_user_evaluation (workspace_id, user_id), 
+                id INT AUTO_INCREMENT NOT NULL,
+                workspace_id INT DEFAULT NULL,
+                user_id INT DEFAULT NULL,
+                user_name VARCHAR(255) NOT NULL,
+                workspace_code VARCHAR(255) NOT NULL,
+                evaluation_date DATETIME DEFAULT NULL,
+                evaluation_status VARCHAR(255) DEFAULT NULL,
+                duration INT DEFAULT NULL,
+                score DOUBLE PRECISION DEFAULT NULL,
+                score_min DOUBLE PRECISION DEFAULT NULL,
+                score_max DOUBLE PRECISION DEFAULT NULL,
+                custom_score VARCHAR(255) DEFAULT NULL,
+                progression INT DEFAULT NULL,
+                progression_max INT DEFAULT NULL,
+                uuid VARCHAR(36) NOT NULL,
+                UNIQUE INDEX UNIQ_E0FF6754D17F50A6 (uuid),
+                INDEX IDX_E0FF675482D40A1F (workspace_id),
+                INDEX IDX_E0FF6754A76ED395 (user_id),
+                UNIQUE INDEX workspace_user_evaluation (workspace_id, user_id),
                 PRIMARY KEY(id)
             ) DEFAULT CHARACTER SET UTF8 COLLATE UTF8_unicode_ci ENGINE = InnoDB
         ');
         $this->addSql('
-            ALTER TABLE claro_workspace_requirements 
-            ADD CONSTRAINT FK_894BE40982D40A1F FOREIGN KEY (workspace_id) 
-            REFERENCES claro_workspace (id) 
+            ALTER TABLE claro_workspace_requirements
+            ADD CONSTRAINT FK_894BE40982D40A1F FOREIGN KEY (workspace_id)
+            REFERENCES claro_workspace (id)
             ON DELETE CASCADE
         ');
         $this->addSql('
-            ALTER TABLE claro_workspace_requirements 
-            ADD CONSTRAINT FK_894BE409A76ED395 FOREIGN KEY (user_id) 
-            REFERENCES claro_user (id) 
+            ALTER TABLE claro_workspace_requirements
+            ADD CONSTRAINT FK_894BE409A76ED395 FOREIGN KEY (user_id)
+            REFERENCES claro_user (id)
             ON DELETE CASCADE
         ');
         $this->addSql('
-            ALTER TABLE claro_workspace_requirements 
-            ADD CONSTRAINT FK_894BE409D60322AC FOREIGN KEY (role_id) 
-            REFERENCES claro_role (id) 
+            ALTER TABLE claro_workspace_requirements
+            ADD CONSTRAINT FK_894BE409D60322AC FOREIGN KEY (role_id)
+            REFERENCES claro_role (id)
             ON DELETE CASCADE
         ');
         $this->addSql('
-            ALTER TABLE claro_workspace_required_resources 
-            ADD CONSTRAINT FK_85A0B2D9296B0ED5 FOREIGN KEY (requirements_id) 
-            REFERENCES claro_workspace_requirements (id) 
+            ALTER TABLE claro_workspace_required_resources
+            ADD CONSTRAINT FK_85A0B2D9296B0ED5 FOREIGN KEY (requirements_id)
+            REFERENCES claro_workspace_requirements (id)
             ON DELETE CASCADE
         ');
         $this->addSql('
-            ALTER TABLE claro_workspace_required_resources 
-            ADD CONSTRAINT FK_85A0B2D977C292AE FOREIGN KEY (resourcenode_id) 
-            REFERENCES claro_resource_node (id) 
+            ALTER TABLE claro_workspace_required_resources
+            ADD CONSTRAINT FK_85A0B2D977C292AE FOREIGN KEY (resourcenode_id)
+            REFERENCES claro_resource_node (id)
             ON DELETE CASCADE
         ');
         $this->addSql('
-            ALTER TABLE claro_workspace_evaluation 
-            ADD CONSTRAINT FK_E0FF675482D40A1F FOREIGN KEY (workspace_id) 
-            REFERENCES claro_workspace (id) 
+            ALTER TABLE claro_workspace_evaluation
+            ADD CONSTRAINT FK_E0FF675482D40A1F FOREIGN KEY (workspace_id)
+            REFERENCES claro_workspace (id)
             ON DELETE SET NULL
         ');
         $this->addSql('
-            ALTER TABLE claro_workspace_evaluation 
-            ADD CONSTRAINT FK_E0FF6754A76ED395 FOREIGN KEY (user_id) 
-            REFERENCES claro_user (id) 
+            ALTER TABLE claro_workspace_evaluation
+            ADD CONSTRAINT FK_E0FF6754A76ED395 FOREIGN KEY (user_id)
+            REFERENCES claro_user (id)
             ON DELETE SET NULL
         ');
     }
@@ -112,7 +112,7 @@ class Version20191004153353 extends AbstractMigration
     public function down(Schema $schema)
     {
         $this->addSql('
-            ALTER TABLE claro_workspace_required_resources 
+            ALTER TABLE claro_workspace_required_resources
             DROP FOREIGN KEY FK_85A0B2D9296B0ED5
         ');
         $this->addSql('

--- a/main/core/Migrations/pdo_mysql/Version20191022104610.php
+++ b/main/core/Migrations/pdo_mysql/Version20191022104610.php
@@ -33,7 +33,7 @@ class Version20191022104610 extends AbstractMigration
         ');
 
         $this->addSql('
-            ALTER TABLE claro_home_tab_config 
+            ALTER TABLE claro_home_tab_config
             ADD is_visible TINYINT(1) NOT NULL
         ');
     }

--- a/main/core/Migrations/pdo_mysql/Version20191031091700.php
+++ b/main/core/Migrations/pdo_mysql/Version20191031091700.php
@@ -15,31 +15,31 @@ class Version20191031091700 extends AbstractMigration
     public function up(Schema $schema)
     {
         $this->addSql('
-            ALTER TABLE claro_resource_node 
+            ALTER TABLE claro_resource_node
             DROP FOREIGN KEY FK_A76799FF54B9D732
         ');
         $this->addSql('
             DROP INDEX IDX_A76799FF54B9D732 ON claro_resource_node
         ');
         $this->addSql('
-            ALTER TABLE claro_resource_node 
+            ALTER TABLE claro_resource_node
             DROP icon_id
         ');
         $this->addSql('
-            ALTER TABLE claro_icon_set 
-            DROP icon_sprite, 
-            DROP icon_sprite_css, 
+            ALTER TABLE claro_icon_set
+            DROP icon_sprite,
+            DROP icon_sprite_css,
             DROP resource_stamp_icon
         ');
         $this->addSql('
-            ALTER TABLE claro_icon_item 
+            ALTER TABLE claro_icon_item
             DROP FOREIGN KEY FK_D727F16B91930DA
         ');
         $this->addSql('
             DROP INDEX IDX_D727F16B91930DA ON claro_icon_item
         ');
         $this->addSql('
-            ALTER TABLE claro_icon_item 
+            ALTER TABLE claro_icon_item
             DROP resource_icon_id
         ');
     }
@@ -47,32 +47,32 @@ class Version20191031091700 extends AbstractMigration
     public function down(Schema $schema)
     {
         $this->addSql('
-            ALTER TABLE claro_icon_item 
+            ALTER TABLE claro_icon_item
             ADD resource_icon_id INT DEFAULT NULL
         ');
         $this->addSql('
-            ALTER TABLE claro_icon_item 
-            ADD CONSTRAINT FK_D727F16B91930DA FOREIGN KEY (resource_icon_id) 
-            REFERENCES claro_resource_icon (id) 
+            ALTER TABLE claro_icon_item
+            ADD CONSTRAINT FK_D727F16B91930DA FOREIGN KEY (resource_icon_id)
+            REFERENCES claro_resource_icon (id)
             ON DELETE CASCADE
         ');
         $this->addSql('
             CREATE INDEX IDX_D727F16B91930DA ON claro_icon_item (resource_icon_id)
         ');
         $this->addSql('
-            ALTER TABLE claro_icon_set 
-            ADD icon_sprite VARCHAR(255) DEFAULT NULL COLLATE utf8_unicode_ci, 
-            ADD icon_sprite_css VARCHAR(255) DEFAULT NULL COLLATE utf8_unicode_ci, 
+            ALTER TABLE claro_icon_set
+            ADD icon_sprite VARCHAR(255) DEFAULT NULL COLLATE utf8_unicode_ci,
+            ADD icon_sprite_css VARCHAR(255) DEFAULT NULL COLLATE utf8_unicode_ci,
             ADD resource_stamp_icon VARCHAR(255) DEFAULT NULL COLLATE utf8_unicode_ci
         ');
         $this->addSql('
-            ALTER TABLE claro_resource_node 
+            ALTER TABLE claro_resource_node
             ADD icon_id INT DEFAULT NULL
         ');
         $this->addSql('
-            ALTER TABLE claro_resource_node 
-            ADD CONSTRAINT FK_A76799FF54B9D732 FOREIGN KEY (icon_id) 
-            REFERENCES claro_resource_icon (id) 
+            ALTER TABLE claro_resource_node
+            ADD CONSTRAINT FK_A76799FF54B9D732 FOREIGN KEY (icon_id)
+            REFERENCES claro_resource_icon (id)
             ON DELETE SET NULL
         ');
         $this->addSql('

--- a/main/core/Migrations/pdo_mysql/Version20191105121055.php
+++ b/main/core/Migrations/pdo_mysql/Version20191105121055.php
@@ -8,23 +8,19 @@ use Doctrine\DBAL\Schema\Schema;
 /**
  * Auto-generated migration based on mapping information: modify it with caution.
  *
- * Generation date: 2019/10/31 08:48:11
+ * Generation date: 2019/11/05 12:10:56
  */
-class Version20191031084808 extends AbstractMigration
+class Version20191105121055 extends AbstractMigration
 {
     public function up(Schema $schema)
     {
         $this->addSql('
-            ALTER TABLE claro_connection_message
-            ADD hidden TINYINT(1) DEFAULT "0" NOT NULL
+            ALTER TABLE claro_home_tab_config
+            DROP is_locked
         ');
     }
 
     public function down(Schema $schema)
     {
-        $this->addSql('
-            ALTER TABLE claro_connection_message
-            DROP hidden
-        ');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed issues | comma-separated list of issues fixed by the PR, if any

This is caused by https://github.com/claroline/Distribution/commit/64d4119e6dc1229fd88b1cacce64a4229d4bbc2c#diff-ac8a29b0a9ff990a668b8d8d4a0dda7bL71

The property has been removed but the database was not updated afaik.

