### PR TITLE
[AgendaBundle] Only fetches event where end > begin.

### DIFF
--- a/plugin/agenda/Finder/EventFinder.php
+++ b/plugin/agenda/Finder/EventFinder.php
@@ -188,6 +188,8 @@ class EventFinder extends AbstractFinder
            }
         }
 
+        $qb->andWhere($qb->expr()->gte('obj.end', 'obj.start'));
+
         return $qb;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | yes/no
| Fixed issues | #6448

@elorfin 

L'agenda ne permet pas d'afficher les events dont endDate = null ni les events dont startDate > endDate (logique).

Par contre ils sont récupérés dans la requête et affichés dans le widget d'ou les events fantômes de l'issue.


