### PR TITLE
Fix invalid self-references in traits

### DIFF
--- a/main/app/Command/BaseCommandTrait.php
+++ b/main/app/Command/BaseCommandTrait.php
@@ -18,8 +18,6 @@ use Symfony\Component\Console\Question\Question;
 
 trait BaseCommandTrait
 {
-    use BaseCommandTrait;
-
     public function configureParams()
     {
         $args = [];

--- a/main/core/Command/Traits/AskRolesTrait.php
+++ b/main/core/Command/Traits/AskRolesTrait.php
@@ -18,8 +18,6 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
  */
 trait AskRolesTrait
 {
-    use AskRolesTrait;
-
     public function askRoles($all, $input, $output, $container, $helper)
     {
         $roles = $container->get('Claroline\AppBundle\Persistence\ObjectManager')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Fixed issues | -

The traits are wrongly referencing themselves, which breaks on PHP 7.4:
![Screenshot 2020-04-23 at 16 22 32](https://user-images.githubusercontent.com/7502063/80110282-cd012800-857e-11ea-8574-8e1779560ed7.png)


