### PR TITLE
Don't execute updaters more than once

### DIFF
--- a/main/core/Command/Dev/ExecuteUpdaterCommand.php
+++ b/main/core/Command/Dev/ExecuteUpdaterCommand.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\CoreBundle\Command\Dev;
+
+use Claroline\CoreBundle\Library\Maintenance\MaintenanceHandler;
+use Claroline\InstallationBundle\Repository\UpdaterExecutionRepository;
+use Claroline\InstallationBundle\Updater\NonReplayableUpdaterInterface;
+use Claroline\InstallationBundle\Updater\Updater;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Executes a single plugin updater.
+ */
+class ExecuteUpdaterCommand extends Command
+{
+    private $updaterExecutionRepository;
+    private $updaters;
+
+    /**
+     * @param ContainerInterface|Updater[] $updaters The Updater service registry
+     */
+    public function __construct(UpdaterExecutionRepository $updaterExecutionRepository, ContainerInterface $updaters)
+    {
+        $this->updaterExecutionRepository = $updaterExecutionRepository;
+        $this->updaters = $updaters;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Executes a single plugin updater.')
+            ->addArgument('updater_class', InputArgument::REQUIRED, 'The fully qualified classname of the updater that should be executed.')
+            ->addOption('install', 'i', InputOption::VALUE_NONE, 'If passed, pre/post install operations will be executed.')
+            ->addOption(
+                'force',
+                'f',
+                InputOption::VALUE_NONE,
+                'When set to true, the Updater will be executed regardless if it has been already.'
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $updaterClass = $input->getArgument('updater_class');
+
+        if (!$this->updaters->has($updaterClass)) {
+            throw new InvalidArgumentException(sprintf('Updater "%s" does not exist.', $updaterClass));
+        }
+
+        if ($this->updaterExecutionRepository->hasBeenExecuted($updaterClass) && (!$input->getOption('force') || \is_subclass_of($updaterClass, NonReplayableUpdaterInterface::class))) {
+            throw new RuntimeException(sprintf('Updater "%s" has been already executed.', $updaterClass));
+        }
+
+        MaintenanceHandler::enableMaintenance();
+
+        /** @var Updater $updater */
+        $updater = $this->updaters->get($updaterClass);
+
+        try {
+            if ($input->getOption('install')) {
+                $this->executeInstallOperations($updater, $output);
+            } else {
+                $this->executeUpdateOperations($updater, $output);
+            }
+        } finally {
+            MaintenanceHandler::disableMaintenance();
+        }
+
+        $output->writeln(
+            sprintf('<comment>%s - Updater execution terminated.</comment>', date('H:i:s'))
+        );
+
+        return 0;
+    }
+
+    private function executeInstallOperations(Updater $updater, OutputInterface $output): void
+    {
+        if (method_exists($updater, 'preInstall')) {
+            $output->writeln(
+                sprintf('<comment>%s - Executing pre-install operations from "%s"...</comment>', date('H:i:s'), \get_class($updater))
+            );
+
+            $updater->preInstall();
+        }
+
+        if (method_exists($updater, 'postInstall')) {
+            $output->writeln(
+                sprintf('<comment>%s - Executing post-install operations from "%s"...</comment>', date('H:i:s'), \get_class($updater))
+            );
+
+            $updater->postInstall();
+        }
+    }
+
+    private function executeUpdateOperations(Updater $updater, OutputInterface $output): void
+    {
+        if (method_exists($updater, 'preUpdate')) {
+            $output->writeln(
+                sprintf('<comment>%s - Executing pre-update operations from "%s"...</comment>', date('H:i:s'), \get_class($updater))
+            );
+
+            $updater->preUpdate();
+        }
+
+        if (method_exists($updater, 'postUpdate')) {
+            $output->writeln(
+                sprintf('<comment>%s - Executing post-update operations from "%s"...</comment>', date('H:i:s'), \get_class($updater))
+            );
+
+            $updater->postUpdate();
+        }
+    }
+}

--- a/main/core/Command/Dev/PlatformUpdateCommand.php
+++ b/main/core/Command/Dev/PlatformUpdateCommand.php
@@ -16,7 +16,6 @@ use Claroline\CoreBundle\Library\Installation\PlatformInstaller;
 use Claroline\CoreBundle\Library\Installation\Refresher;
 use Claroline\CoreBundle\Library\Maintenance\MaintenanceHandler;
 use Claroline\CoreBundle\Manager\VersionManager;
-use Psr\Log\LogLevel;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -81,12 +80,15 @@ class PlatformUpdateCommand extends Command
                 'c',
                 InputOption::VALUE_NONE,
                 'When set to true, the cache is cleared at the end'
+            )
+            ->addOption(
+                'force',
+                'f',
+                InputOption::VALUE_NONE,
+                'When set to true, updaters will be executed regardless if they have been already.'
             );
     }
 
-    /**
-     * @return int
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->refresher->setOutput($output);
@@ -101,6 +103,10 @@ class PlatformUpdateCommand extends Command
 
         if (!$input->getOption('no_symlink')) {
             $this->refresher->buildSymlinks();
+        }
+
+        if ($input->getOption('force')) {
+            $this->installer->setShouldReplayUpdaters(true);
         }
 
         $this->installer->setOutput($output);

--- a/main/core/Entity/Update/UpdaterExecution.php
+++ b/main/core/Entity/Update/UpdaterExecution.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\CoreBundle\Entity\Update;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Represents an updater than has been executed.
+ * It can be used to avoid executing the same updater more than once.
+ *
+ * @ORM\Entity(repositoryClass="Claroline\InstallationBundle\Repository\UpdaterExecutionRepository")
+ * @ORM\Table(name="claro_update")
+ */
+class UpdaterExecution
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    private $id;
+
+    /**
+     * @var string the FQCN of the executed updater
+     *
+     * @ORM\Column(name="updater_class", type="string", unique=true)
+     */
+    private $updaterClass;
+
+    public function __construct(string $updaterClass)
+    {
+        $this->updaterClass = $updaterClass;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getUpdaterClass(): string
+    {
+        return $this->updaterClass;
+    }
+}

--- a/main/core/Installation/Migrations/pdo_mysql/Version20201008141903.php
+++ b/main/core/Installation/Migrations/pdo_mysql/Version20201008141903.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Claroline\CoreBundle\Installation\Migrations\pdo_mysql;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution.
+ *
+ * Generation date: 2020/10/08 02:19:26
+ */
+class Version20201008141903 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql('
+            CREATE TABLE claro_update (
+                id INT AUTO_INCREMENT NOT NULL, 
+                updater_class VARCHAR(255) NOT NULL, 
+                UNIQUE INDEX UNIQ_6B1647E7CACF2BB1 (updater_class), 
+                PRIMARY KEY(id)
+            ) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB
+        ');
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql('
+            DROP TABLE claro_update
+        ');
+    }
+}

--- a/main/core/Library/Installation/PlatformInstaller.php
+++ b/main/core/Library/Installation/PlatformInstaller.php
@@ -67,6 +67,11 @@ class PlatformInstaller implements LoggerAwareInterface
         $this->pluginInstaller->setLogger($logger);
     }
 
+    public function setShouldReplayUpdaters(bool $shouldReplayUpdaters): void
+    {
+        $this->baseInstaller->setShouldReplayUpdaters($shouldReplayUpdaters);
+    }
+
     public function setOutput(OutputInterface $output)
     {
         $this->output = $output;

--- a/main/core/Resources/config/services/command.yml
+++ b/main/core/Resources/config/services/command.yml
@@ -114,6 +114,14 @@ services:
         tags:
             - { name: 'console.command', command: 'claroline:update' }
 
+    Claroline\CoreBundle\Command\Dev\ExecuteUpdaterCommand:
+        arguments:
+            - '@Claroline\InstallationBundle\Repository\UpdaterExecutionRepository'
+            - !tagged_locator
+                  tag: 'claroline.platform.updater'
+        tags:
+            - { name: 'console.command', command: 'claroline:updater:execute' }
+
     Claroline\CoreBundle\Command\Dev\RefreshCommand:
         arguments:
             - '@Claroline\CoreBundle\Library\Installation\Refresher'

--- a/main/installation/Additional/AdditionalInstallerInterface.php
+++ b/main/installation/Additional/AdditionalInstallerInterface.php
@@ -17,6 +17,10 @@ interface AdditionalInstallerInterface
 {
     public function setEnvironment($environment);
 
+    public function setShouldReplayUpdaters(bool $shouldReplayUpdaters): void;
+
+    public function shouldReplayUpdaters(): bool;
+
     public function setLogger(LoggerInterface $logger = null);
 
     public function preInstall();
@@ -32,4 +36,9 @@ interface AdditionalInstallerInterface
     public function postUninstall();
 
     public function end($currentVersion, $targetVersion);
+
+    /**
+     * @return string[] An array of Updater service identifiers (i.e. FQCN) indexed by version
+     */
+    public static function getUpdaters(): array;
 }

--- a/main/installation/Bundle/InstallableBundle.php
+++ b/main/installation/Bundle/InstallableBundle.php
@@ -11,6 +11,7 @@
 
 namespace Claroline\InstallationBundle\Bundle;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 abstract class InstallableBundle extends Bundle implements InstallableInterface
@@ -38,6 +39,11 @@ abstract class InstallableBundle extends Bundle implements InstallableInterface
     public function getAdditionalInstaller()
     {
         return;
+    }
+
+    public function getUpdaterServiceLocator(): ContainerInterface
+    {
+        return $this->container->get('claroline.updater_locator');
     }
 
     public function getComposer()
@@ -91,7 +97,7 @@ abstract class InstallableBundle extends Bundle implements InstallableInterface
 
     public function getInstalled()
     {
-        static $installed;
+        static $installed = null;
 
         if (!$installed) {
             $up = DIRECTORY_SEPARATOR.'..';

--- a/main/installation/Bundle/InstallableInterface.php
+++ b/main/installation/Bundle/InstallableInterface.php
@@ -11,13 +11,20 @@
 
 namespace Claroline\InstallationBundle\Bundle;
 
+use Psr\Container\ContainerInterface;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
 
 interface InstallableInterface extends BundleInterface
 {
     public function hasMigrations();
+
     public function getRequiredFixturesDirectory($environment);
+
     public function getOptionalFixturesDirectory($environment);
+
     public function getPostInstallFixturesDirectory($environment);
+
     public function getAdditionalInstaller();
+
+    public function getUpdaterServiceLocator(): ContainerInterface;
 }

--- a/main/installation/ClarolineInstallationBundle.php
+++ b/main/installation/ClarolineInstallationBundle.php
@@ -11,9 +11,11 @@
 
 namespace Claroline\InstallationBundle;
 
-use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Claroline\InstallationBundle\DependencyInjection\Compiler\CollectUpdatersPass;
 use Claroline\KernelBundle\Bundle\AutoConfigurableInterface;
 use Claroline\KernelBundle\Bundle\ConfigurationBuilder;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class ClarolineInstallationBundle extends Bundle implements AutoConfigurableInterface
 {
@@ -25,5 +27,12 @@ class ClarolineInstallationBundle extends Bundle implements AutoConfigurableInte
     public function getConfiguration($environment)
     {
         return new ConfigurationBuilder();
+    }
+
+    public function build(ContainerBuilder $container)
+    {
+        parent::build($container);
+
+        $container->addCompilerPass(new CollectUpdatersPass());
     }
 }

--- a/main/installation/DependencyInjection/Compiler/CollectUpdatersPass.php
+++ b/main/installation/DependencyInjection/Compiler/CollectUpdatersPass.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\InstallationBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Collects all "claroline.platform.updater" tagged services and make them available through
+ * the "claroline.updater_locator" service locator.
+ */
+class CollectUpdatersPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $updaterRefs = [];
+        foreach (array_keys($container->findTaggedServiceIds('claroline.platform.updater')) as $id) {
+            $updaterRefs[$id] = new Reference($id);
+        }
+
+        if (!$updaterRefs) {
+            return;
+        }
+
+        $locatorId = ServiceLocatorTagPass::register($container, $updaterRefs);
+        $container->setAlias('claroline.updater_locator', (string) $locatorId)->setPublic(true);
+    }
+}

--- a/main/installation/Repository/UpdaterExecutionRepository.php
+++ b/main/installation/Repository/UpdaterExecutionRepository.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\InstallationBundle\Repository;
+
+use Claroline\CoreBundle\Entity\Update\UpdaterExecution;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+class UpdaterExecutionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, UpdaterExecution::class);
+    }
+
+    public function hasBeenExecuted(string $updaterClass): bool
+    {
+        return 0 < $this->count(['updaterClass' => $updaterClass]);
+    }
+
+    public function markAsExecuted(string $updaterClass): void
+    {
+        $em = $this->getEntityManager();
+
+        $em->persist(new UpdaterExecution($updaterClass));
+        $em->flush();
+    }
+}

--- a/main/installation/Resources/config/services.yml
+++ b/main/installation/Resources/config/services.yml
@@ -33,3 +33,8 @@ services:
         class: '%claroline.doctrine_fixture_executor.class%'
         arguments:
             - '@doctrine.orm.entity_manager'
+
+    Claroline\InstallationBundle\Repository\UpdaterExecutionRepository:
+        arguments:
+            - '@Doctrine\Persistence\ManagerRegistry'
+        tags: ['doctrine.repository_service']

--- a/main/installation/Updater/NonReplayableUpdaterInterface.php
+++ b/main/installation/Updater/NonReplayableUpdaterInterface.php
@@ -11,10 +11,9 @@
 
 namespace Claroline\InstallationBundle\Updater;
 
-use Claroline\AppBundle\Log\LoggableTrait;
-use Psr\Log\LoggerAwareInterface;
-
-abstract class Updater implements LoggerAwareInterface
+/**
+ * Marker interface for Updater which cannot be executed more than once.
+ */
+interface NonReplayableUpdaterInterface
 {
-    use LoggableTrait;
 }

--- a/plugin/cursus/ClarolineCursusBundle.php
+++ b/plugin/cursus/ClarolineCursusBundle.php
@@ -23,7 +23,7 @@ class ClarolineCursusBundle extends DistributionPluginBundle
 
     public function getAdditionalInstaller()
     {
-        return new AdditionalInstaller();
+        return new AdditionalInstaller($this->getUpdaterServiceLocator());
     }
 
     public function getPostInstallFixturesDirectory($environment)

--- a/plugin/cursus/DataFixtures/PostInstall/LoadTemplateData.php
+++ b/plugin/cursus/DataFixtures/PostInstall/LoadTemplateData.php
@@ -21,16 +21,21 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class LoadTemplateData extends AbstractFixture implements ContainerAwareInterface
 {
-    private $container;
     private $om;
     private $translator;
+    private $config;
     private $templateTypeRepo;
     private $templateRepo;
     private $availableLocales;
 
     public function setContainer(ContainerInterface $container = null)
     {
-        $this->container = $container;
+        if (!$container) {
+            throw new \LogicException('Expected a service container, got null.');
+        }
+
+        $this->translator = $container->get('translator');
+        $this->config = $container->get(PlatformConfigurationHandler::class);
     }
 
     public function load(ObjectManager $om)
@@ -38,8 +43,7 @@ class LoadTemplateData extends AbstractFixture implements ContainerAwareInterfac
         $this->om = $om;
         $this->templateTypeRepo = $om->getRepository(TemplateType::class);
         $this->templateRepo = $om->getRepository(Template::class);
-        $this->translator = $this->container->get('translator');
-        $this->availableLocales = $this->container->get(PlatformConfigurationHandler::class)->getParameter('locales.available');
+        $this->availableLocales = $this->config->getParameter('locales.available');
 
         $this->createCourseTemplates();
         $this->createSessionTemplates();

--- a/plugin/cursus/Installation/AdditionalInstaller.php
+++ b/plugin/cursus/Installation/AdditionalInstaller.php
@@ -2,25 +2,15 @@
 
 namespace Claroline\CursusBundle\Installation;
 
+use Claroline\CursusBundle\Installation\Updater\Updater130000;
 use Claroline\InstallationBundle\Additional\AdditionalInstaller as BaseInstaller;
 
 class AdditionalInstaller extends BaseInstaller
 {
-    public function preUpdate($currentVersion, $targetVersion)
+    public static function getUpdaters(): array
     {
-        if (version_compare($currentVersion, '13.0.0', '<')) {
-            $updater = new Updater\Updater130000($this->container, $this->logger);
-            $updater->setLogger($this->logger);
-            $updater->preUpdate();
-        }
-    }
-
-    public function postUpdate($currentVersion, $targetVersion)
-    {
-        if (version_compare($currentVersion, '13.0.0', '<')) {
-            $updater = new Updater\Updater130000($this->container, $this->logger);
-            $updater->setLogger($this->logger);
-            $updater->postUpdate();
-        }
+        return [
+            '13.0.0' => Updater130000::class,
+        ];
     }
 }

--- a/plugin/cursus/Installation/Updater/Updater130000.php
+++ b/plugin/cursus/Installation/Updater/Updater130000.php
@@ -6,20 +6,21 @@ use Claroline\AppBundle\Persistence\ObjectManager;
 use Claroline\CoreBundle\Entity\Template\TemplateType;
 use Claroline\CursusBundle\DataFixtures\PostInstall\LoadTemplateData;
 use Claroline\InstallationBundle\Updater\Updater;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Log\LoggerInterface;
 
 class Updater130000 extends Updater
 {
-    protected $logger;
-    private $container;
-    /** @var ObjectManager */
     private $om;
+    private $dataFixtures;
 
-    public function __construct(ContainerInterface $container, $logger = null)
-    {
+    public function __construct(
+        ObjectManager $om,
+        LoadTemplateData $dataFixtures,
+        LoggerInterface $logger = null
+    ) {
+        $this->om = $om;
+        $this->dataFixtures = $dataFixtures;
         $this->logger = $logger;
-        $this->container = $container;
-        $this->om = $container->get(ObjectManager::class);
     }
 
     public function preUpdate()
@@ -32,10 +33,7 @@ class Updater130000 extends Updater
 
     public function postUpdate()
     {
-        $dataFixtures = new LoadTemplateData();
-        $dataFixtures->setContainer($this->container);
-
-        $dataFixtures->load($this->om);
+        $this->dataFixtures->load($this->om);
     }
 
     private function renameTool($oldName, $newName)

--- a/plugin/cursus/Resources/config/services.yml
+++ b/plugin/cursus/Resources/config/services.yml
@@ -6,3 +6,4 @@ imports:
     - { resource: services/listener.yml }
     - { resource: services/manager.yml }
     - { resource: services/serializer.yml }
+    - { resource: services/updater.yml }

--- a/plugin/cursus/Resources/config/services/updater.yml
+++ b/plugin/cursus/Resources/config/services/updater.yml
@@ -1,0 +1,12 @@
+services:
+
+    Claroline\CursusBundle\DataFixtures\PostInstall\LoadTemplateData:
+        calls:
+            - ['setContainer', ['@service_container']]
+
+    Claroline\CursusBundle\Installation\Updater\Updater130000:
+        arguments:
+            - '@Claroline\AppBundle\Persistence\ObjectManager'
+            - '@Claroline\CursusBundle\DataFixtures\PostInstall\LoadTemplateData'
+            - '@logger'
+        tags: ['claroline.platform.updater']


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Fixed issues | -

- [x] Store updaters execution in DB
- [x] By default, ensure they are never executed twice
- [x] Allow using `claroline:update --force` to execute any updater no matter if they have been already
- [x] Add `claroline:updater:execute [UPDATER CLASS]` to manually run a given updater.
- [x] Add marker interface for updaters that cannot be executed more than once, regardless of the `--force` flag

