### PR TITLE
enhances archived workspaces management

### DIFF
--- a/main/core/API/Finder/Resource/ResourceNodeFinder.php
+++ b/main/core/API/Finder/Resource/ResourceNodeFinder.php
@@ -86,16 +86,6 @@ class ResourceNodeFinder extends AbstractFinder
                     $qb->andWhere('ow.uuid = :workspaceUuid');
                     $qb->setParameter('workspaceUuid', $filterValue);
                     break;
-                case 'workspace.name':
-                    $qb->andWhere('UPPER(ow.name) LIKE :workspace');
-                    $qb->setParameter('workspace', '%'.strtoupper($filterValue).'%');
-                    break;
-                case 'meta.parent.name':
-                    $qb->join('obj.parent', 'op');
-                    $qb->andWhere('UPPER(op.name) LIKE :parent');
-                    $qb->setParameter('parent', '%'.strtoupper($filterValue).'%');
-                    $this->usedJoin['parent'] = true;
-                    break;
                 case 'path.after':
                     $qb->andWhere('UPPER(obj.path) != :path'); // required otherwise we also get the parent in the results
                     $qb->andWhere('UPPER(obj.path) LIKE :pathLike');
@@ -111,14 +101,6 @@ class ResourceNodeFinder extends AbstractFinder
                         $qb->setParameter('parent', $filterValue);
                         $this->usedJoin['parent'] = true;
                     }
-                    break;
-                case 'uuid_or_slug':
-                    $qb->andWhere($qb->expr()->orX(
-                        $qb->expr()->eq('obj.uuid', ':uuid_or_slug'),
-                        $qb->expr()->eq('obj.slug', ':uuid_or_slug')
-                    ));
-
-                    $qb->setParameter('uuid_or_slug', $filterValue);
                     break;
                 case 'managerRole':
                     $managerRoles = [];
@@ -174,14 +156,17 @@ class ResourceNodeFinder extends AbstractFinder
             }
         }
 
+        // if we don't explicitly set the parent, only grab resources from not archived workspaces
+        if (!isset($searches['workspace']) && !isset($searches['parent'])) {
+            $qb->andWhere('ow.archived = false');
+        }
+
         if (!is_null($sortBy) && isset($sortBy['property']) && isset($sortBy['direction'])) {
             $sortByProperty = $sortBy['property'];
             $sortByDirection = 1 === $sortBy['direction'] ? 'ASC' : 'DESC';
 
             switch ($sortByProperty) {
                 case 'meta.type':
-                    $qb->orderBy('ort.name', $sortByDirection);
-                    break;
                 case 'resourceType':
                     $qb->orderBy('ort.name', $sortByDirection);
                     break;
@@ -194,10 +179,10 @@ class ResourceNodeFinder extends AbstractFinder
                 case 'meta.created':
                     $qb->orderBy('obj.creationDate', $sortByDirection);
                     break;
-                case 'workspace.name':
+                case 'workspace':
                     $qb->orderBy('ow.name', $sortByDirection);
                     break;
-                case 'meta.parent.name':
+                case 'parent':
                     if (!$this->usedJoin['parent']) {
                         $qb->join('obj.parent', 'op');
                     }

--- a/main/core/Controller/APINew/Resource/ResourceNodeController.php
+++ b/main/core/Controller/APINew/Resource/ResourceNodeController.php
@@ -89,7 +89,7 @@ class ResourceNodeController extends AbstractCrudController
         if ($parent) {
             // grab directory content
             /** @var ResourceNode $parentNode */
-            $parentNode = $this->finder->get(ResourceNode::class)->findOneBy(['uuid_or_slug' => $parent]);
+            $parentNode = $this->om->getRepository(ResourceNode::class)->findOneByUuidOrSlug($parent);
 
             if ($all) {
                 $options['hiddenFilters']['path.after'] = $parentNode ? $parentNode->getPath() : null;

--- a/main/core/Controller/ResourceController.php
+++ b/main/core/Controller/ResourceController.php
@@ -129,7 +129,7 @@ class ResourceController
     public function openAction($id, $embedded = 0)
     {
         /** @var ResourceNode $resourceNode */
-        $resourceNode = $this->finder->get(ResourceNode::class)->findOneBy(['uuid_or_slug' => $id]);
+        $resourceNode = $this->om->getRepository(ResourceNode::class)->findOneByUuidOrSlug($id);
         if (!$resourceNode) {
             return new JsonResponse(['resource_not_found'], 404);
         }

--- a/main/core/Manager/Workspace/WorkspaceRestrictionsManager.php
+++ b/main/core/Manager/Workspace/WorkspaceRestrictionsManager.php
@@ -53,6 +53,7 @@ class WorkspaceRestrictionsManager
     public function isGranted(Workspace $workspace): bool
     {
         return $this->hasRights($workspace)
+            && !$workspace->isArchived()
             && ($this->isStarted($workspace) && !$this->isEnded($workspace))
             && $this->isUnlocked($workspace)
             && $this->isIpAuthorized($workspace);
@@ -73,6 +74,7 @@ class WorkspaceRestrictionsManager
             $errors = [
                 'noRights' => !$this->hasRights($workspace),
                 'selfRegistration' => $workspace->getSelfRegistration(),
+                'archived' => $workspace->isArchived(),
             ];
 
             if ($user) {

--- a/main/core/Repository/ResourceNodeRepository.php
+++ b/main/core/Repository/ResourceNodeRepository.php
@@ -40,7 +40,9 @@ class ResourceNodeRepository extends MaterializedPathRepository implements Conta
     public function search(string $search, int $nbResults)
     {
         return $this->createQueryBuilder('n')
+            ->join('n.workspace', 'w')
             ->where('UPPER(n.name) LIKE :search')
+            ->andWhere('w.archived = false')
             ->andWhere('n.active = true')
             ->andWhere('n.published = true')
             ->andWhere('n.hidden = false')
@@ -49,6 +51,15 @@ class ResourceNodeRepository extends MaterializedPathRepository implements Conta
             ->setParameter('search', '%'.strtoupper($search).'%')
             ->getQuery()
             ->getResult();
+    }
+
+    public function findOneByUuidOrSlug($id)
+    {
+        return $this->createQueryBuilder('n')
+            ->where('n.uuid = :id OR n.slug = :id')
+            ->setParameter('id', $id)
+            ->getQuery()
+            ->getOneOrNullResult();
     }
 
     /**

--- a/main/core/Repository/WorkspaceRepository.php
+++ b/main/core/Repository/WorkspaceRepository.php
@@ -22,6 +22,7 @@ class WorkspaceRepository extends EntityRepository
         return $this->createQueryBuilder('w')
             ->where('(UPPER(w.name) LIKE :search OR UPPER(w.code) LIKE :search)')
             ->andWhere('w.displayable = true')
+            ->andWhere('w.archived = false')
             ->setFirstResult(0)
             ->setMaxResults($nbResults)
             ->setParameter('search', '%'.strtoupper($search).'%')

--- a/main/core/Resources/modules/workspace/actions/archive.js
+++ b/main/core/Resources/modules/workspace/actions/archive.js
@@ -35,6 +35,7 @@ export default (workspaces, refresher) => {
       success: (response) => refresher.update(response)
     },
     group: trans('management'),
-    scope: ['object', 'collection']
+    scope: ['object', 'collection'],
+    dangerous: true
   }
 }

--- a/main/core/Resources/modules/workspace/actions/delete.js
+++ b/main/core/Resources/modules/workspace/actions/delete.js
@@ -12,7 +12,7 @@ export default (workspaces, refresher) => ({
   type: ASYNC_BUTTON,
   icon: 'fa fa-fw fa-trash-o',
   label: trans('delete', {}, 'actions'),
-  displayed: 0 < workspaces.filter(w => hasPermission('delete', w) && w.code !== 'default_personal' && w.code !== 'default_workspace').length,
+  displayed: 0 < workspaces.filter(w => hasPermission('delete', w) && w.code !== 'default_personal' && w.code !== 'default_workspace' && w.meta.archived).length,
   dangerous: true,
   confirm: {
     title: trans('workspace_delete_confirm_title'),

--- a/main/core/Resources/modules/workspace/actions/register-groups.js
+++ b/main/core/Resources/modules/workspace/actions/register-groups.js
@@ -15,7 +15,7 @@ export default (workspaces, refresher) => ({
   type: MODAL_BUTTON,
   icon: 'fa fa-fw fa-users',
   label: trans('register_groups'),
-  displayed: -1 !== workspaces.findIndex(workspace => hasPermission('administrate', workspace)),
+  displayed: -1 !== workspaces.findIndex(workspace => !workspace.meta.archived && hasPermission('administrate', workspace)),
   // open a modal to select the list of groups to register
   modal: [MODAL_GROUPS, {
     title: trans('register_groups'),

--- a/main/core/Resources/modules/workspace/actions/register-self.js
+++ b/main/core/Resources/modules/workspace/actions/register-self.js
@@ -15,7 +15,7 @@ export default (workspaces, refresher, path, currentUser) => ({
   label: trans('self-register', {}, 'actions'),
   // TODO : replace by workspace.permissions.register later
   displayed: !!currentUser && -1 !== workspaces.findIndex(workspace =>
-    !workspace.registered && !get(workspace, 'registration.waitingForRegistration') && (get(workspace, 'registration.selfRegistration') || isAdmin(currentUser))
+    !workspace.registered && !workspace.meta.archived && !get(workspace, 'registration.waitingForRegistration') && (get(workspace, 'registration.selfRegistration') || isAdmin(currentUser))
   ),
   request: {
     url: url(['apiv2_workspace_register', {user: get(currentUser, 'id')}], {workspaces: workspaces.map(workspace => workspace.id)}),

--- a/main/core/Resources/modules/workspace/actions/register-users.js
+++ b/main/core/Resources/modules/workspace/actions/register-users.js
@@ -15,7 +15,7 @@ export default (workspaces, refresher) => ({
   type: MODAL_BUTTON,
   icon: 'fa fa-fw fa-user',
   label: trans('register_users'),
-  displayed: -1 !== workspaces.findIndex(workspace => hasPermission('administrate', workspace)),
+  displayed: -1 !== workspaces.findIndex(workspace => !workspace.meta.archived && hasPermission('administrate', workspace)),
   // open a modal to select the list of users to register
   modal: [MODAL_USERS, {
     title: trans('register_users'),

--- a/main/core/Resources/modules/workspace/components/restrictions.jsx
+++ b/main/core/Resources/modules/workspace/components/restrictions.jsx
@@ -75,7 +75,7 @@ class WorkspaceRestrictions extends Component {
                 })
               }}
             >
-              {this.props.authenticated && this.props.errors.selfRegistration &&
+              {this.props.authenticated && !this.props.errors.archived && this.props.errors.selfRegistration &&
                 <Button
                   style={{marginTop: 20}}
                   className="btn btn-block btn-emphasis"
@@ -94,7 +94,7 @@ class WorkspaceRestrictions extends Component {
                   label={trans('login', {}, 'actions')}
                   modal={[MODAL_LOGIN, {
                     onLogin: () => {
-                      if (this.props.errors.selfRegistration) {
+                      if (!this.props.errors.archived && this.props.errors.selfRegistration) {
                         this.props.selfRegister()
                       } else {
                         this.props.reload()
@@ -105,7 +105,7 @@ class WorkspaceRestrictions extends Component {
                 />
               }
 
-              {!this.props.authenticated && this.props.platformSelfRegistration && this.props.errors.selfRegistration &&
+              {!this.props.authenticated && !this.props.errors.archived && this.props.platformSelfRegistration && this.props.errors.selfRegistration &&
                 <Button
                   className="btn btn-block"
                   type={MODAL_BUTTON}
@@ -116,7 +116,7 @@ class WorkspaceRestrictions extends Component {
                 />
               }
 
-              {!this.props.authenticated && this.props.errors.selfRegistration &&
+              {!this.props.authenticated && !this.props.errors.archived && this.props.errors.selfRegistration &&
                 <ContentHelp
                   help="Vous serez automatiquement inscrit à l'espace d'activités après votre connexion ou inscription."
                 />
@@ -144,6 +144,18 @@ class WorkspaceRestrictions extends Component {
               }}
             />
           }
+
+          {this.props.errors.archived &&
+            <ContentRestriction
+              icon="fa fa-fw fa-eye"
+              failed={this.props.errors.archived}
+              fail={{
+                title: trans('restricted_workspace.archived', {}, 'resource'),
+                help: trans('restricted_workspace.archived_help', {}, 'resource')
+              }}
+            />
+          }
+
 
           {(!isUndefined(this.props.errors.notStarted) || !isUndefined(this.props.errors.ended)) &&
             <ContentRestriction
@@ -241,6 +253,7 @@ WorkspaceRestrictions.propTypes = {
     noRights: T.bool.isRequired,
     registered: T.bool,
     pendingRegistration: T.bool,
+    archived: T.bool,
     selfRegistration: T.bool,
     locked: T.bool,
     invalidLocation: T.bool,

--- a/main/core/Resources/translations/platform.en.json
+++ b/main/core/Resources/translations/platform.en.json
@@ -959,7 +959,9 @@
         "wait": "Please wait until",
         "you_are_manager": "You are a manager of the workspace.",
         "pending_registration": "Your registration request is pending validation.",
-        "wait_validation": "Please wait for a manager to validate your request to access the workspace."
+        "wait_validation": "Please wait for a manager to validate your request to access the workspace.",
+        "archived": "The workspace is archived.",
+        "archived_help": "You can no longer access the content of archived workspaces."
     },
     "restrictions": "Restrictions",
     "results": "Results",

--- a/main/core/Resources/translations/platform.fr.json
+++ b/main/core/Resources/translations/platform.fr.json
@@ -982,7 +982,9 @@
         "wait": "Veuillez patientez jusqu'au",
         "you_are_manager": "Vous êtes un gestionnaire de l'espace d'activités.",
         "pending_registration": "Votre demande d'inscription est en attente de validation.",
-        "wait_validation": "Veuillez attendre qu'un gestionnaire valide votre demande afin d'accéder à l'espace d'activités."
+        "wait_validation": "Veuillez attendre qu'un gestionnaire valide votre demande afin d'accéder à l'espace d'activités.",
+        "archived": "L'espace d'activités est archivé.",
+        "archived_help": "Vous ne pouvez plus accéder au contenu des espaces d'activités archivés."
     },
     "restrictions": "Restrictions",
     "results": "Résultats",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no

- only allow to delete workspaces if archived.
- disable registration actions for archived workspaces (for managers too).
- only allow managers to access archived workspaces.
- exclude archived workspaces and resources of archived workspaces from the global search.
- exclude resources of archives workspaces from desktop resource manager.

fixes #6809.