### PR TITLE
fixes templating service

### DIFF
--- a/doc/sections/event-tracking.md
+++ b/doc/sections/event-tracking.md
@@ -281,8 +281,8 @@ function is given below:
 ```php
 public function onCreateLogListItem(LogCreateDelegateViewEvent $event)
 {
-    $content = $this->container->get('templating')->render(
-        'ICAPBlogBundle::log_list_item.html.twig',
+    $content = $this->container->get('twig')->render(
+        '@ICAPBlog/log_list_item.html.twig',
         array('log' => $event->getLog())
     );
     $event->setResponseContent($content);
@@ -333,12 +333,12 @@ its view are more complex.
 ```php
 public function onCreateLogDetails(LogCreateDelegateViewEvent $event)
 {
-    $content = $this->container->get('templating')->render(
-        'ICAPBlogBundle::log_details.html.twig',
+    $content = $this->container->get('twig')->render(
+        '@ICAPBlog/log_details.html.twig',
         array(
             'log' => $event->getLog(),
-            'listItemView' => $this->container->get('templating')->render(
-                'ICAPBlogBundle::log_list_item.html.twig',
+            'listItemView' => $this->container->get('twig')->render(
+                '@ICAPBlog/log_list_item.html.twig',
                 array('log' => $event->getLog())
             )
         )

--- a/doc/sections/plugins/resources.md
+++ b/doc/sections/plugins/resources.md
@@ -191,8 +191,8 @@ public function onOpen(OpenResourceEvent $event)
     $isGranted = $this->container->get('security.authorization_checker')->isGranted('WRITE', $collection);
     $revisionRepo = $this->container->get('doctrine.orm.entity_manager')
         ->getRepository('ClarolineCoreBundle:Resource\Revision');
-    $content = $this->container->get('templating')->render(
-        'ClarolineCoreBundle:Text:index.html.twig',
+    $content = $this->container->get('twig')->render(
+        '@ClarolineCore/text/index.html.twig',
         array(
             'text' => $revisionRepo->getLastRevision($text)->getContent(),
             '_resource' => $text,
@@ -220,8 +220,8 @@ public function onCompose(CustomActionResourceEvent $event)
     $activity = $event->getResource();
     ...
 
-    $content = $this->container->get('templating')->render(
-        'ClarolineCoreBundle:Activity:index.html.twig',
+    $content = $this->container->get('twig')->render(
+        '@ClarolineCore/activity/index.html.twig',
         array(
             'resourceTypes' => $resourceTypes,
             'resourceActivities' => $resourceActivities,

--- a/doc/sections/plugins/tools.md
+++ b/doc/sections/plugins/tools.md
@@ -69,15 +69,15 @@ private function workspace($workspaceId)
     $em = $this->container->get('doctrine.orm.entity_manager');
     $workspace = $em->getRepository('ClarolineCoreBundle:Workspace\Workspace')->find($workspaceId);
 
-    return $this->container->get('templating')->render(
-        'ClarolineExampleBundle::workspace_tool.html.twig', array('workspace' => $workspace)
+    return $this->container->get('twig')->render(
+        '@ClarolineExample/workspace_tool.html.twig', array('workspace' => $workspace)
     );
 }
 
 private function desktop()
 {
-    return $this->container->get('templating')->render(
-        'ClarolineExampleBundle::desktop_tool.html.twig'
+    return $this->container->get('twig')->render(
+        '@ClarolineExample/desktop_tool.html.twig'
     );
 }
 ```

--- a/main/app/Controller/Platform/ClientController.php
+++ b/main/app/Controller/Platform/ClientController.php
@@ -81,7 +81,7 @@ class ClientController
         }
 
         return new Response(
-            $this->templating->render('ClarolineAppBundle::index.html.twig', [
+            $this->templating->render('@ClarolineApp/index.html.twig', [
                 'parameters' => $this->clientSerializer->serialize(),
                 'maintenance' => [
                     'enabled' => MaintenanceHandler::isMaintenanceEnabled() || $this->configHandler->getParameter('maintenance.enable'),

--- a/main/core/Controller/ResourceController.php
+++ b/main/core/Controller/ResourceController.php
@@ -160,7 +160,7 @@ class ResourceController
         }
 
         return new Response(
-            $this->templating->render("ClarolineCoreBundle:resource:embed/{$view}.html.twig", [
+            $this->templating->render("@ClarolineCore/resource/embed/{$view}.html.twig", [
                 'resource' => $this->manager->getResourceFromNode($resourceNode),
             ])
         );

--- a/main/core/Listener/Log/LogListener.php
+++ b/main/core/Listener/Log/LogListener.php
@@ -139,7 +139,8 @@ class LogListener
             $log->setReceiver($event->getReceiver());
         }
         if (LogGroupDeleteEvent::ACTION !== $event->getAction()) {
-            if ($receiverGroup = $event->getReceiverGroup()) {
+            $receiverGroup = $event->getReceiverGroup();
+            if ($receiverGroup) {
                 $this->om->merge($receiverGroup);
             }
             $log->setReceiverGroup($receiverGroup);
@@ -340,8 +341,8 @@ class LogListener
 
     public function onLogListItem(LogCreateDelegateViewEvent $event)
     {
-        $content = $this->container->get('templating')->render(
-            'ClarolineCoreBundle:log:view_list_item_sentence.html.twig',
+        $content = $this->container->get('twig')->render(
+            '@ClarolineCore/log/view_list_item_sentence.html.twig',
             ['log' => $event->getLog()]
         );
 
@@ -351,8 +352,8 @@ class LogListener
 
     public function onLogDetails(LogCreateDelegateViewEvent $event)
     {
-        $content = $this->container->get('templating')->render(
-            'ClarolineCoreBundle:log:view_details.html.twig',
+        $content = $this->container->get('twig')->render(
+            '@ClarolineCore/log/view_details.html.twig',
             ['log' => $event->getLog()]
         );
 

--- a/main/core/Listener/Notification/NotificationListener.php
+++ b/main/core/Listener/Notification/NotificationListener.php
@@ -208,8 +208,8 @@ class NotificationListener
             break;
       }
 
-        $content = $this->container->get('templating')->render(
-            'ClarolineCoreBundle:notification:notification_item.html.twig',
+        $content = $this->container->get('twig')->render(
+            '@ClarolineCore/notification/notification_item.html.twig',
             [
                 'notification' => $notification,
                 'status' => $notificationView->getStatus(),

--- a/main/core/Twig/LogTranslatorExtension.php
+++ b/main/core/Twig/LogTranslatorExtension.php
@@ -22,6 +22,10 @@ use Twig\TwigFunction;
 
 class LogTranslatorExtension extends AbstractExtension
 {
+    private $helper;
+    private $translator;
+    private $templating;
+
     public function __construct(RoutingHelper $helper, TranslatorInterface $translator, Environment $templating)
     {
         $this->helper = $helper;
@@ -43,12 +47,12 @@ class LogTranslatorExtension extends AbstractExtension
 
     public function translateLog(Log $log)
     {
-        $resource = $this->templating->render('ClarolineCoreBundle:log:view_list_item_resource.html.twig', ['log' => $log]);
-        $receiverUser = $this->templating->render('ClarolineCoreBundle:log:view_list_item_receiver_user.html.twig', ['log' => $log]);
-        $receiverGroup = $this->templating->render('ClarolineCoreBundle:log:view_list_item_receiver_group.html.twig', ['log' => $log]);
-        $role = $this->templating->render('ClarolineCoreBundle:log:view_list_item_role.html.twig', ['log' => $log]);
-        $workspace = $this->templating->render('ClarolineCoreBundle:log:view_list_item_workspace.html.twig', ['log' => $log]);
-        $tool = $this->templating->render('ClarolineCoreBundle:log:view_list_item_tool.html.twig', ['log' => $log]);
+        $resource = $this->templating->render('@ClarolineCore/log/view_list_item_resource.html.twig', ['log' => $log]);
+        $receiverUser = $this->templating->render('@ClarolineCore/log/view_list_item_receiver_user.html.twig', ['log' => $log]);
+        $receiverGroup = $this->templating->render('@ClarolineCore/log/view_list_item_receiver_group.html.twig', ['log' => $log]);
+        $role = $this->templating->render('@ClarolineCore/log/view_list_item_role.html.twig', ['log' => $log]);
+        $workspace = $this->templating->render('@ClarolineCore/log/view_list_item_workspace.html.twig', ['log' => $log]);
+        $tool = $this->templating->render('@ClarolineCore/log/view_list_item_tool.html.twig', ['log' => $log]);
 
         $data = [
           '%resource%' => $resource,

--- a/main/migration/Generator/Writer.php
+++ b/main/migration/Generator/Writer.php
@@ -62,7 +62,7 @@ class Writer
         }
 
         $content = $this->twigEnvironment->render(
-            'ClarolineMigrationBundle::migration_class.html.twig',
+            '@ClarolineMigration/migration_class.html.twig',
             [
                 'namespace' => $namespace,
                 'class' => $class,

--- a/main/migration/Tests/Generator/WriterTest.php
+++ b/main/migration/Tests/Generator/WriterTest.php
@@ -67,7 +67,7 @@ class WriterTest extends MockeryTestCase
         $this->twigEnvironment->shouldReceive('render')
             ->once()
             ->with(
-                'ClarolineMigrationBundle::migration_class.html.twig',
+                '@ClarolineMigration/migration_class.html.twig',
                 [
                     'namespace' => 'Bundle\Namespace\Installation\Migrations\some_driver',
                     'class' => 'Versionsome_version',

--- a/plugin/agenda/Manager/AgendaManager.php
+++ b/plugin/agenda/Manager/AgendaManager.php
@@ -194,8 +194,8 @@ class AgendaManager
         $date = new \Datetime();
         $tz = $date->getTimezone();
 
-        return $this->container->get('templating')->render(
-            'ClarolineAgendaBundle:ics_calendar.ics.twig',
+        return $this->container->get('twig')->render(
+            '@ClarolineAgenda/ics_calendar.ics.twig',
             [
                 'tzName' => $tz->getName(),
                 'events' => $events,

--- a/plugin/blog/Controller/Resource/BlogController.php
+++ b/plugin/blog/Controller/Resource/BlogController.php
@@ -105,7 +105,7 @@ class BlogController
             }
         }
 
-        return new Response($this->templating->render('IcapBlogBundle:blog/rss:rss.html.twig', [
+        return new Response($this->templating->render('@IcapBlog/blog/rss/rss.html.twig', [
             'feed' => $feed,
             'items' => $items,
         ]), 200, [
@@ -146,7 +146,7 @@ class BlogController
         }
 
         $content = $this->templating->render(
-            'IcapBlogBundle:blog/pdf:view.pdf.twig',
+            '@IcapBlog/blog/pdf/view.pdf.twig',
             ['_resource' => $blog, 'posts' => $items]
         );
 

--- a/plugin/blog/Listener/LogListener.php
+++ b/plugin/blog/Listener/LogListener.php
@@ -11,8 +11,8 @@ class LogListener
 
     public function onCreateLogListItem(LogCreateDelegateViewEvent $event)
     {
-        $content = $this->container->get('templating')->render(
-            'IcapBlogBundle:log:log_list_item.html.twig',
+        $content = $this->container->get('twig')->render(
+            '@IcapBlog/log/log_list_item.html.twig',
             ['log' => $event->getLog()]
         );
 
@@ -22,12 +22,12 @@ class LogListener
 
     public function onPostCreateLogDetails(LogCreateDelegateViewEvent $event)
     {
-        $content = $this->container->get('templating')->render(
-            'IcapBlogBundle:log:log_details.html.twig',
+        $content = $this->container->get('twig')->render(
+            '@IcapBlog/log/log_details.html.twig',
             [
                 'log' => $event->getLog(),
-                'listItemView' => $this->container->get('templating')->render(
-                    'IcapBlogBundle:log:log_list_item.html.twig',
+                'listItemView' => $this->container->get('twig')->render(
+                    '@IcapBlog/log/log_list_item.html.twig',
                     ['log' => $event->getLog()]
                 ),
             ]

--- a/plugin/claco-form/Controller/ClacoFormController.php
+++ b/plugin/claco-form/Controller/ClacoFormController.php
@@ -892,7 +892,7 @@ class ClacoFormController
         }
 
         return $this->templating->render(
-            'ClarolineClacoFormBundle:claco_form:entries_export.html.twig',
+            '@ClarolineClacoForm/claco_form/entries_export.html.twig',
             [
                 'fields' => $fields,
                 'entries' => $entriesData,
@@ -972,7 +972,7 @@ class ClacoFormController
         }
 
         return $this->templating->render(
-            'ClarolineClacoFormBundle:claco_form:entry.html.twig',
+            '@ClarolineClacoForm/claco_form/entry.html.twig',
             [
                 'entry' => $entry,
                 'template' => $template,

--- a/plugin/drop-zone/Listener/Log/DisplayLogListener.php
+++ b/plugin/drop-zone/Listener/Log/DisplayLogListener.php
@@ -11,12 +11,12 @@ class DisplayLogListener
 
     public function onCreateLogDetails(LogCreateDelegateViewEvent $event)
     {
-        $content = $this->container->get('templating')->render(
-            'ClarolineDropZoneBundle:log:log_details.html.twig',
+        $content = $this->container->get('twig')->render(
+            '@ClarolineDropZone/log/log_details.html.twig',
             [
                 'log' => $event->getLog(),
-                'listItemView' => $this->container->get('templating')->render(
-                    'ClarolineDropZoneBundle:log:log_list_item.html.twig',
+                'listItemView' => $this->container->get('twig')->render(
+                    '@ClarolineDropZone/log/log_list_item.html.twig',
                     ['log' => $event->getLog()]
                 ),
             ]

--- a/plugin/exo/Listener/Log/DisplayLogListener.php
+++ b/plugin/exo/Listener/Log/DisplayLogListener.php
@@ -10,25 +10,16 @@ class DisplayLogListener
 {
     use ContainerAwareTrait;
 
-    /**
-     * @param ContainerInterface $container
-     */
     public function __construct(ContainerInterface $container)
     {
         $this->setContainer($container);
     }
 
-    /**
-     * @param LogCreateDelegateViewEvent $event
-     */
     public function onCreateLogDetails(LogCreateDelegateViewEvent $event)
     {
-        $content = $this->container->get('templating')->render(
-            'UJMExoBundle:log:show.html.twig',
-            [
-                'log' => $event->getLog(),
-            ]
-        );
+        $content = $this->container->get('twig')->render('@UJMExo/log/show.html.twig', [
+            'log' => $event->getLog(),
+        ]);
 
         $event->setResponseContent($content);
         $event->stopPropagation();

--- a/plugin/lesson/Controller/ChapterController.php
+++ b/plugin/lesson/Controller/ChapterController.php
@@ -201,7 +201,7 @@ class ChapterController
         $domPdf->set_option('isHtml5ParserEnabled', true);
         $domPdf->set_option('isRemoteEnabled', true);
         $domPdf->set_option('tempDir', $this->config->getParameter('server.tmp_dir'));
-        $domPdf->loadHtml($this->templating->render('IcapLessonBundle:lesson:open.pdf.twig', [
+        $domPdf->loadHtml($this->templating->render('@IcapLesson/lesson/open.pdf.twig', [
             '_resource' => $lesson,
             'tree' => $this->chapterRepository->getChapterTree($chapter),
         ]));

--- a/plugin/lesson/Controller/LessonController.php
+++ b/plugin/lesson/Controller/LessonController.php
@@ -86,7 +86,7 @@ class LessonController
         $domPdf->set_option('isHtml5ParserEnabled', true);
         $domPdf->set_option('isRemoteEnabled', true);
         $domPdf->set_option('tempDir', $this->config->getParameter('server.tmp_dir'));
-        $domPdf->loadHtml($this->templating->render('IcapLessonBundle:lesson:open.pdf.twig', [
+        $domPdf->loadHtml($this->templating->render('@IcapLesson/lesson/open.pdf.twig', [
             '_resource' => $lesson,
             'tree' => $this->chapterRepo->getChapterTree($lesson->getRoot(), false),
         ]));

--- a/plugin/lesson/Listener/LogListener.php
+++ b/plugin/lesson/Listener/LogListener.php
@@ -11,8 +11,8 @@ class LogListener
 
     public function onCreateLogListItem(LogCreateDelegateViewEvent $event)
     {
-        $content = $this->container->get('templating')->render(
-            'IcapLessonBundle:log:log_list_item.html.twig',
+        $content = $this->container->get('twig')->render(
+            '@IcapLesson/log/log_list_item.html.twig',
             ['log' => $event->getLog()]
         );
 
@@ -22,12 +22,12 @@ class LogListener
 
     public function onChapterCreateLogDetails(LogCreateDelegateViewEvent $event)
     {
-        $content = $this->container->get('templating')->render(
-            'IcapLessonBundle:log:log_details.html.twig',
+        $content = $this->container->get('twig')->render(
+            '@IcapLesson/log/log_details.html.twig',
             [
                 'log' => $event->getLog(),
-                'listItemView' => $this->container->get('templating')->render(
-                    'IcapLessonBundle:log:log_list_item.html.twig',
+                'listItemView' => $this->container->get('twig')->render(
+                    '@IcapLesson/log/log_list_item.html.twig',
                     ['log' => $event->getLog()]
                 ),
             ]

--- a/plugin/notification/Listener/Platform/ClientListener.php
+++ b/plugin/notification/Listener/Platform/ClientListener.php
@@ -41,7 +41,7 @@ class ClientListener
 
     public function onInjectCss(InjectStylesheetEvent $event)
     {
-        $content = $this->templating->render('IcapNotificationBundle:layout:stylesheets.html.twig', []);
+        $content = $this->templating->render('@IcapNotification/layout/stylesheets.html.twig', []);
 
         $event->addContent($content);
     }

--- a/plugin/open-badge/Listener/LayoutListener.php
+++ b/plugin/open-badge/Listener/LayoutListener.php
@@ -31,7 +31,7 @@ class LayoutListener
     public function onInjectJs(InjectJavascriptEvent $event)
     {
         $event->addContent(
-            $this->templating->render('ClarolineOpenBadgeBundle::javascripts.html.twig')
+            $this->templating->render('@ClarolineOpenBadge/javascripts.html.twig')
         );
     }
 }

--- a/plugin/open-badge/Manager/OpenBadgeManager.php
+++ b/plugin/open-badge/Manager/OpenBadgeManager.php
@@ -140,6 +140,6 @@ class OpenBadgeManager
 
         $content = $this->templateManager->getTemplate('badge_certificate', $placeholders);
 
-        return $this->templating->render('ClarolineOpenBadgeBundle::pdf.html.twig', ['content' => $content]);
+        return $this->templating->render('@ClarolineOpenBadge/pdf.html.twig', ['content' => $content]);
     }
 }

--- a/plugin/social-media/Listener/LogListener.php
+++ b/plugin/social-media/Listener/LogListener.php
@@ -21,21 +21,15 @@ class LogListener
 {
     use ContainerAwareTrait;
 
-    /**
-     * @param $container
-     */
     public function __construct($container)
     {
         $this->container = $container;
     }
 
-    /**
-     * @param LogCreateDelegateViewEvent $event
-     */
     public function onCreateLogListItem(LogCreateDelegateViewEvent $event)
     {
-        $content = $this->container->get('templating')->render(
-            'IcapSocialmediaBundle:log:log_list_item.html.twig',
+        $content = $this->container->get('twig')->render(
+            '@IcapSocialmedia/log/log_list_item.html.twig',
             ['log' => $event->getLog()]
         );
 
@@ -43,17 +37,14 @@ class LogListener
         $event->stopPropagation();
     }
 
-    /**
-     * @param LogCreateDelegateViewEvent $event
-     */
     public function onCreateLogDetails(LogCreateDelegateViewEvent $event)
     {
-        $content = $this->container->get('templating')->render(
-            'IcapSocialmediaBundle:log:log_details.html.twig',
+        $content = $this->container->get('twig')->render(
+            '@IcapSocialmedia/log/log_details.html.twig',
             [
                 'log' => $event->getLog(),
-                'listItemView' => $this->container->get('templating')->render(
-                    'IcapSocialmediaBundle:log:log_list_item.html.twig',
+                'listItemView' => $this->container->get('twig')->render(
+                    '@IcapSocialmedia/log/log_list_item.html.twig',
                     ['log' => $event->getLog()]
                 ),
             ]

--- a/plugin/tag/Listener/Platform/ClientListener.php
+++ b/plugin/tag/Listener/Platform/ClientListener.php
@@ -20,7 +20,7 @@ class ClientListener
 
     public function onInjectCss(InjectStylesheetEvent $event)
     {
-        $content = $this->templating->render('ClarolineTagBundle:layout:stylesheets.html.twig', []);
+        $content = $this->templating->render('@ClarolineTag/layout/stylesheets.html.twig', []);
 
         $event->addContent($content);
     }

--- a/plugin/video-player/Listener/PluginListener.php
+++ b/plugin/video-player/Listener/PluginListener.php
@@ -22,7 +22,7 @@ class PluginListener
     public function onInjectJs(InjectJavascriptEvent $event)
     {
         $event->addContent(
-            $this->templating->render('ClarolineVideoPlayerBundle::scripts.html.twig')
+            $this->templating->render('@ClarolineVideoPlayer/scripts.html.twig')
         );
     }
 }

--- a/plugin/wiki/Controller/WikiController.php
+++ b/plugin/wiki/Controller/WikiController.php
@@ -80,7 +80,7 @@ class WikiController
         $sectionTree = $this->sectionManager->getSerializedSectionTree($wiki, $user, $isAdmin);
 
         return new JsonResponse([
-            'content' => $this->templating->render('IcapWikiBundle:wiki:pdf.html.twig', [
+            'content' => $this->templating->render('@IcapWiki/wiki/pdf.html.twig', [
                 '_resource' => $wiki,
                 'tree' => $sectionTree,
                 'isAdmin' => $isAdmin,

--- a/plugin/wiki/Listener/LogListener.php
+++ b/plugin/wiki/Listener/LogListener.php
@@ -24,7 +24,7 @@ class LogListener
     public function onCreateLogListItem(LogCreateDelegateViewEvent $event)
     {
         $content = $this->templating->render(
-            'IcapWikiBundle:log:log_list_item.html.twig',
+            '@IcapWiki/log/log_list_item.html.twig',
             ['log' => $event->getLog()]
         );
 
@@ -35,11 +35,11 @@ class LogListener
     public function onSectionCreateLogDetails(LogCreateDelegateViewEvent $event)
     {
         $content = $this->templating->render(
-            'IcapWikiBundle:log:log_details.html.twig',
+            '@IcapWiki/log/log_details.html.twig',
             [
                 'log' => $event->getLog(),
                 'listItemView' => $this->templating->render(
-                    'IcapWikiBundle:log:log_list_item.html.twig',
+                    '@IcapWiki/log/log_list_item.html.twig',
                     ['log' => $event->getLog()]
                 ),
             ]


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no

- Fixes access to `templating` service from the container.
- Updates templates shortnames. It seems like the synthax we were using is not supported (`Template reference "ClarolineOpenBadgeBundle::javascripts.html.twig" not found, did you mean "@ClarolineOpenBadge/javascripts.html.twig"?`).

@Zowac @chalasr FYI.