### PR TITLE
Fix Symfony deprecation using WebTestCase

### DIFF
--- a/main/core/Library/Testing/RepositoryTestCase.php
+++ b/main/core/Library/Testing/RepositoryTestCase.php
@@ -51,6 +51,7 @@ abstract class RepositoryTestCase extends WebTestCase
 
     public static function setUpBeforeClass(): void
     {
+        self::ensureKernelShutdown();
         self::$client = static::createClient();
         self::$om = self::$client->getContainer()->get('Claroline\AppBundle\Persistence\ObjectManager');
         self::$persister = self::$client->getContainer()->get('claroline.library.testing.persister');

--- a/main/core/Library/Testing/TransactionalTestCase.php
+++ b/main/core/Library/Testing/TransactionalTestCase.php
@@ -25,6 +25,7 @@ abstract class TransactionalTestCase extends WebTestCase
     protected function setUp(): void
     {
         parent::setUp();
+        self::ensureKernelShutdown();
         $this->client = self::createClient();
         $this->client->disableReboot();
         $this->client->getContainer()->get('Claroline\AppBundle\Persistence\ObjectManager')->beginTransaction();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no

<!-- please add a description here if needed -->

Calling "Symfony\Bundle\FrameworkBundle\Test\WebTestCase::createClient()" while a kernel has been booted is deprecated, ensure the kernel is shut down before calling the method.