### PR TITLE
Fix allowMockingMethodsUnnecessarily's deprecation

### DIFF
--- a/main/core/Library/Testing/MockeryTestCase.php
+++ b/main/core/Library/Testing/MockeryTestCase.php
@@ -76,7 +76,6 @@ abstract class MockeryTestCase extends TestCase
     private function initMockery()
     {
         m::getConfiguration()->allowMockingNonExistentMethods(false);
-        m::getConfiguration()->allowMockingMethodsUnnecessarily(false);
     }
 
     private function isCloneable($class)

--- a/main/migration/Tests/MockeryTestCase.php
+++ b/main/migration/Tests/MockeryTestCase.php
@@ -19,7 +19,6 @@ abstract class MockeryTestCase extends TestCase
     protected function setUp(): void
     {
         m::getConfiguration()->allowMockingNonExistentMethods(false);
-        m::getConfiguration()->allowMockingMethodsUnnecessarily(false);
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no

<!-- please add a description here if needed -->

According to https://github.com/mockery/mockery/issues/804 the method is not used and so not necessary 
