### PR TITLE
Fix  : change doctrine/orm version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "doctrine/dbal": "^2.7",
         "doctrine/doctrine-bundle": "^1.9",
         "doctrine/migrations": "^1.7",
-        "doctrine/orm": "^2.6",
+        "doctrine/orm": "^2.8",
         "dompdf/dompdf": "*",
         "friendsofsymfony/jsrouting-bundle": "^2.2",
         "gedmo/doctrine-extensions": "2.4.35",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Fixed issues | comma-separated list of issues fixed by the PR, if any

<!-- please add a description here if needed -->

According to https://github.com/doctrine/orm/pull/8147, we need to use doctrine/orm 2.8
