### PR TITLE
fix  tree builder without a root node 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "symfony/maker-bundle": "1.2.0",
         "sensio/framework-extra-bundle": "^5.6",
         "stefk/jval": "dev-master",
-        "stof/doctrine-extensions-bundle": "1.3.0",
+        "stof/doctrine-extensions-bundle": "1.4.0",
         "symfony/monolog-bundle": "^3.5",
         "symfony/asset": "4.4.*",
         "symfony/browser-kit": "4.4.*",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no

<!-- please add a description here if needed -->

 "A tree builder without a root node is deprecated since Symfony 4.2 and will not be supported anymore in 5.0"



