### PR TITLE
Add github action to close stale issues

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -1,0 +1,15 @@
+name: 'Close all issues'
+on:
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: 'This issue is going to be closed because it has no recent activity and the project has been moved to https://github.com/claroline/Claroline. If you think it is still relevant, please consider opening a new issue on https://github.com/claroline/Claroline.'
+          days-before-stale: 0
+          days-before-close: 0
+          exempt-issue-labels: 'Keep Open'


### PR DESCRIPTION
This workflow closes all open issues except the ones labelled as `Keep Open`. 
It needs to be executed manually from the Actions tab.